### PR TITLE
Add first version of API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,11 +1,5 @@
 Reference/API
 =============
 
-.. automodapi:: regions.io
-   :no-inheritance-diagram:
-
-.. automodapi:: regions.core
-   :no-inheritance-diagram:
-
-.. automodapi:: regions.shapes
+.. automodapi:: regions
    :no-inheritance-diagram:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,4 +1,11 @@
 Reference/API
 =============
 
+.. automodapi:: regions.io
+   :no-inheritance-diagram:
 
+.. automodapi:: regions.core
+   :no-inheritance-diagram:
+
+.. automodapi:: regions.shapes
+   :no-inheritance-diagram:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,3 +1,18 @@
 ===============
 Getting started
 ===============
+
+Let's make a region:
+
+.. code-block:: python
+
+    from astropy.coordinates import Angle, SkyCoord
+    import regions
+
+    center = SkyCoord(42, 43, unit='deg')
+    radius = Angle(3, 'deg')
+    region = regions.shapes.CircleSkyRegion(center, radius)
+    print(region)
+
+
+TODO: do more things ...

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,9 +4,9 @@
 Astropy Regions Documentation
 #############################
 
-This is an astropy-affiliated package for region handling. The goal is to merge
-the functionality in astropy/`pyregion`_ and astropy/`photutils`_/aperture.
-After a test phase of a few week this package should be moved to astropy core. 
+This is an in-development package for region handling based on Astropy.
+The goal is to merge the functionality from `pyregion`_ and `photutils`_ apertures
+and then after some time propose this package for inclusion in the Astropy core.
 
 * Code : `Github repository`_
 * Docs : `Region documentation`_

--- a/regions/__init__.py
+++ b/regions/__init__.py
@@ -1,7 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
-This is an experimental package for representing regions
+This is an in-development package for region handling based on Astropy.
+
+The goal is to merge the functionality from pyregion and photutils apertures
+and then after some time propose this package for inclusion in the Astropy core.
+
+* Code : https://github.com/astropy/regions
+* Docs : http://astropy-regions.readthedocs.io/en/latest/
 """
 
 # Affiliated packages may add whatever they like to this file, but

--- a/regions/__init__.py
+++ b/regions/__init__.py
@@ -12,6 +12,6 @@ from ._astropy_init import *
 
 # For egg_info test builds to pass, put package imports here.
 if not _ASTROPY_SETUP_:
-    from . import io
-    from . import shapes
-    from . import core
+    from .core import *
+    from .io import *
+    from .shapes import *

--- a/regions/core/__init__.py
+++ b/regions/core/__init__.py
@@ -1,2 +1,5 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Region core functionality.
+"""
 from .core import *
 from .pixcoord import *

--- a/regions/io/__init__.py
+++ b/regions/io/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""I/O
+"""Region I/O.
 """
 from .read_ds9 import *
 from .write_ds9 import *

--- a/regions/shapes/__init__.py
+++ b/regions/shapes/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Region shapes
+"""Region shapes.
 """
 from .circle import *
 from .ellipse import *

--- a/regions/utils/__init__.py
+++ b/regions/utils/__init__.py
@@ -1,0 +1,3 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Region utilities.
+"""


### PR DESCRIPTION
At PyAstro16 @joleroi set up online docs for this regions repo here:
http://astropy-regions.readthedocs.io/en/latest/

This pull request adds a first version of the API docs.

There's a few warnings in the API docs build like this that I don't know how to fix.
@keflavich @astrofrog or @bsipocz - Do you know how to address those? If yes, can you make a PR against this PR?
```
<autosummary>:None: WARNING: toctree contains reference to nonexisting document 'api/regions.shapes.PixelRegion'
<autosummary>:None: WARNING: toctree contains reference to nonexisting document 'api/regions.shapes.SkyRegion'
None:None: WARNING: toctree contains reference to nonexisting document 'api/regions.shapes.PixelRegion'
None:None: WARNING: toctree contains reference to nonexisting document 'api/regions.shapes.SkyRegion'
```
https://gist.github.com/cdeil/539490416ffee012f3a1081b90940168

If I don't hear back I might merge this soon, because something with warnings is better than nothing. :-)