### PR TITLE
Document available shapes, add some repr and tests

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -29,8 +29,8 @@ Some functions for region-based calculations (e.g. filtering a table of sky or
 pixel positions) as well as functions for region serialisation (e.g. to and from
 ds9 region string format) are available.
 
-Example dataset
-===============
+Dataset
+=======
 
 Throughout this tutorial, we will be working with the same `~regions.ExampleSimulatedDataset`
 and assume that you have executed this code to create example ``dataset`` and ``wcs`` objects:
@@ -58,12 +58,12 @@ Before we start diving into coding with regions, here's an image that illustrate
 example counts image, with source positions and a few regions overplotted:
 
 .. plot:: plot_example.py
-   :include-source: false
+:include-source: false
 
 .. _gs-coord:
 
-Sky and pixel coordinates
-=========================
+Coordinates
+===========
 
 This regions package uses `astropy.coordinates.SkyCoord` objects to represent sky
 coordinates.
@@ -206,10 +206,102 @@ or in IPython print the list like this:
     In [1]: import regions
     In [2]: regions.*PixelRegion?
 
+.. _gs-shapes:
+
+Shapes
+======
+
+This section shows one example how to construct a region for each shape that's currently supported.
+
+* `~regions.CircleSkyRegion` and `~regions.CirclePixelRegion`
+
+.. code-block:: python
+
+    from astropy.coordinates import Angle, SkyCoord
+    from regions import PixCoord, CircleSkyRegion, CirclePixelRegion
+
+    circle_sky = CircleSkyRegion(
+        center=SkyCoord(42, 43, unit='deg'),
+        radius=Angle(3, 'deg'),
+    )
+    circle_pix = CirclePixelRegion(
+        center=PixCoord(x=42, y=43),
+        radius=4.2,
+    )
+
+* `~regions.EllipseSkyRegion` and `~regions.EllipsePixelRegion`
+
+.. code-block:: python
+
+    from astropy.coordinates import Angle, SkyCoord
+    from regions import PixCoord, EllipseSkyRegion, EllipsePixelRegion
+
+    ellipse_sky = EllipseSkyRegion(
+        center=SkyCoord(42, 43, unit='deg'),
+        minor=Angle(3, 'deg'),
+        major=Angle(4, 'deg'),
+        angle=Angle(5, 'deg'),
+    )
+    ellipse_pix = EllipsePixelRegion(
+        center=PixCoord(x=42, y=43),
+        minor=3,
+        major=4,
+        angle=Angle(5, 'deg'),
+    )
+
+* `~regions.PointSkyRegion` and `~regions.PointPixelRegion`
+
+.. code-block:: python
+
+    from astropy.coordinates import SkyCoord
+    from regions import PixCoord, PointSkyRegion, PointPixelRegion
+
+    point_sky = PointSkyRegion(
+        center=SkyCoord(42, 43, unit='deg'),
+    )
+    point_pix = PointPixelRegion(
+        center=PixCoord(x=42, y=43),
+    )
+
+* `~regions.PolygonSkyRegion` and `~regions.PolygonPixelRegion`
+
+.. code-block:: python
+
+    from astropy.coordinates import SkyCoord
+    from regions import PixCoord, PolygonSkyRegion, PolygonPixelRegion
+
+    polygon_sky = PolygonSkyRegion(
+        vertices=SkyCoord([1, 2, 2], [1, 1, 2], unit='deg'),
+    )
+    polygon_pix = PolygonPixelRegion(
+        vertices=PixCoord(x=[1, 2, 2], y=[1, 1, 2]),
+    )
+
+* `~regions.RectangleSkyRegion` and `~regions.RectanglePixelRegion`
+
+.. code-block:: python
+
+    from astropy.coordinates import Angle, SkyCoord
+    from regions import PixCoord, RectangleSkyRegion, RectanglePixelRegion
+
+    rectangle_sky = RectangleSkyRegion(
+        center=SkyCoord(42, 43, unit='deg'),
+        width=Angle(3, 'deg'),
+        height=Angle(4, 'deg'),
+        angle=Angle(5, 'deg'),
+    )
+    rectangle_pix = RectanglePixelRegion(
+        center=PixCoord(x=42, y=43),
+        width=3,
+        height=4,
+        angle=Angle(5, 'deg'),
+    )
+
+
 .. _gs-wcs:
 
-Region transformations
-======================
+Transformations
+===============
 
 In the last two sections, we talked about how for every region shape (e.g. circle),
 there's two classes, one representing "sky regions" and another representing "pixel regions"
