### PR TITLE
Round to int, not float

### DIFF
--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -48,6 +48,32 @@ class BoundingBox(object):
         self.iymin = iymin
         self.iymax = iymax
 
+    @classmethod
+    def _from_float(cls, xmin, xmax, ymin, ymax):
+        """Smallest BoundingBox that fully contains a given float rectangle.
+
+        Parameters
+        ----------
+        xmin, xmax, ymin, ymax : float
+            Rectangle with arbitrary float coordinates
+
+        Returns
+        -------
+        bbox : `BoundingBox`
+            Smallest bounding box fully containing the rectangle
+        """
+        # We use round here because if the region extends
+        # to e.g. -0.4, it's enough to set the bounding box lower value to 0
+        # because the 0-th pixel goes from -0.5 to 0.5. At the upper end we add
+        # 1 because the upper limits need to be exclusive.
+
+        # Note: we call `int` explicitly, because `round` returns float on Python 2
+        ixmin = int(round(xmin))
+        ixmax = int(round(xmax) + 1)
+        iymin = int(round(ymin))
+        iymax = int(round(ymax) + 1)
+        return cls(ixmin, ixmax, iymin, iymax)
+
     def __eq__(self, other):
         if not isinstance(other, BoundingBox):
             raise TypeError('Can only compare BoundingBox to other BoundingBox')

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -52,6 +52,17 @@ class BoundingBox(object):
     def _from_float(cls, xmin, xmax, ymin, ymax):
         """Smallest BoundingBox that fully contains a given float rectangle.
 
+        Following the pixel convention, the pixel edges correspond to these
+        pixel coordinates for example for three pixels:
+
+        - pixel 0 from -0.5 to 0.5
+        - pixel 1 from 0.5 to 1.5
+        - pixel 2 from 1.5 to 2.5
+
+        Therefore we call the Python built-in ``round`` function, which implements
+        these ranges. At the upper end we add 1, because by definition,
+        `BoundingBox` upper limits are exclusive. See examples below.
+
         Parameters
         ----------
         xmin, xmax, ymin, ymax : float
@@ -61,17 +72,21 @@ class BoundingBox(object):
         -------
         bbox : `BoundingBox`
             Smallest bounding box fully containing the rectangle
-        """
-        # We use round here because if the region extends
-        # to e.g. -0.4, it's enough to set the bounding box lower value to 0
-        # because the 0-th pixel goes from -0.5 to 0.5. At the upper end we add
-        # 1 because the upper limits need to be exclusive.
 
