### PR TITLE
Add make_example_wcs function

### DIFF
--- a/regions/__init__.py
+++ b/regions/__init__.py
@@ -18,6 +18,7 @@ from ._astropy_init import *
 
 # For egg_info test builds to pass, put package imports here.
 if not _ASTROPY_SETUP_:
+    from .utils.examples import *
     from .core import *
     from .io import *
     from .shapes import *

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_equal, assert_allclose
 from astropy.tests.helper import pytest
+from ...utils.examples import make_example_wcs
 from ..pixcoord import PixCoord
 
 try:
@@ -10,25 +11,6 @@ try:
     HAS_SHAPELY = True
 except:
     HAS_SHAPELY = False
-
-
-def make_test_wcs():
-    """Make a WCS object for tests and documentation examples.
-
-    TODO: make this part of the public API, so that it can be used
-    for documentation examples
-    """
-    from astropy.wcs import WCS
-
-    wcs = WCS(naxis=2)
-    wcs.wcs.crval = 0, 0
-    wcs.wcs.crpix = 18, 9
-    wcs.wcs.cdelt = 10, 10
-    wcs.wcs.ctype = 'GLON-AIT', 'GLAT-AIT'
-
-    # shape = (36, 18) would give an image that covers the whole sky.
-
-    return wcs
 
 
 def test_pixcoord_scalar_basics():
@@ -80,7 +62,7 @@ def test_pixcoord_array_basics():
 
 
 def test_pixcoord_scalar_sky():
-    wcs = make_test_wcs()
+    wcs = make_example_wcs()
     p = PixCoord(x=18, y=9)
 
     s = p.to_sky(wcs=wcs)
@@ -94,7 +76,7 @@ def test_pixcoord_scalar_sky():
 
 
 def test_pixcoord_array_sky():
-    wcs = make_test_wcs()
+    wcs = make_example_wcs()
     p = PixCoord(x=[17, 18], y=[8, 9])
 
     s = p.to_sky(wcs=wcs)

--- a/regions/utils/examples.py
+++ b/regions/utils/examples.py
@@ -1,0 +1,46 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+from astropy.wcs import WCS
+
+__all__ = ['make_example_wcs']
+
+
+def make_example_wcs(projection='AIT'):
+    """Make a WCS object for documentation examples and tests.
+
+    Parameters
+    ----------
+    projection : {'AIT', 'CAR'}
+        WCS projection type
+
+    Returns
+    -------
+    wcs : `~astropy.wcs.WCS`
+        World coordinate system transformation object.
+
+    Examples
+    --------
+    Make an example WCS object:
+
+    >>> from regions import make_example_wcs
+    >>> wcs = make_example_wcs(projection='AIT')
+
+    WCS parameters::
+
+        CTYPE : 'GLON-AIT'  'GLAT-AIT'
+        CRVAL : 0.0  0.0
+        CRPIX : 18.0  9.0
+        CDELT : 10.0  10.0
+    """
+    if not projection in {'AIT', 'CAR'}:
+        raise ValueError('Invalid projection: {}'.format(projection))
+
+    wcs = WCS(naxis=2)
+    wcs.wcs.crval = 0, 0
+    wcs.wcs.crpix = 18, 9
+    wcs.wcs.cdelt = 10, 10
+    wcs.wcs.ctype = 'GLON-' + projection, 'GLAT-' + projection
+
+    # shape = (36, 18) would give an image that covers the whole sky.
+
+    return wcs

--- a/regions/utils/tests/test_examples.py
+++ b/regions/utils/tests/test_examples.py
@@ -1,0 +1,13 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose
+from ..examples import make_example_wcs
+
+
+def test_make_example_wcs():
+    wcs = make_example_wcs()
+    assert_allclose(wcs.wcs.crval, (0, 0))
+    assert_allclose(wcs.wcs.crpix, (18, 9))
+    assert_allclose(wcs.wcs.cdelt, (10, 10))
+    assert wcs.wcs.ctype[0] == 'GLON-AIT'
+    assert wcs.wcs.ctype[1] == 'GLAT-AIT'


### PR DESCRIPTION
This PR adds a `make_example_wcs` function.

I made it part of the public API so that it can also be used for docs examples, e.g. here:
http://astropy-regions.readthedocs.io/en/latest/getting_started.html#region-transformations

The functionality of this function can be expanded later as needed. E.g. once we have spatial filtering, we probably want to add image data.