@@ -310,10 +402,10 @@ to be a scalar bool). If you have arrays of coordinates, use the
 TODO: add pixel coordinate example
 
 
-.. _gs-spatial:
+.. _gs-masks:
 
-Spatial filtering
-=================
+Masks
+=====
 
 For aperture photometry, a common operation is to compute, for a given image and region,
 a boolean mask or array of pixel indices defining which pixels (in the whole image or a
@@ -329,8 +421,8 @@ For now, please use `photutils`_ or `pyregion`_.
 
 .. _gs-compound:
 
-Compound regions
-================
+Compounds
+=========
 
 There's a few ways to combine any two `~regions.Region` objects into a compound region,
 i.e. a `~regions.CompoundPixelRegion` or `~regions.CompoundSkyRegion` object.
@@ -385,8 +477,8 @@ namely to buffer a rectangle, resulting in a polygon.
 
 .. _gs-ds9:
 
-ds9 region strings
-==================
+DS9
+===
 
 The regions package provides functions to serialise and de-serialise Python lists of
 `regions.Region` objects to DS9 region strings: `~regions.ds9_objects_to_string`
@@ -456,8 +548,8 @@ TODO: this is very confusing, because there are two "region lists", one with tup
 and one with `region.Region` objects as input. Need to find better names, maybe even
 a better API?
 
-Plotting regions
-================
+Plotting
+========
 
 TODO
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -92,7 +92,7 @@ To represent pixel coordinates, `regions.PixCoord` objects are used.
 `~astropy.coordinates.SkyCoord` is a very powerful and complex class (different representations,
 a coordinate transformation tree) that is documented extensively in the `astropy.coordinates` docs.
 
-In contrast, `regions.PixCoord` is a small and simple helper class. The pixel coordinate is always
+In contrast, `~regions.PixCoord` is a small and simple helper class. The pixel coordinate is always
 represented as cartesian coordinate data members ``x`` and ``y``. A pixel coordinate doesn't have a
 frame and is not connected to the `astropy.coordinates` transformation tree.
 
@@ -288,6 +288,19 @@ This section shows one example how to construct a region for each shape that's c
         height=4,
         angle=Angle(5, 'deg'),
     )
+
+
+.. _gs-poly:
+
+Polygons
+========
+
+Polygons are the most versatile region. Any region can be approximated as a polygon.
+
+TODO: explain how polygons are implemented and special polygon methods, e.g. how to
+obtain a polygon approximation for any shape.
+This is not available yet, for now see `spherical_geometry`_ for spherical polygons
+and `shapely`_ for pixel polygons.
 
 
 .. _gs-wcs:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -32,8 +32,8 @@ ds9 region string format) are available.
 Dataset
 =======
 
-Throughout this tutorial, we will be working with the same `~regions.ExampleSimulatedDataset`
-and assume that you have executed this code to create example ``dataset`` and ``wcs`` objects:
+Throughout this tutorial, we will be working with the same example dataset and assume that
+you have run `~regions.make_example_dataset` to create example ``dataset`` and ``wcs`` objects like this:
 
 .. code-block:: python
 
@@ -58,7 +58,7 @@ Before we start diving into coding with regions, here's an image that illustrate
 example counts image, with source positions and a few regions overplotted:
 
 .. plot:: plot_example.py
-:include-source: false
+    :include-source: false
 
 .. _gs-coord:
 
@@ -83,9 +83,7 @@ To represent pixel coordinates, `regions.PixCoord` objects are used.
     >>> from regions import PixCoord
     >>> pixcoord = PixCoord(x=42, y=43)
     >>> pixcoord
-    PixCoord
-    x : 42
-    y : 43
+    PixCoord(x=42, y=43)
     >>> pixcoord.x
     42
     >>> pixcoord.y
@@ -106,9 +104,7 @@ forth between sky and pixel coordinates:
     >>> skycoord = SkyCoord(42, 43, unit='deg', frame='galactic')
     >>> pixcoord = PixCoord.from_sky(skycoord=skycoord, wcs=wcs)
     >>> pixcoord
-    PixCoord
-    x : 20.27424296606442
-    y : 12.259980510825843
+    PixCoord(x=146.2575703393558, y=131.5998051082584)
     >>> pixcoord.to_sky(wcs=wcs)
     <SkyCoord (Galactic): (l, b) in deg
         (42.0, 43.0)>
@@ -123,9 +119,7 @@ to represent arrays of pixel coordinates:
 
     >>> pixcoord = PixCoord(x=[0, 1], y=[2, 3])
     >>> pixcoord
