### PR TITLE
Adding conda channels to CI files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,7 @@ env:
         - MAIN_CMD='python setup.py'
         - PIP_DEPENDENCIES=''
         - CONDA_DEPENDENCIES='Cython shapely wcsaxes'
-
-        # If there are matplotlib or other GUI tests, uncomment the following
-        # line to use the X virtual framebuffer.
+        - CONDA_CHANNELS='astropy'
         - SETUP_XVFB=True
 
     matrix:


### PR DESCRIPTION
Conda channels now need to be explicitly listed, ci-helpers won't add astropy and astropy-ci-extras by default in the future astropy/ci-helpers#128.