### PR TITLE
Add ds9_string_to_objects

### DIFF
--- a/regions/io/tests/test_ds9_language.py
+++ b/regions/io/tests/test_ds9_language.py
@@ -1,13 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import distutils.version as v
+from numpy.testing import assert_allclose
 from astropy.utils.data import get_pkg_data_filename, get_pkg_data_filenames
 from astropy.tests.helper import pytest
 import astropy.version as astrov
 from astropy.coordinates import Angle, SkyCoord
 from ...shapes.circle import CircleSkyRegion
-from ..read_ds9 import read_ds9
-from ..write_ds9 import objects_to_ds9_string
+from ..read_ds9 import read_ds9, ds9_string_to_objects
+from ..write_ds9 import write_ds9, ds9_objects_to_string
 
 _ASTROPY_MINVERSION = v.LooseVersion('1.1')
 _ASTROPY_VERSION = v.LooseVersion(astrov.version)
@@ -31,7 +32,7 @@ def test_fk5(filename):
     filename = get_pkg_data_filename(filename)
     regs = read_ds9(filename)
 
-    actual = objects_to_ds9_string(regs, coordsys='fk5', fmt='.2f', radunit='arcsec')
+    actual = ds9_objects_to_string(regs, coordsys='fk5', fmt='.2f', radunit='arcsec')
 
     # Use this to produce reference file for now
     # print(actual)
@@ -53,7 +54,7 @@ def test_galactic(filename):
     filename = get_pkg_data_filename(filename)
     regs = read_ds9(filename)
 
-    actual = objects_to_ds9_string(regs, coordsys='galactic', fmt='.2f', radunit='arcsec')
+    actual = ds9_objects_to_string(regs, coordsys='galactic', fmt='.2f', radunit='arcsec')
 
     # Use this to produce reference file for now
     # print(actual)
@@ -74,7 +75,7 @@ def test_physical(filename):
     filename = get_pkg_data_filename(filename)
     regs = read_ds9(filename)
 
-    actual = objects_to_ds9_string(regs, coordsys='physical', fmt='.2f')
+    actual = ds9_objects_to_string(regs, coordsys='physical', fmt='.2f')
 
     # Use this to produce reference file for now
     # print(actual)
@@ -87,14 +88,40 @@ def test_physical(filename):
     assert actual == desired
 
 
-def test_ds9_circle():
-    """Test that circle to ds9 string works.
-
-    Regression test for https://github.com/astropy/regions/issues/41
+def test_ds9_objects_to_str():
+    """Simple test case for ds9_objects_to_str.
     """
     center = SkyCoord(42, 43, unit='deg')
     radius = Angle(3, 'deg')
     region = CircleSkyRegion(center, radius)
     expected = '# Region file format: DS9 astropy/regions\nfk5\ncircle(42.0000,43.0000,3.0000)\n'
-    actual = objects_to_ds9_string([region])
+    actual = ds9_objects_to_string([region])
     assert actual == expected
+
+
+def test_ds9_string_to_objects():
+    """Simple test case for ds9_string_to_objects
+    """
+    ds9_str = '# Region file format: DS9 astropy/regions\nfk5\ncircle(42.0000,43.0000,3.0000)\n'
+    regions = ds9_string_to_objects(ds9_str)
+    reg = regions[0]
+
+    assert_allclose(reg.center.ra.deg, 42)
+    assert_allclose(reg.center.dec.deg, 43)
+    assert_allclose(reg.radius.value, 3)
+
+
+def test_ds9_io(tmpdir):
+    """Simple test case for write_ds9 and read_ds9.
+    """
+    center = SkyCoord(42, 43, unit='deg')
+    radius = Angle(3, 'deg')
+    reg = CircleSkyRegion(center, radius)
+
+    filename = str(tmpdir / 'ds9.reg')
+    write_ds9([reg], filename)
+    reg = read_ds9(filename)[0]
+
+    assert_allclose(reg.center.ra.deg, 42)
+    assert_allclose(reg.center.dec.deg, 43)
+    assert_allclose(reg.radius.value, 3)

--- a/regions/io/write_ds9.py
+++ b/regions/io/write_ds9.py
@@ -3,22 +3,43 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from astropy import coordinates
 from .. import shapes
 
-__all__ = ['objects_to_ds9_string', 'write_ds9']
+__all__ = [
+    'write_ds9',
+    'ds9_objects_to_string',
+]
 
 coordsys_name_mapping = dict(zip(coordinates.frame_transform_graph.get_names(),
                                  coordinates.frame_transform_graph.get_names()))
 coordsys_name_mapping['ecliptic'] = 'geocentrictrueecliptic'  # needs expert attention TODO
 
 
-def objects_to_ds9_string(obj_list, coordsys='fk5', fmt='.4f', radunit='deg'):
-    """Take a list of regions and generate ds9 region strings"""
+def ds9_objects_to_string(regions, coordsys='fk5', fmt='.4f', radunit='deg'):
+    """Convert list of regions ato ds9 region strings.
 