-    PixCoord
-    x : [0 1]
-    y : [2 3]
+    PixCoord(x=[0 1], y=[2 3])
     >>> pixcoord.isscalar
     False
 
@@ -154,9 +148,9 @@ You can print the regions to get some info about its properties:
 
     >>> print(region)
     CircleSkyRegion
-    Center:<SkyCoord (ICRS): (ra, dec) in deg
+    center:<SkyCoord (ICRS): (ra, dec) in deg
         (42.0, 43.0)>
-    Radius:3.0 deg
+    radius:3.0 deg
 
 To see a list of all available sky regions, you can go to the API docs
 or in IPython print the list like this:
@@ -193,10 +187,8 @@ You can print the regions to get some info about its properties:
 
     >>> print(region)
     CirclePixelRegion
-    Center: PixCoord
-    x : 42
-    y : 43
-    Radius: 4.2
+    center: PixCoord(x=42, y=43)
+    radius: 4.2
 
 To see a list of all available sky regions, you can go to the API docs
 or in IPython print the list like this:
@@ -330,12 +322,10 @@ To convert it to a pixel region, call the :meth:`~regions.SkyRegion.to_pixel` me
 .. code-block:: python
 
     >>> pix_reg = sky_reg.to_pixel(wcs)
-    >>> pix_reg.center
+    >>> pix_reg
     CirclePixelRegion
-    Center: PixCoord
-    x : 29.364794288785394
-    y : 3.10958313892697
-    Radius: 3.6932908082121654
+    center: PixCoord(x=55.35205711214607, y=40.0958313892697)
+    radius: 36.93290808340659
 
 TODO: show example using lists of regions and mention that a single region object can't represent
 an array of regions.
@@ -351,15 +341,13 @@ Let's continue with the ``sky_reg`` and ``pix_reg`` objects defined in the previ
 
     >>> print(sky_reg)
     CircleSkyRegion
-    Center:<SkyCoord (ICRS): (ra, dec) in deg
+    center:<SkyCoord (ICRS): (ra, dec) in deg
         (50.0, 10.0)>
-    Radius:30.0 deg
+    radius:30.0 deg
     >>> print(pix_reg)
     CirclePixelRegion
-    Center: PixCoord
-    x : 29.364794288785394
-    y : 3.10958313892697
-    Radius: 3.6932908082121654
+    center: PixCoord(x=55.35205711214607, y=40.0958313892697)
+    radius: 36.93290808340659
 
 
 To test if a given point is inside or outside the regions, the Python ``in`` operator
@@ -491,9 +479,9 @@ and `~regions.ds9_string_to_objects`.
     >>> regions = ds9_string_to_objects(reg_string)
     >>> regions[0]
     CircleSkyRegion
-    Center: <Galactic Coordinate: (l, b) in deg
+    center: <Galactic Coordinate: (l, b) in deg
         (42.0, 43.0)>
-    Radius: 3.0 deg
+    radius: 3.0 deg
     >>> ds9_objects_to_string(regions, coordsys='galactic')
     '# Region file format: DS9 astropy/regions\ngalactic\ncircle(42.0000,43.0000,3.0000)\n'
 
@@ -507,6 +495,11 @@ a file in addition to doing the region serialisation and parsing.
     >>> write_ds9(regions, filename)
     >>> regions = read_ds9(filename)
     >>> regions
+    [CircleSkyRegion
+     center: <FK5 Coordinate (equinox=J2000.000): (ra, dec) in deg
+         (245.3477, 24.4291)>
+     radius: 3.0 deg]
+
 
 Often DS9 region files contain extra information about colors or other attributes.
 This information is lost when converting to `~region.Region` objects.
@@ -537,12 +530,12 @@ expose the intermediate "region list", which contains the extra attributes.
     >>> regions = ds9_region_list_to_objects(region_list)
     >>> regions
     [CircleSkyRegion
-     Center: <Galactic Coordinate: (l, b) in deg
+     center: <Galactic Coordinate: (l, b) in deg
          (42.0, 43.0)>
-     Radius: 3.0 deg, CircleSkyRegion
-     Center: <Galactic Coordinate: (l, b) in deg
+     radius: 3.0 deg, CircleSkyRegion
+     center: <Galactic Coordinate: (l, b) in deg
          (99.0, 33.0)>
-     Radius: 1.0 deg]
+     radius: 1.0 deg]
 
 TODO: this is very confusing, because there are two "region lists", one with tuples
 and one with `region.Region` objects as input. Need to find better names, maybe even

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,3 +1,5 @@
+.. include:: references.txt
+
 .. _install:
 
 ************
