### PR TITLE
Bug in write_ds9 for CircleSkyRegion

### DIFF
--- a/regions/io/tests/test_ds9_language.py
+++ b/regions/io/tests/test_ds9_language.py
@@ -1,11 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from ..read_ds9 import read_ds9
-from ..write_ds9 import objects_to_ds9_string
+import distutils.version as v
 from astropy.utils.data import get_pkg_data_filename, get_pkg_data_filenames
 from astropy.tests.helper import pytest
-import distutils.version as v
 import astropy.version as astrov
+from astropy.coordinates import Angle, SkyCoord
+from ...shapes.circle import CircleSkyRegion
+from ..read_ds9 import read_ds9
+from ..write_ds9 import objects_to_ds9_string
 
 _ASTROPY_MINVERSION = v.LooseVersion('1.1')
 _ASTROPY_VERSION = v.LooseVersion(astrov.version)
@@ -83,3 +85,16 @@ def test_physical(filename):
         desired = fh.read()
 
     assert actual == desired
+
+
+def test_ds9_circle():
+    """Test that circle to ds9 string works.
+
+    Regression test for https://github.com/astropy/regions/issues/41
+    """
+    center = SkyCoord(42, 43, unit='deg')
+    radius = Angle(3, 'deg')
+    region = CircleSkyRegion(center, radius)
+    expected = '# Region file format: DS9 astropy/regions\nfk5\ncircle(42.0000,43.0000,3.0000)\n'
+    actual = objects_to_ds9_string([region])
+    assert actual == expected

--- a/regions/io/write_ds9.py
+++ b/regions/io/write_ds9.py
@@ -44,23 +44,21 @@ def objects_to_ds9_string(obj_list, coordsys='fk5', fmt='.4f', radunit='deg'):
 
     for reg in obj_list:
         if isinstance(reg, shapes.circle.CircleSkyRegion):
-            # TODO: Why is circle.center a list of SkyCoords?
-            x = reg.center.transform_to(frame).spherical.lon.to('deg').value[0]
-            y = reg.center.transform_to(frame).spherical.lat.to('deg').value[0]
-            r = reg.radius.to(radunit).value
+            x = float(reg.center.transform_to(frame).spherical.lon.to('deg').value)
+            y = float(reg.center.transform_to(frame).spherical.lat.to('deg').value)
+            r = float(reg.radius.to(radunit).value)
             output += ds9_strings['circle'].format(**locals())
         elif isinstance(reg, shapes.circle.CirclePixelRegion):
-            # TODO: Why is circle.center a list of SkyCoords?
             x = reg.center.x
             y = reg.center.y
             r = reg.radius
             output += ds9_strings['circle'].format(**locals())
         elif isinstance(reg, shapes.ellipse.EllipseSkyRegion):
-            x = reg.center.transform_to(frame).spherical.lon.to('deg').value[0]
-            y = reg.center.transform_to(frame).spherical.lat.to('deg').value[0]
-            r2 = reg.major.to(radunit).value
-            r1 = reg.minor.to(radunit).value
-            ang = reg.angle.to('deg').value
+            x = float(reg.center.transform_to(frame).spherical.lon.to('deg').value)
+            y = float(reg.center.transform_to(frame).spherical.lat.to('deg').value)
+            r2 = float(reg.major.to(radunit).value)
+            r1 = float(reg.minor.to(radunit).value)
+            ang = float(reg.angle.to('deg').value)
             output += ds9_strings['ellipse'].format(**locals())
         elif isinstance(reg, shapes.ellipse.EllipsePixelRegion):
             x = reg.center.x


### PR DESCRIPTION
I've run into this bug in `write_ds9` for `CircleSkyRegion`:
```python
>>> from astropy.coordinates import Angle, SkyCoord
>>> import regions
>>> center = SkyCoord(42, 43, unit='deg')
>>> radius = Angle(3, 'deg')
>>> region = regions.CircleSkyRegion(center, radius)
>>> regions.objects_to_ds9_string([region])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/deil/code/regions/regions/io/write_ds9.py", line 46, in objects_to_ds9_string
    x = reg.center.transform_to(frame).spherical.lon.to('deg').value[0]
TypeError: 'float' object is not subscriptable
```

Removing the `TODO` and `[0]` indexing here fixes the issue:
https://github.com/astropy/regions/blame/master/regions/io/write_ds9.py#L44
```
44        if isinstance(reg, shapes.circle.CircleSkyRegion):
45	            # TODO: Why is circle.center a list of SkyCoords?
46	            x = reg.center.transform_to(frame).spherical.lon.to('deg').value[0]
47	            y = reg.center.transform_to(frame).spherical.lat.to('deg').value[0]
```

But with this change, the tests that read and write ds9 regions start failing:
https://github.com/astropy/regions/blob/master/regions/io/tests/test_ds9_language.py#L27
because after reading regions, `center.shape` is `(1,)`, and not `center.shape == ()` scalar like in my code example above.

@keflavich @joleroi - I guess the ds9 reader has to be fixed to return scalar `center` SkyCoord?
Does one of you have time to have a look and implement a fix?

(If I remember correctly we discussed whether regions with array parameters should be supported and `PyAstro16`, and I think agreed we only want to do simple scalar regions because vector regions are a nightmare to implement and of limited use, right?)