+        Examples
+        --------
+
+        >>> from regions import BoundingBox
+        >>> BoundingBox._from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
+        BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=21)
+        >>> BoundingBox._from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
+        BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
+        """
         # Note: we call `int` explicitly, because `round` returns float on Python 2
         ixmin = int(round(xmin))
-        ixmax = int(round(xmax) + 1)
+        ixmax = int(round(xmax)) + 1
         iymin = int(round(ymin))
-        iymax = int(round(ymax) + 1)
+        iymax = int(round(ymax)) + 1
         return cls(ixmin, ixmax, iymin, iymax)
 
     def __eq__(self, other):

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -21,6 +21,15 @@ def test_bounding_box_init():
     assert bbox.iymax == 20
 
 
+def test_bounding_box_from_float():
+    # This is the example from the method docstring
+    bbox = BoundingBox._from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
+    assert bbox == BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=21)
+
+    bbox = BoundingBox._from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
+    assert bbox == BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
+
+
 def test_bounding_box_eq():
     bbox = BoundingBox(1, 10, 2, 20)
     assert bbox == bbox

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -67,6 +67,9 @@ class CirclePixelRegion(PixelRegion):
 
     @property
     def bounding_box(self):
+        """
+        Bounding box (`~regions.BoundingBox`).
+        """
 
         # Find exact bounds
         xmin = self.center.x - self.radius
@@ -74,16 +77,7 @@ class CirclePixelRegion(PixelRegion):
         ymin = self.center.y - self.radius
         ymax = self.center.y + self.radius
 
-        # Find range of pixels. We use round here because if the region extends
-        # to e.g. -0.4, it's enough to set the bounding box lower value to 0
-        # because the 0-th pixel goes from -0.5 to 0.5. At the upper end we add
-        # 1 because the upper limits need to be exlcusive.
-        ixmin = round(xmin)
-        ixmax = round(xmax) + 1
-        iymin = round(ymin)
-        iymax = round(ymax) + 1
-
-        return BoundingBox(ixmin, ixmax, iymin, iymax)
+        return BoundingBox._from_float(xmin, xmax, ymin, ymax)
 
     def to_mask(self, mode='center', subpixels=1):
 

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -65,7 +65,9 @@ class EllipsePixelRegion(PixelRegion):
 
     @property
     def bounding_box(self):
-
+        """
+        Bounding box (`~regions.BoundingBox`).
+        """
         # Find exact bounds
         # FIXME: this is not the minimal bounding box, and can be optimized
         xmin = self.center.x - max(self.major, self.minor)
@@ -73,16 +75,7 @@ class EllipsePixelRegion(PixelRegion):
         ymin = self.center.y - max(self.major, self.minor)
         ymax = self.center.y + max(self.major, self.minor)
 
-        # Find range of pixels. We use round here because if the region extends
-        # to e.g. -0.4, it's enough to set the bounding box lower value to 0
-        # because the 0-th pixel goes from -0.5 to 0.5. At the upper end we add
-        # 1 because the upper limits need to be exlcusive.
-        ixmin = round(xmin)
-        ixmax = round(xmax) + 1
-        iymin = round(ymin)
-        iymax = round(ymax) + 1
-
-        return BoundingBox(ixmin, ixmax, iymin, iymax)
+        return BoundingBox._from_float(xmin, xmax, ymin, ymax)
 
     def to_mask(self, mode='center', subpixels=5):
 

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -65,6 +65,9 @@ class RectanglePixelRegion(PixelRegion):
 
     @property
     def bounding_box(self):
+        """
+        Bounding box (`~regions.BoundingBox`).
+        """
 
         # Find exact bounds
         # FIXME: this is not the minimal bounding box, and can be optimized
@@ -74,16 +77,7 @@ class RectanglePixelRegion(PixelRegion):
         ymin = self.center.y - radius
         ymax = self.center.y + radius
 
-        # Find range of pixels. We use round here because if the region extends
-        # to e.g. -0.4, it's enough to set the bounding box lower value to 0
-        # because the 0-th pixel goes from -0.5 to 0.5. At the upper end we add
-        # 1 because the upper limits need to be exlcusive.
-        ixmin = round(xmin)
-        ixmax = round(xmax) + 1
-        iymin = round(ymin)
-        iymax = round(ymax) + 1
-
-        return BoundingBox(ixmin, ixmax, iymin, iymax)
+        return BoundingBox._from_float(xmin, xmax, ymin, ymax)
 
     def to_mask(self, mode='center', subpixels=5):
 


### PR DESCRIPTION
@astrofrog added bounding box methods that call `round`:
https://github.com/astropy/regions/search?utf8=%E2%9C%93&q=round

Now here's what I think is an amazing catch by PyCharm (or a false positive if I misunderstand the situation): It points out that e.g. `CirclePixelRegion.bounding_box` calls `BoundingBox(ixmin, ixmax, iymin, iymax)` with floats, but it should call it with ints.

Now first of all, I think it knows about the expected types because it's parsing the `BoundingBox` Numpy-format docstring. Also, it asked me if this project should be simultaneously Python 2.7 and 3 compatible and I said yes. And lastly, on Python 2, `round` returns float:
```
$ python2
>>> type(round(0.3))
<type 'float'>

$ python3
>>> type(round(0.3))
<class 'int'>
```

@astrofrog @adonath - Is this indeed a potential issue? I think we should change callers to always call `int`, instead of auto-casting of ints stored in `float` in `BoundingBox.__init__`? Should we add an extra check that ints are passed in? What's the best (correct, short) way to write this, i.e. what code changes should we make?

Should we do a general review of `round` code in `astropy`, `photutils`, `gammapy` or just make a change here? Does one of you have time to make a PR or should I?