@@ -31,7 +33,7 @@ To check if your install is OK, run the tests:
 Development version
 ===================
 
-Install the latest development version:
+Install the latest development version from https://github.com/astropy/regions :
 
 .. code-block:: bash
 
@@ -46,6 +48,6 @@ Optional dependencies
 
 The following packages are optional dependencies, install if needed:
 
-* Shapely for advanced pixel region operations
-* matplotlib and wcsaxes for plotting regions
-* maybe https://github.com/spacetelescope/sphere
+* `shapely`_ for advanced pixel region operations
+* `matplotlib`_ and `wcsaxes`_ for plotting regions
+* maybe `spherical_geometry`_ for polygons.

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -1,5 +1,9 @@
 .. _pyregion: http://pyregion.readthedocs.io/en/latest/
+.. _spherical_geometry: http://spacetelescope.github.io/sphere/spherical_geometry/index.html
 .. _photutils: http://photutils.readthedocs.io/en/latest/photutils/aperture.html
+.. _matplotlib: http://matplotlib.org/
+.. _shapely: http://toblerity.org/shapely/manual.html
+.. _wcsaxes: http://wcsaxes.readthedocs.io/en/latest/
 .. _Github repository: https://github.com/astropy/regions
 .. _PyAstro16 doc: https://docs.google.com/document/d/17owovjcpNFirz-f8qCWWxvcHHPGGpO5JJic5WbtD9JY/edit?pref=2&pli=1
 .. _Region documentation: http://astropy-regions.readthedocs.io/en/latest/

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -78,9 +78,9 @@ class PixCoord(object):
         return np.isscalar(self.x)
 
     def __repr__(self):
-        d = dict(name=self.__class__.__name__, x=self.x, y=self.y)
-        s = '{name}\nx : {x}\ny : {y}'
-        return s.format(**d)
+        data = dict(name=self.__class__.__name__, x=self.x, y=self.y)
+        fmt = '{name}(x={x}, y={y})'
+        return fmt.format(**data)
 
     def __len__(self):
         """Define len(pixcoord) for array-valued pixcoord"""

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -28,8 +28,8 @@ def test_pixcoord_scalar_basics():
 
     assert p.isscalar is True
 
-    assert str(p) == 'PixCoord\nx : 1\ny : 2'
-    assert repr(p) == 'PixCoord\nx : 1\ny : 2'
+    assert str(p) == 'PixCoord(x=1, y=2)'
+    assert repr(p) == 'PixCoord(x=1, y=2)'
 
     with pytest.raises(TypeError):
         len(p)
@@ -46,8 +46,8 @@ def test_pixcoord_array_basics():
 
     assert p.isscalar is False
 
-    assert str(p) == 'PixCoord\nx : [1 2 3]\ny : [11 22 33]'
-    assert repr(p) == 'PixCoord\nx : [1 2 3]\ny : [11 22 33]'
+    assert str(p) == 'PixCoord(x=[1 2 3], y=[11 22 33])'
+    assert repr(p) == 'PixCoord(x=[1 2 3], y=[11 22 33])'
 
     assert len(p) == 3
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -16,9 +16,9 @@ class CirclePixelRegion(PixelRegion):
     Parameters
     ----------
     center : `~regions.PixCoord`
-        The position of the center of the circle.
+        Center position
     radius : float
-        The radius of the circle
+        Radius
     """
 
     def __init__(self, center, radius, meta=None, visual=None):
@@ -29,10 +29,13 @@ class CirclePixelRegion(PixelRegion):
         self.visual = visual or {}
 
     def __repr__(self):
-        name = self.__class__.__name__
-        center = self.center
-        radius = self.radius
-        return '{name}\nCenter: {center}\nRadius: {radius}'.format(**locals())
+        data = dict(
+            name=self.__class__.__name__,
+            center=self.center,
+            radius=self.radius,
+        )
+        fmt = '{name}\ncenter: {center}\nradius: {radius}'
+        return fmt.format(**data)
 
     @property
     def area(self):
@@ -78,9 +81,9 @@ class CircleSkyRegion(SkyRegion):
     Parameters
     ----------
     center : `~astropy.coordinates.SkyCoord`
-        The position of the center of the circle.
+        Center position
     radius : `~astropy.units.Quantity`
-        The radius of the circle in angular units
+        Radius in angular units
     """
 
     def __init__(self, center, radius, meta=None, visual=None):
@@ -91,10 +94,13 @@ class CircleSkyRegion(SkyRegion):
         self.visual = visual or {}
 
     def __repr__(self):
