### PR TITLE
Change from deprecated build_sphinx to new build_docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,10 @@ matrix:
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
+        - python: 2.7
+          env: SETUP_CMD='build_docs -w'
         - python: 3.5
-          env: SETUP_CMD='build_sphinx -w'
+          env: SETUP_CMD='build_docs -w'
 
         # Do a test without the optional dependencies
         - python: 3.5

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -63,7 +63,7 @@ Install the latest development version from https://github.com/astropy/regions :
     cd regions
     python setup.py install
     python setup.py test
-    python setup.py build_sphinx
+    python setup.py build_docs
 
 Optional dependencies
 =====================

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[build_sphinx]
+[build_docs]
 source-dir = docs
 build-dir = docs/_build
 all_files = 1


### PR DESCRIPTION
The `build_sphinx` command has been deprecated in `astropy-helpers`.
This PR changes to the new equivalent command (that has existed for a long time) of `build_docs`.