### PR TITLE
Check that pytest-arraydiff is installed

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,7 +62,19 @@ Install the latest development version from https://github.com/astropy/regions :
     git clone https://github.com/astropy/regions
     cd regions
     python setup.py install
+
+To run the tests, you will need to make sure the `pytest-arraydiff
+<https://pypi.python.org/pypi/pytest-arraydiff>`_ package is installed. Then,
+run the tests with:
+
+.. code-block:: bash
+
     python setup.py test
+
+To build the documentation, do:
+
+.. code-block:: bash
+
     python setup.py build_docs
 
 Optional dependencies

--- a/regions/__init__.py
+++ b/regions/__init__.py
@@ -22,14 +22,3 @@ if not _ASTROPY_SETUP_:
     from .core import *
     from .io import *
     from .shapes import *
-else:
-    import sys
-    if 'test' in sys.argv:
-        try:
-            import pytest_arraydiff
-        except ImportError:
-            raise ImportError("The pytest-arraydiff package is required for the tests. "
-                              "You can install it with: pip install pytest-arraydiff")
-        else:
-            # Just make sure the plugin import works to avoid obscure errors later
-            import pytest_arraydiff.plugin

--- a/regions/__init__.py
+++ b/regions/__init__.py
@@ -22,3 +22,14 @@ if not _ASTROPY_SETUP_:
     from .core import *
     from .io import *
     from .shapes import *
+else:
+    import sys
+    if 'test' in sys.argv:
+        try:
+            import pytest_arraydiff
+        except ImportError:
+            raise ImportError("The pytest-arraydiff package is required for the tests. "
+                              "You can install it with: pip install pytest-arraydiff")
+        else:
+            # Just make sure the plugin import works to avoid obscure errors later
+            import pytest_arraydiff.plugin

--- a/regions/conftest.py
+++ b/regions/conftest.py
@@ -8,6 +8,9 @@ except ImportError:
     raise ImportError("The pytest-arraydiff package is required for the tests. "
                       "You can install it with: pip install pytest-arraydiff")
 else:
+    # We need to remove pytest_arraydiff from the namespace otherwise pytest
+    # gets confused, because it tries to interpret pytest_* as a special
+    # function name.
     del pytest_arraydiff
 
 from astropy.tests.pytest_plugins import *

--- a/regions/conftest.py
+++ b/regions/conftest.py
@@ -2,6 +2,14 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
+try:
+    import pytest_arraydiff
+except ImportError:
+    raise ImportError("The pytest-arraydiff package is required for the tests. "
+                      "You can install it with: pip install pytest-arraydiff")
+else:
+    del pytest_arraydiff
+
 from astropy.tests.pytest_plugins import *
 
 ## Uncomment the following line to treat all DeprecationWarnings as

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ setup(name=PACKAGENAME,
               'wcsaxes',
           ],
           test=[
+              'pytest-mpl',
               'pytest-arraydiff'
           ],
       ),

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(name=PACKAGENAME,
               'wcsaxes',
           ],
           test=[
-              'pytest-mpl',
+              'pytest-arraydiff'
           ],
       ),
       author=AUTHOR,


### PR DESCRIPTION
@cdeil - this is one way to make sure that pytest-arraydiff is installed and give a better error message. I'm not a fan of this, but it does the job:

```
$ python setup.py test
Traceback (most recent call last):
  File "/Users/tom/Dropbox/Code/Astropy/regions/regions/__init__.py", line 29, in <module>
    import pytest_arraydiff
ImportError: No module named 'pytest_arraydiff'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "setup.py", line 41, in <module>
    __import__(PACKAGENAME)
  File "/Users/tom/Dropbox/Code/Astropy/regions/regions/__init__.py", line 31, in <module>
    raise ImportError("The pytest-arraydiff package is required for the tests. "
ImportError: The pytest-arraydiff package is required for the tests. You can install it with: pip install pytest-arraydiff
```

I'm open to other ideas though.