-        name = self.__class__.__name__
-        center = self.center
-        radius = self.radius
-        return '{name}\nCenter: {center}\nRadius: {radius}'.format(**locals())
+        data = dict(
+            name=self.__class__.__name__,
+            center=self.center,
+            radius=self.radius,
+        )
+        fmt = '{name}\ncenter: {center}\nradius: {radius}'
+        return fmt.format(**data)
 
     @property
     def area(self):

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -14,13 +14,14 @@ class EllipsePixelRegion(PixelRegion):
     Parameters
     ----------
     center : `~regions.PixCoord`
-        The position of the center of the ellipse.
+        Center position
     minor : float
-        The minor radius of the ellipse
+        Minor radius
     major : float
-        The major radius of the ellipse
+        Major radius
     angle : `~astropy.units.Quantity`
-        The rotation of the ellipse. If set to zero (the default), the major
+        The rotation angle of the ellipse.
+        If set to zero (the default), the major
         axis is lined up with the x axis.
     """
 
@@ -33,6 +34,17 @@ class EllipsePixelRegion(PixelRegion):
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
+
+    def __repr__(self):
+        data = dict(
+            name=self.__class__.__name__,
+            center=self.center,
+            minor=self.minor,
+            major=self.major,
+            angle=self.angle,
+        )
+        fmt = '{name}\ncenter: {center}\nminor: {minor}\nmajor: {major}\nangle: {angle}'
+        return fmt.format(**data)
 
     @property
     def area(self):
@@ -65,14 +77,15 @@ class EllipseSkyRegion(SkyRegion):
 
     Parameters
     ----------
-    center : `~regions.PixCoord`
-        The position of the center of the ellipse.
+    center : `~astropy.coordinates.SkyCoord`
+        Center position
     minor : `~astropy.units.Quantity`
-        The minor radius of the ellipse
+        Minor radius
     major : `~astropy.units.Quantity`
-        The major radius of the ellipse
+        Major radius
     angle : `~astropy.units.Quantity`
-        The rotation of the ellipse. If set to zero (the default), the major
+        The rotation angle of the ellipse.
+        If set to zero (the default), the major
         axis is lined up with the longitude axis of the celestial coordinates.
     """
 
@@ -84,6 +97,17 @@ class EllipseSkyRegion(SkyRegion):
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
+
+    def __repr__(self):
+        data = dict(
+            name=self.__class__.__name__,
+            center=self.center,
+            minor=self.minor,
+            major=self.major,
+            angle=self.angle,
+        )
+        fmt = '{name}\ncenter: {center}\nminor: {minor}\nmajor: {major}\nangle: {angle}'
+        return fmt.format(**data)
 
     @property
     def area(self):

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -21,6 +21,14 @@ class PointPixelRegion(PixelRegion):
         self.meta = meta or {}
         self.visual = visual or {}
 
+    def __repr__(self):
+        data = dict(
+            name=self.__class__.__name__,
+            center=self.center,
+        )
+        fmt = '{name}\ncenter: {center}'
+        return fmt.format(**data)
+
     @property
     def area(self):
         return 0
@@ -59,6 +67,14 @@ class PointSkyRegion(SkyRegion):
         self.center = center
         self.meta = meta or {}
         self.visual = visual or {}
+
+    def __repr__(self):
+        data = dict(
+            name=self.__class__.__name__,
+            center=self.center,
+        )
+        fmt = '{name}\ncenter: {center}'
+        return fmt.format(**data)
 
     @property
     def area(self):

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -21,6 +21,14 @@ class PolygonPixelRegion(PixelRegion):
         self.meta = meta or {}
         self.visual = visual or {}
 
+    def __repr__(self):
+        data = dict(
+            name=self.__class__.__name__,
+            vertices=self.vertices,
+        )
+        fmt = '{name}\nvertices: {vertices}'
+        return fmt.format(**data)
+
     @property
     def area(self):
         # TODO: needs to be implemented
@@ -62,6 +70,14 @@ class PolygonSkyRegion(SkyRegion):
         self.vertices = vertices
         self.meta = meta or {}
         self.visual = visual or {}
+
+    def __repr__(self):
+        data = dict(
+            name=self.__class__.__name__,
+            vertices=self.vertices,
+        )
+        fmt = '{name}\nvertices: {vertices}'
+        return fmt.format(**data)
 
     @property
     def area(self):

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -53,7 +53,7 @@ class PolygonSkyRegion(SkyRegion):
 
     Parameters
     ----------