-    ids = {shapes.circle.CircleSkyRegion: 'skycircle',
-           shapes.circle.CirclePixelRegion: 'pixcircle',
-           shapes.ellipse.EllipseSkyRegion: 'skyellipse',
-           shapes.ellipse.EllipsePixelRegion: 'pixellipse',
-           shapes.polygon.PolygonSkyRegion: 'skypolygon',
-           shapes.polygon.PolygonPixelRegion: 'pixpolygon'}
+    Parameters
+    ----------
+    regions : list
+        List of `regions.Region` objects
+
+    Returns
+    -------
+    region_string : str
+        ds9 region string
+
+
+    Examples
+    --------
+    TODO
+    """
+
+    ids = {
+        shapes.circle.CircleSkyRegion: 'skycircle',
+        shapes.circle.CirclePixelRegion: 'pixcircle',
+        shapes.ellipse.EllipseSkyRegion: 'skyellipse',
+        shapes.ellipse.EllipsePixelRegion: 'pixellipse',
+        shapes.polygon.PolygonSkyRegion: 'skypolygon',
+        shapes.polygon.PolygonPixelRegion: 'pixpolygon',
+    }
 
     if radunit == 'arcsec':
         if coordsys in coordsys_name_mapping.keys():
@@ -28,9 +49,11 @@ def objects_to_ds9_string(obj_list, coordsys='fk5', fmt='.4f', radunit='deg'):
     else:
         radunitstr = ''
 
-    ds9_strings = {'circle': 'circle({x:' + fmt + '},{y:' + fmt + '},{r:' + fmt + '}' + radunitstr + ')\n',
-                   'ellipse': 'ellipse({x:' + fmt + '},{y:' + fmt + '},{r1:' + fmt + '}' + radunitstr + ',{r2:' + fmt + '}' + radunitstr + ',{ang:' + fmt + '})\n',
-                   'polygon': 'polygon({c})\n'}
+    ds9_strings = {
+        'circle': 'circle({x:' + fmt + '},{y:' + fmt + '},{r:' + fmt + '}' + radunitstr + ')\n',
+        'ellipse': 'ellipse({x:' + fmt + '},{y:' + fmt + '},{r1:' + fmt + '}' + radunitstr + ',{r2:' + fmt + '}' + radunitstr + ',{ang:' + fmt + '})\n',
+        'polygon': 'polygon({c})\n',
+    }
 
     output = '# Region file format: DS9 astropy/regions\n'
     output += '{}\n'.format(coordsys)
@@ -42,7 +65,7 @@ def objects_to_ds9_string(obj_list, coordsys='fk5', fmt='.4f', radunit='deg'):
         # for pixel/image/physical frames
         frame = None
 
-    for reg in obj_list:
+    for reg in regions:
         if isinstance(reg, shapes.circle.CircleSkyRegion):
             x = float(reg.center.transform_to(frame).spherical.lon.to('deg').value)
             y = float(reg.center.transform_to(frame).spherical.lat.to('deg').value)
@@ -86,8 +109,18 @@ def objects_to_ds9_string(obj_list, coordsys='fk5', fmt='.4f', radunit='deg'):
     return output
 
 
-def write_ds9(obj_list, filename='ds9.reg', coordsys='fk5'):
-    """Write ds9 region file"""
-    output = objects_to_ds9_string(obj_list, coordsys)
+def write_ds9(regions, filename='ds9.reg', coordsys='fk5'):
+    """Convert list of regions to ds9 string and write to file.
+
+    Parameters
+    ----------
+    regions : list
+        List of `regions.Region` objects
+    filename : str
+        Filename
+    coordsys : {TODO}
+        Coordinate system
+    """
+    output = ds9_objects_to_string(regions, coordsys)
     with open(filename, 'w') as fh:
         fh.write(output)


### PR DESCRIPTION
Looking at
http://astropy-regions.readthedocs.io/en/latest/api.html#functions
I see `objects_to_ds9_string`, but no `ds9_string_to_objects`.

It seems that in the implementation (`ds9_parser(filename)`) the reading from file and parsing aren't separated.

This is weird, parsing should take string as input and then read should just read the file and call the parser with the string, no?
OK if I make this change now?