-    vertices : `~regions.PixCoord`
+    vertices : `~astropy.coordinates.SkyCoord`
         The vertices of the polygon
     """
 

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -32,6 +32,17 @@ class RectanglePixelRegion(PixelRegion):
         self.meta = meta or {}
         self.visual = visual or {}
 
+    def __repr__(self):
+        data = dict(
+            name=self.__class__.__name__,
+            center=self.center,
+            height=self.height,
+            width=self.width,
+            angle=self.angle,
+        )
+        fmt = '{name}\ncenter: {center}\nheight: {height}\nwidth: {width}\nangle: {angle}'
+        return fmt.format(**data)
+
     @property
     def area(self):
         return self.width * self.height
@@ -82,6 +93,17 @@ class RectangleSkyRegion(SkyRegion):
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
+
+    def __repr__(self):
+        data = dict(
+            name=self.__class__.__name__,
+            center=self.center,
+            height=self.height,
+            width=self.width,
+            angle=self.angle,
+        )
+        fmt = '{name}\ncenter: {center}\nheight: {height}\nwidth: {width}\nangle: {angle}'
+        return fmt.format(**data)
 
     @property
     def area(self):

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -8,7 +8,7 @@ __all__ = ['RectanglePixelRegion', 'RectangleSkyRegion']
 
 class RectanglePixelRegion(PixelRegion):
     """
-    An rectangle in pixel coordinates.
+    A rectangle in pixel coordinates.
 
     Parameters
     ----------
@@ -59,11 +59,11 @@ class RectanglePixelRegion(PixelRegion):
 
 class RectangleSkyRegion(SkyRegion):
     """
-    An rectangle in sky coordinates.
+    A rectangle in sky coordinates.
 
     Parameters
     ----------
-    center : `~regions.PixCoord`
+    center : `~astropy.coordinates.SkyCoord`
         The position of the center of the rectangle.
     height : `~astropy.units.Quantity`
         The height radius of the rectangle

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -1,0 +1,21 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+from ...core import PixCoord
+from ..ellipse import EllipsePixelRegion, EllipseSkyRegion
+
+
+def test_ellipse_pixel():
+    center = PixCoord(3, 4)
+    reg = EllipsePixelRegion(center, 3, 4, 5)
+
+    assert str(reg) == 'EllipsePixelRegion\ncenter: PixCoord(x=3, y=4)\nminor: 3\nmajor: 4\nangle: 5'
+
+
+def test_ellipse_sky():
+    center = SkyCoord(3, 4, unit='deg')
+    reg = EllipseSkyRegion(center, 3 * u.deg, 4 * u.deg, 5 * u.deg)
+
+    print(reg)
+    assert str(reg) == 'EllipseSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>\nminor: 3.0 deg\nmajor: 4.0 deg\nangle: 5.0 deg'

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -17,5 +17,4 @@ def test_ellipse_sky():
     center = SkyCoord(3, 4, unit='deg')
     reg = EllipseSkyRegion(center, 3 * u.deg, 4 * u.deg, 5 * u.deg)
 
-    print(reg)
     assert str(reg) == 'EllipseSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>\nminor: 3.0 deg\nmajor: 4.0 deg\nangle: 5.0 deg'

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -8,13 +8,15 @@ from ..ellipse import EllipsePixelRegion, EllipseSkyRegion
 
 def test_ellipse_pixel():
     center = PixCoord(3, 4)
-    reg = EllipsePixelRegion(center, 3, 4, 5)
+    reg = EllipsePixelRegion(center, 3, 4, 5 * u.deg)
 
-    assert str(reg) == 'EllipsePixelRegion\ncenter: PixCoord(x=3, y=4)\nminor: 3\nmajor: 4\nangle: 5'
+    assert str(reg) == 'EllipsePixelRegion\ncenter: PixCoord(x=3, y=4)\nminor: 3\nmajor: 4\nangle: 5.0 deg'
 
 
 def test_ellipse_sky():
     center = SkyCoord(3, 4, unit='deg')
     reg = EllipseSkyRegion(center, 3 * u.deg, 4 * u.deg, 5 * u.deg)
 
-    assert str(reg) == 'EllipseSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>\nminor: 3.0 deg\nmajor: 4.0 deg\nangle: 5.0 deg'
+    expected = ('EllipseSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
+                '    (3.0, 4.0)>\nminor: 3.0 deg\nmajor: 4.0 deg\nangle: 5.0 deg')
+    assert str(reg) == expected

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -1,0 +1,19 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+from astropy.coordinates import SkyCoord
+from ...core import PixCoord
+from ..point import PointPixelRegion, PointSkyRegion
+
+
+def test_ellipse_pixel():
+    center = PixCoord(3, 4)
+    reg = PointPixelRegion(center)
+
+    assert str(reg) == 'PointPixelRegion\ncenter: PixCoord(x=3, y=4)'
+
+
+def test_ellipse_sky():
+    center = SkyCoord(3, 4, unit='deg')
+    reg = PointSkyRegion(center)
+
+    assert str(reg) == 'PointSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>'

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -1,65 +1,82 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose, assert_equal
+from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from ...core import PixCoord
 from ..polygon import PolygonPixelRegion, PolygonSkyRegion
 
 
-def test_polygon_pixel():
+@pytest.fixture
+def pix_poly():
     vertices = PixCoord([3, 4, 3], [3, 4, 4])
-    reg = PolygonPixelRegion(vertices)
-
-    assert str(reg) == 'PolygonPixelRegion\nvertices: PixCoord(x=[3 4 3], y=[3 4 4])'
+    return PolygonPixelRegion(vertices)
 
 
-def test_polygon_sky():
+@pytest.fixture
+def sky_poly():
     vertices = SkyCoord([3, 4, 3] * u.deg, [3, 4, 4] * u.deg)
-    reg = PolygonSkyRegion(vertices)
+    return PolygonSkyRegion(vertices)
 
+
+def test_polygon_pixel(pix_poly):
+    expected = 'PolygonPixelRegion\nvertices: PixCoord(x=[3 4 3], y=[3 4 4])'
+    assert str(pix_poly) == expected
+
+
+def test_polygon_sky(sky_poly):
     expected = ('PolygonSkyRegion\nvertices: <SkyCoord (ICRS): (ra, dec) in deg\n'
                 '    [(3.0, 3.0), (4.0, 4.0), (3.0, 4.0)]>')
-    assert str(reg) == expected
+    assert str(sky_poly) == expected
 
-# def test_basic():
-#     """
-#     Just make sure that things don't crash, but no test of numerical accuracy
-#     """
-#
-#     poly1 = PolygonRegion(([10, 20, 20, 10, 10], [20, 20, 10, 10, 20]))
-#
-#     poly2 = PolygonRegion(([15, 25, 25, 15, 15], [23, 23, 13, 13, 23]))
-#
-#     poly3 = poly1.union(poly2)
-#     poly4 = poly1.intersection(poly2)
-#
-#     np.testing.assert_allclose(poly1.area, 100)
-#     np.testing.assert_allclose(poly2.area, 100)
-#     np.testing.assert_allclose(poly3.area, 165)
-#     np.testing.assert_allclose(poly4.area, 35)
-#
-#     assert (13, 12) in poly1
-#     assert not (13, 12) in poly2
-#
-#     # TODO: it seems __contains__ has to return a scalar value?
-#     # assert np.all(((np.array([13, 8]), np.array([15, 15])) in poly1) == np.array([False, True]))
-#
-#
-# def test_sky_basic():
-#     """
-#     Just make sure that things don't crash, but no test of numerical accuracy
-#     """
-#
-#     coords1 = SkyCoord([10, 20, 20, 10, 10] * u.deg, [20, 20, 10, 10, 20] * u.deg)
-#     poly1 = SkyPolygonRegion(coords1)
-#
-#     coords1 = SkyCoord([15, 25, 25, 15, 15] * u.deg, [23, 23, 13, 13, 23] * u.deg)
-#     poly2 = SkyPolygonRegion(coords1)
-#
-#     poly3 = poly1.union(poly2)
-#     poly4 = poly1.intersection(poly2)
-#
-#     poly1.area
-#     poly2.area
-#     poly3.area
-#     poly4.area
+
+def _test_polygon_basic():
+    """
+    TODO: implement these tests!
+
+    Just make sure that things don't crash, but no test of numerical accuracy
+    """
+
+    poly1 = PolygonPixelRegion(([10, 20, 20, 10, 10], [20, 20, 10, 10, 20]))
+
+    poly2 = PolygonPixelRegion(([15, 25, 25, 15, 15], [23, 23, 13, 13, 23]))
+
+    assert_allclose(poly1.area, 100)
+    assert_allclose(poly2.area, 100)
+
+    assert PixCoord(13, 12) in poly1
+    assert not PixCoord(13, 12) in poly2
+
+    coords = PixCoord([13, 8], [15, 15])
+    assert_equal(poly1.contains(coords), [False, True])
+
+    # poly3 = poly1.union(poly2)
+    # poly4 = poly1.intersection(poly2)
+    # assert_allclose(poly3.area, 165)
+    # assert_allclose(poly4.area, 35)
+
+
+def _test_polygon_sky_basic():
+    """
+    TODO: implement these tests!
+
+    Just make sure that things don't crash, but no test of numerical accuracy
+    """
+
+    coords1 = SkyCoord([10, 20, 20, 10, 10] * u.deg, [20, 20, 10, 10, 20] * u.deg)
+    poly1 = PolygonSkyRegion(coords1)
+
+    coords1 = SkyCoord([15, 25, 25, 15, 15] * u.deg, [23, 23, 13, 13, 23] * u.deg)
+    poly2 = PolygonSkyRegion(coords1)
+
+    assert_quantity_allclose(poly1.area, 42 * u.sr)
+    assert_quantity_allclose(poly2.area, 42 * u.sr)
+
+    # TODO: test contains
+
+    poly3 = poly1.union(poly2)
+    poly4 = poly1.intersection(poly2)
+
+    assert_quantity_allclose(poly3.area, 42 * u.sr)
+    assert_quantity_allclose(poly4.area, 42 * u.sr)

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -10,7 +10,6 @@ def test_polygon_pixel():
     vertices = PixCoord([3, 4, 3], [3, 4, 4])
     reg = PolygonPixelRegion(vertices)
 
-    print(reg)
     assert str(reg) == 'PolygonPixelRegion\nvertices: PixCoord(x=[3 4 3], y=[3 4 4])'
 
 
@@ -18,8 +17,9 @@ def test_polygon_sky():
     vertices = SkyCoord([3, 4, 3] * u.deg, [3, 4, 4] * u.deg)
     reg = PolygonSkyRegion(vertices)
 
-    print(reg)
-    assert str(reg) == 'PolygonSkyRegion\nvertices: <SkyCoord (ICRS): (ra, dec) in deg\n    [(3.0, 3.0), (4.0, 4.0), (3.0, 4.0)]>'
+    expected = ('PolygonSkyRegion\nvertices: <SkyCoord (ICRS): (ra, dec) in deg\n'
+                '    [(3.0, 3.0), (4.0, 4.0), (3.0, 4.0)]>')
+    assert str(reg) == expected
 
 # def test_basic():
 #     """

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -6,14 +6,20 @@ from ...core import PixCoord
 from ..polygon import PolygonPixelRegion, PolygonSkyRegion
 
 
-def test_init_pixel():
+def test_polygon_pixel():
     vertices = PixCoord([3, 4, 3], [3, 4, 4])
-    c = PolygonPixelRegion(vertices)
+    reg = PolygonPixelRegion(vertices)
+
+    print(reg)
+    assert str(reg) == 'PolygonPixelRegion\nvertices: PixCoord(x=[3 4 3], y=[3 4 4])'
 
 
-def test_init_sky():
+def test_polygon_sky():
     vertices = SkyCoord([3, 4, 3] * u.deg, [3, 4, 4] * u.deg)
-    c = PolygonSkyRegion(vertices)
+    reg = PolygonSkyRegion(vertices)
+
+    print(reg)
+    assert str(reg) == 'PolygonSkyRegion\nvertices: <SkyCoord (ICRS): (ra, dec) in deg\n    [(3.0, 3.0), (4.0, 4.0), (3.0, 4.0)]>'
 
 # def test_basic():
 #     """

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -1,0 +1,22 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+from ...core import PixCoord
+from ..rectangle import RectanglePixelRegion, RectangleSkyRegion
+
+
+def test_ellipse_pixel():
+    center = PixCoord(3, 4)
+    reg = RectanglePixelRegion(center, 3, 4, 5 * u.deg)
+
+    assert str(reg) == 'RectanglePixelRegion\ncenter: PixCoord(x=3, y=4)\nheight: 3\nwidth: 4\nangle: 5.0 deg'
+
+
+def test_ellipse_sky():
+    center = SkyCoord(3, 4, unit='deg')
+    reg = RectangleSkyRegion(center, 3 * u.deg, 4 * u.deg, 5 * u.deg)
+
+    expected = ('RectangleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
+                '    (3.0, 4.0)>\nheight: 3.0 deg\nwidth: 4.0 deg\nangle: 5.0 deg')
+    assert str(reg) == expected


### PR DESCRIPTION
This PR:
- [x] Adds a 'shapes' section to the docs with an example how to create each available shape
- [x] Implements `repr` for every shape in a consistent way
- [x] Adds a test file for every shape and checks object creation and repr at the very least
- [x] A few minor misc improvements in other places.

I'll merge if travis-ci passes, this should be uncontroversial.

If someone wants to do a quick review, it's welcome of course.