### PR TITLE
Improve shape classes and MPL plotting

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -815,20 +815,57 @@ expose the intermediate "region list", which contains the extra attributes.
     and stored as region data members. These need to be documented and tests added,
     or removed.
 
-Plotting
-========
+Matplotlib plotting
+===================
 
-Some `~regions.Region` objects have an ``as_patch()`` and ``plot()`` method that allows
-plotting them with `matplotlib` and `wcsaxes` for sky regions and sky images.
-This is not the case for compound regions.
+Some `~regions.PixelRegion` objects have an ``as_patch()`` method that returns an
+equivalent `matplotlib.patches` object. For example :meth:`~regions.CirclePixelRegion.as_patch`
+returns a `matplotlib.patches.Circle` object.
 
-Here's how to plot a `~regions.CirclePixelRegion` on an image.
+To draw a matplotlib patch object, add it to an `matplotlib.axes.Axes` object.
+
+.. plot::
+   :include-source:
+
+    from regions import PixCoord, CirclePixelRegion
+    import matplotlib.pyplot as plt
+
+    region = CirclePixelRegion(PixCoord(x=0.3, y=0.42), radius=0.5)
+    patch = region.as_patch()
+
+    axes = plt.gca()
+    axes.add_patch(patch)
+
+    plt.show()
+
+
+The :meth:`~regions.PixelRegion.plot` convenience method just does these two
+steps at once (creating a matplotlib patch and adding it to an axis),
+and does call ``plt.gca()`` if no axis is passed in.
+
+Note that not all pixel regions have ``as_patch()`` methods, e.g.
+the `~regions.PointPixelRegion` or compound regions don't because there's
+no equivalent matplotlib object.
+
+Here's a full example how to plot a `~regions.CirclePixelRegion` on an image.
 
 .. plot:: plot_example_pix.py
    :include-source:
 
-Calling :meth:`~regions.CirclePixelRegion.as_patch` on the ``region`` object would
-return a `matplotlib.patches.Circle` object.
+`~regions.SkyRegion` objects currently don't have an ``as_patch()`` or ``plot()``
+method. To plot them, convert them to a pixel region first:
+
+.. code-block:: python
+
+    sky_region = <...>
+    pixel_region = sky_region.to_pixel(wcs, mode, tolerance)
+    pixel_region.plot(**kwargs)  # plot options passed to matplotlib
+
+We do plan to add extensive documentation on sky region plotting, or to
+add methods on sky region to do it directly in the future
+(see https://github.com/astropy/regions/issues/76 ),
+after the polygon region classes are developed and ``wcsaxes`` is merged
+in the Astropy core package.
 
 An example of how to plot sky regions on a sky image is shown above.
 

--- a/docs/plot_compound.py
+++ b/docs/plot_compound.py
@@ -9,9 +9,9 @@ from regions import CircleSkyRegion, make_example_dataset
 
 # load example dataset to get skymap
 config = dict(crval=(0, 0),
-              crpix=(8, 8),
+              crpix=(180, 90),
               cdelt=(-1, 1),
-              shape=(16, 16))
+              shape=(180, 360))
 
 dataset = make_example_dataset(data='simulated', config=config)
 wcs = dataset.wcs
@@ -21,19 +21,19 @@ dataset.image.data = np.zeros_like(dataset.image.data)
 
 # define 2 sky circles
 circle1 = CircleSkyRegion(
-    center=SkyCoord(1,2, unit='deg', frame='galactic'),
-    radius=Angle('5 deg')
+    center=SkyCoord(20, 0, unit='deg', frame='galactic'),
+    radius=Angle('30 deg')
 )
 
 circle2 = CircleSkyRegion(
-    center=SkyCoord(-4,3, unit='deg', frame='galactic'),
-    radius=Angle('3 deg'),
+    center=SkyCoord(50, 45, unit='deg', frame='galactic'),
+    radius=Angle('30 deg'),
 )
 
 # define skycoords
-lon = np.concatenate([np.arange(352, 360), np.arange(0,8)])
-lat = np.arange(-7,7)
-coords = np.array(np.meshgrid(lon, lat)).T.reshape(-1,2)
+lon = np.arange(-180, 181, 10)
+lat = np.arange(-90, 91, 10)
+coords = np.array(np.meshgrid(lon, lat)).T.reshape(-1, 2)
 skycoords = SkyCoord(coords, unit='deg', frame='galactic')
 
 # get events in AND and XOR
@@ -49,18 +49,15 @@ skycoords_xor = skycoords[mask_xor]
 fig = plt.figure()
 ax = fig.add_axes([0.15, 0.1, 0.8, 0.8], projection=wcs)
 
-ax.imshow(dataset.image.data, cmap='gray', vmin=0, vmax=1,
-          interpolation='nearest', origin='lower')
-
-ax.scatter(skycoords.l, skycoords.b, label='all events',
+ax.scatter(skycoords.l, skycoords.b, label='all',
            transform=ax.get_transform('galactic'))
-ax.scatter(skycoords_xor.l, skycoords_xor.b, color='orange', label='XOR',
-          transform=ax.get_transform('galactic'))
-ax.scatter(skycoords_and.l, skycoords_and.b, color='magenta', label='AND',
-          transform=ax.get_transform('galactic'))
+ax.scatter(skycoords_xor.l, skycoords_xor.b, color='orange', label='xor',
+           transform=ax.get_transform('galactic'))
+ax.scatter(skycoords_and.l, skycoords_and.b, color='magenta', label='and',
+           transform=ax.get_transform('galactic'))
 
-circle1.plot(ax, edgecolor='yellow', facecolor='none', alpha=0.8, lw=3)
-circle2.plot(ax, edgecolor='cyan', facecolor='none', alpha=0.8, lw=3)
+circle1.to_pixel(wcs=wcs).plot(ax, edgecolor='green', facecolor='none', alpha=0.8, lw=3)
+circle2.to_pixel(wcs=wcs).plot(ax, edgecolor='red', facecolor='none', alpha=0.8, lw=3)
 
 ax.legend(loc='lower right')
 

--- a/docs/plot_example.py
+++ b/docs/plot_example.py
@@ -27,7 +27,6 @@ for source in dataset.source_table:
     region = CircleSkyRegion(center=center, radius=radius)
     pix_region = region.to_pixel(wcs=wcs)
 
-    pix_region.plot(ax, edgecolor='green', facecolor='none', alpha=0.8, lw=3)
-    region.plot(ax, edgecolor='yellow', facecolor='none', alpha=0.8, lw=3)
+    pix_region.plot(ax, edgecolor='yellow', facecolor='yellow', alpha=0.5, lw=3)
 
 plt.show()

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -317,33 +317,3 @@ class SkyRegion(Region):
         tolerance : `~astropy.units.Quantity`
             The tolerance for the ``'full'`` mode described above.
         """
-
-    @abc.abstractmethod
-    def as_patch(self, ax, **kwargs):
-        """Convert to mpl patch using a given wcs axis
-
-        Parameters
-        ----------
-        ax : `~astropy.wcsaxes.WCSAxes`
-            WCS axis object
-
-        Returns
-        -------
-        patch : `~matplotlib.patches.Patch`
-            Matplotlib patch
-        """
-
-    def plot(self, ax=None, **kwargs):
-        """
-        Calls as_patch method forwarding all kwargs and adds patch
-        to given wcs axis.
-
-        Parameters
-        ----------
-        ax : `~astropy.wcsaxes.WCSAxes`
-            WCS axis object
-        """
-        patch = self.as_patch(ax, **kwargs)
-        ax.add_patch(patch)
-
-        return ax

--- a/regions/io/write_ds9.py
+++ b/regions/io/write_ds9.py
@@ -79,15 +79,15 @@ def ds9_objects_to_string(regions, coordsys='fk5', fmt='.4f', radunit='deg'):
         elif isinstance(reg, shapes.ellipse.EllipseSkyRegion):
             x = float(reg.center.transform_to(frame).spherical.lon.to('deg').value)
             y = float(reg.center.transform_to(frame).spherical.lat.to('deg').value)
-            r2 = float(reg.major.to(radunit).value)
-            r1 = float(reg.minor.to(radunit).value)
+            r1 = float(reg.major.to(radunit).value)
+            r2 = float(reg.minor.to(radunit).value)
             ang = float(reg.angle.to('deg').value)
             output += ds9_strings['ellipse'].format(**locals())
         elif isinstance(reg, shapes.ellipse.EllipsePixelRegion):
             x = reg.center.x
             y = reg.center.y
-            r2 = reg.major
-            r1 = reg.minor
+            r1 = reg.major
+            r2 = reg.minor
             ang = reg.angle
             output += ds9_strings['ellipse'].format(**locals())
         elif isinstance(reg, shapes.polygon.PolygonSkyRegion):

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -181,18 +181,3 @@ class CircleSkyRegion(SkyRegion):
         radius = self.radius.to('deg').value * scale
 
         return CirclePixelRegion(center, radius)
-
-    def as_patch(self, ax, **kwargs):
-        import matplotlib.patches as mpatches
-
-        val = self.center.icrs
-        center = (val.ra.to('deg').value, val.dec.to('deg').value)
-
-        temp = dict(transform=ax.get_transform('icrs'),
-                    radius=self.radius.to('deg').value)
-        kwargs.update(temp)
-        for key, value in self.visual.items():
-            kwargs.setdefault(key, value)
-        patch = mpatches.Circle(center, **kwargs)
-
-        return patch

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -110,12 +110,12 @@ class CirclePixelRegion(PixelRegion):
         return Mask(fraction, bbox=bbox)
 
     def as_patch(self, **kwargs):
-        import matplotlib.patches as mpatches
-
+        """Matplotlib patch object for this region (`matplotlib.patches.Circle`).
+        """
+        from matplotlib.patches import Circle
         xy = self.center.x, self.center.y
         radius = self.radius
-        patch = mpatches.Circle(xy=xy, radius=radius, **kwargs)
-        return patch
+        return Circle(xy=xy, radius=radius, **kwargs)
 
 
 class CircleSkyRegion(SkyRegion):

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -133,21 +133,21 @@ class EllipseSkyRegion(SkyRegion):
     ----------
     center : `~astropy.coordinates.SkyCoord`
         Center position
-    minor : `~astropy.units.Quantity`
-        Minor radius
     major : `~astropy.units.Quantity`
         Major radius
+    minor : `~astropy.units.Quantity`
+        Minor radius
     angle : `~astropy.units.Quantity`
         The rotation angle of the ellipse.
         If set to zero (the default), the major
         axis is lined up with the longitude axis of the celestial coordinates.
     """
 
-    def __init__(self, center, minor, major, angle=0. * u.deg, meta=None, visual=None):
+    def __init__(self, center, major, minor, angle=0. * u.deg, meta=None, visual=None):
         # TODO: use quantity_input to check that height, width, and angle are angles
         self.center = center
-        self.minor = minor
         self.major = major
+        self.minor = minor
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
@@ -156,11 +156,11 @@ class EllipseSkyRegion(SkyRegion):
         data = dict(
             name=self.__class__.__name__,
             center=self.center,
-            minor=self.minor,
             major=self.major,
+            minor=self.minor,
             angle=self.angle,
         )
-        fmt = '{name}\ncenter: {center}\nminor: {minor}\nmajor: {major}\nangle: {angle}'
+        fmt = '{name}\ncenter: {center}\nmajor: {major}\nminor: {minor}\nangle: {angle}'
         return fmt.format(**data)
 
     @property

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -24,6 +24,32 @@ class EllipsePixelRegion(PixelRegion):
         The rotation angle of the ellipse.
         If set to zero (the default), the major
         axis is lined up with the x axis.
+
+    Examples
+    --------
+
+    .. plot::
+        :include-source:
+
+        import numpy as np
+        from astropy.modeling.models import Ellipse2D
+        from astropy.coordinates import Angle
+        from regions import PixCoord, EllipsePixelRegion
+        import matplotlib.pyplot as plt
+        x0, y0 = 15, 10
+        a, b = 8, 5
+        theta = Angle(30, 'deg')
+        e = Ellipse2D(amplitude=100., x_0=x0, y_0=y0, a=a, b=b, theta=theta.radian)
+        y, x = np.mgrid[0:20, 0:30]
+        fig, ax = plt.subplots(1, 1)
+        ax.imshow(e(x, y), origin='lower', interpolation='none', cmap='Greys_r')
+
+        center = PixCoord(x=x0, y=y0)
+        reg = EllipsePixelRegion(center=center, major=a, minor=b, angle=theta)
+        patch = reg.as_patch(facecolor='none', edgecolor='red', lw=2)
+        ax.add_patch(patch)
+
+        plt.show()
     """
 
     def __init__(self, center, major, minor, angle=0. * u.deg, meta=None,
@@ -118,9 +144,7 @@ class EllipsePixelRegion(PixelRegion):
         xy = self.center.x, self.center.y
         width = 2 * self.major
         height = 2 * self.minor
-        # TODO: think about how to map major / minor / angle to MPL parameters.
-        # MPL expects this:
-        # "rotation in degrees (anti-clockwise)"
+        # From the docstring: MPL expects "rotation in degrees (anti-clockwise)"
         angle = self.angle.to('deg').value
         return Ellipse(xy=xy, width=width, height=height, angle=angle, **kwargs)
 

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -164,7 +164,3 @@ class EllipseSkyRegion(SkyRegion):
     def to_pixel(self, wcs, mode='local', tolerance=None):
         # TODO: needs to be implemented
         raise NotImplementedError
-
-    def as_patch(self, **kwargs):
-        # TODO: needs to be implemented
-        raise NotImplementedError

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -91,7 +91,3 @@ class PointSkyRegion(SkyRegion):
     def to_pixel(self, wcs, mode='local', tolerance=None):
         # TODO: needs to be implemented
         raise NotImplementedError
-
-    def as_patch(self, **kwargs):
-        # TODO: needs to be implemented
-        raise NotImplementedError

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -96,7 +96,3 @@ class PolygonSkyRegion(SkyRegion):
     def to_pixel(self, wcs, mode='local', tolerance=None):
         # TODO: needs to be implemented
         raise NotImplementedError
-
-    def as_patch(self, **kwargs):
-        # TODO: needs to be implemented
-        raise NotImplementedError

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -164,7 +164,3 @@ class RectangleSkyRegion(SkyRegion):
     def to_pixel(self, wcs, mode='local', tolerance=None):
         # TODO: needs to be implemented
         raise NotImplementedError
-
-    def as_patch(self, **kwargs):
-        # TODO: needs to be implemented
-        raise NotImplementedError

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -18,20 +18,20 @@ class RectanglePixelRegion(PixelRegion):
     ----------
     center : `~regions.PixCoord`
         The position of the center of the rectangle.
-    height : float
-        The height of the rectangle
     width : float
         The width of the rectangle
+    height : float
+        The height of the rectangle
     angle : `~astropy.units.Quantity`
         The rotation of the rectangle. If set to zero (the default), the width
         is lined up with the x axis.
     """
 
-    def __init__(self, center, height, width, angle=0 * u.deg, meta=None, visual=None):
+    def __init__(self, center, width, height, angle=0 * u.deg, meta=None, visual=None):
         # TODO: use quantity_input to check that angle is an angle
         self.center = center
-        self.height = height
         self.width = width
+        self.height = height
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
@@ -40,11 +40,11 @@ class RectanglePixelRegion(PixelRegion):
         data = dict(
             name=self.__class__.__name__,
             center=self.center,
-            height=self.height,
             width=self.width,
+            height=self.height,
             angle=self.angle,
         )
-        fmt = '{name}\ncenter: {center}\nheight: {height}\nwidth: {width}\nangle: {angle}'
+        fmt = '{name}\ncenter: {center}\nwidth: {width}\nheight: {height}\nangle: {angle}'
         return fmt.format(**data)
 
     @property
@@ -104,16 +104,27 @@ class RectanglePixelRegion(PixelRegion):
         else:
             use_exact = 1
 
-        fraction = rectangular_overlap_grid(xmin, xmax, ymin, ymax, nx, ny,
-                                            self.width, self.height,
-                                            self.angle.to(u.deg).value,
-                                            use_exact, subpixels)
+        fraction = rectangular_overlap_grid(
+            xmin, xmax, ymin, ymax, nx, ny,
+            self.width, self.height,
+            self.angle.to(u.deg).value,
+            use_exact, subpixels,
+        )
 
         return Mask(fraction, bbox=bbox)
 
     def as_patch(self, **kwargs):
-        # TODO: needs to be implemented
-        raise NotImplementedError
+        """Matplotlib patch object for this region (`matplotlib.patches.Rectangle`).
+        """
+        from matplotlib.patches import Rectangle
+        xy = self.center.x, self.center.y
+        width = self.width
+        height = self.height
+        # TODO: think about how to map major / minor / angle to MPL parameters.
+        # MPL expects this:
+        # "rotation in degrees (anti-clockwise)"
+        angle = self.angle.to('deg').value
+        return Rectangle(xy=xy, width=width, height=height, angle=angle, **kwargs)
 
 
 class RectangleSkyRegion(SkyRegion):
@@ -124,20 +135,20 @@ class RectangleSkyRegion(SkyRegion):
     ----------
     center : `~astropy.coordinates.SkyCoord`
         The position of the center of the rectangle.
-    height : `~astropy.units.Quantity`
-        The height radius of the rectangle
     width : `~astropy.units.Quantity`
         The width radius of the rectangle
+    height : `~astropy.units.Quantity`
+        The height radius of the rectangle
     angle : `~astropy.units.Quantity`
         The rotation of the rectangle. If set to zero (the default), the width
         is lined up with the longitude axis of the celestial coordinates.
     """
 
-    def __init__(self, center, height, width, angle=0 * u.deg, meta=None, visual=None):
+    def __init__(self, center, width, height, angle=0 * u.deg, meta=None, visual=None):
         # TODO: use quantity_input to check that height, width, and angle are angles
         self.center = center
-        self.height = height
         self.width = width
+        self.height = height
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
@@ -146,11 +157,11 @@ class RectangleSkyRegion(SkyRegion):
         data = dict(
             name=self.__class__.__name__,
             center=self.center,
-            height=self.height,
             width=self.width,
+            height=self.height,
             angle=self.angle,
         )
-        fmt = '{name}\ncenter: {center}\nheight: {height}\nwidth: {width}\nangle: {angle}'
+        fmt = '{name}\ncenter: {center}\nwidth: {width}\nheight: {height}\nangle: {angle}'
         return fmt.format(**data)
 
     @property

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -16,24 +16,18 @@ from ..circle import CirclePixelRegion, CircleSkyRegion
 from ..ellipse import EllipsePixelRegion, EllipseSkyRegion
 from ..polygon import PolygonPixelRegion, PolygonSkyRegion
 from ..rectangle import RectanglePixelRegion, RectangleSkyRegion
-
-try:
-    import shapely
-    HAS_SHAPELY = True
-except:
-    HAS_SHAPELY = False
-
+from .utils import HAS_SHAPELY
 
 PIXEL_REGIONS = [
     CirclePixelRegion(PixCoord(3, 4), radius=5),
-    EllipsePixelRegion(PixCoord(3, 4), minor=5, major=7, angle=3 * u.deg),
+    EllipsePixelRegion(PixCoord(3, 4), major=7, minor=5, angle=3 * u.deg),
     PolygonPixelRegion(PixCoord([1, 4, 3], [2, 4, 4])),
     RectanglePixelRegion(PixCoord(6, 5), width=3, height=5)
 ]
 
 SKY_REGIONS = [
     CircleSkyRegion(ICRS(3 * u.deg, 4 * u.deg), radius=5 * u.deg),
-    EllipseSkyRegion(ICRS(3 * u.deg, 4 * u.deg), minor=5, major=7, angle=3 * u.deg),
+    EllipseSkyRegion(ICRS(3 * u.deg, 4 * u.deg), major=7, minor=5, angle=3 * u.deg),
     PolygonSkyRegion(ICRS([1, 4, 3] * u.deg, [2, 4, 4] * u.deg)),
     RectangleSkyRegion(ICRS(6 * u.deg, 5 * u.deg), width=3 * u.deg, height=5 * u.deg)
 ]
@@ -114,7 +108,11 @@ def test_sky_area(region):
         pytest.xfail()
 
 
-@pytest.mark.parametrize(('region', 'mode'), itertools.product(SKY_REGIONS, SKYPIX_MODES), ids=ids_func)
+@pytest.mark.parametrize(
+    ('region', 'mode'),
+    itertools.product(SKY_REGIONS, SKYPIX_MODES),
+    ids=ids_func,
+)
 def test_sky_to_pix(region, mode):
     try:
         pix_region = region.to_pixel(mode=mode, wcs=COMMON_WCS)

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -5,12 +5,10 @@ implemented and doesn't check anything about correctness.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import itertools
-import numpy as np
 from astropy.tests.helper import pytest
 from astropy import units as u
 from astropy.coordinates import ICRS
 from astropy.wcs import WCS
-
 from ...core.mask import Mask
 from ...core.core import Region, SkyRegion, PixelRegion
 from ...core.pixcoord import PixCoord

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -10,14 +10,7 @@ from astropy.io.fits import getheader
 from astropy.wcs import WCS
 from ...core import PixCoord
 from ..circle import CirclePixelRegion, CircleSkyRegion
-from .utils import ASTROPY_LT_13
-
-try:
-    import matplotlib
-
-    HAS_MATPLOTLIB = True
-except:
-    HAS_MATPLOTLIB = False
+from .utils import ASTROPY_LT_13, HAS_MATPLOTLIB
 
 
 class TestCirclePixelRegion:
@@ -41,16 +34,17 @@ class TestCirclePixelRegion:
 
 
 class TestCircleSkyRegion:
-    def test_str(self):
+    def setup(self):
         center = SkyCoord(3 * u.deg, 4 * u.deg)
-        reg = CircleSkyRegion(center, 2 * u.arcsec)
+        self.reg = CircleSkyRegion(center, 2 * u.arcsec)
 
+    def test_str(self):
         if ASTROPY_LT_13:
-            assert str(
-                reg) == 'CircleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>\nradius: 2.0 arcsec'
+            expected = 'CircleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>\nradius: 2.0 arcsec'
         else:
-            assert str(
-                reg) == 'CircleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    ( 3.,  4.)>\nradius: 2.0 arcsec'
+            expected = 'CircleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    ( 3.,  4.)>\nradius: 2.0 arcsec'
+
+        assert str(self.reg) == expected
 
     def test_transformation(self):
         skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='galactic')

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-from astropy.tests.helper import assert_quantity_allclose
+from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.utils.data import get_pkg_data_filename
 from astropy.io.fits import getheader
 from astropy.wcs import WCS
@@ -21,17 +21,23 @@ except:
 
 
 class TestCirclePixelRegion:
-    def test_str(self):
+    def setup(self):
         center = PixCoord(3, 4)
-        reg = CirclePixelRegion(center, 2)
+        self.reg = CirclePixelRegion(center, 2)
 
-        assert str(reg) == 'CirclePixelRegion\ncenter: PixCoord(x=3, y=4)\nradius: 2'
+    def test_str(self):
+        expected = 'CirclePixelRegion\ncenter: PixCoord(x=3, y=4)\nradius: 2'
+        assert str(self.reg) == expected
 
     def test_to_mask(self):
-        center = PixCoord(3, 4)
-        reg = CirclePixelRegion(center, 2)
-        mask = reg.to_mask(mode='exact')
+        mask = self.reg.to_mask(mode='exact')
         assert_allclose(np.sum(mask.data), 4 * np.pi)
+
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
+    def test_as_patch(self):
+        patch = self.reg.as_patch()
+        assert_allclose(patch.center, (3, 4))
+        assert_allclose(patch.radius, 2)
 
 
 class TestCircleSkyRegion:
@@ -40,9 +46,11 @@ class TestCircleSkyRegion:
         reg = CircleSkyRegion(center, 2 * u.arcsec)
 
         if ASTROPY_LT_13:
-            assert str(reg) == 'CircleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>\nradius: 2.0 arcsec'
+            assert str(
+                reg) == 'CircleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>\nradius: 2.0 arcsec'
         else:
-            assert str(reg) == 'CircleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    ( 3.,  4.)>\nradius: 2.0 arcsec'
+            assert str(
+                reg) == 'CircleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    ( 3.,  4.)>\nradius: 2.0 arcsec'
 
     def test_transformation(self):
         skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='galactic')

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -1,12 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
 from numpy.testing import assert_allclose
-
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-from astropy.tests.helper import pytest, assert_quantity_allclose
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.data import get_pkg_data_filename
 from astropy.io.fits import getheader
 from astropy.wcs import WCS
@@ -16,51 +14,52 @@ from .utils import ASTROPY_LT_13
 
 try:
     import matplotlib
+
     HAS_MATPLOTLIB = True
 except:
     HAS_MATPLOTLIB = False
 
 
-def test_circle_pixel():
-    center = PixCoord(3, 4)
-    reg = CirclePixelRegion(center, 2)
+class TestCirclePixelRegion:
+    def test_str(self):
+        center = PixCoord(3, 4)
+        reg = CirclePixelRegion(center, 2)
 
-    assert str(reg) == 'CirclePixelRegion\ncenter: PixCoord(x=3, y=4)\nradius: 2'
+        assert str(reg) == 'CirclePixelRegion\ncenter: PixCoord(x=3, y=4)\nradius: 2'
 
-
-def test_circle_sky():
-    center = SkyCoord(3 * u.deg, 4 * u.deg)
-    reg = CircleSkyRegion(center, 2 * u.arcsec)
-
-    if ASTROPY_LT_13:
-        assert str(reg) == 'CircleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>\nradius: 2.0 arcsec'
-    else:
-        assert str(reg) == 'CircleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    ( 3.,  4.)>\nradius: 2.0 arcsec'
+    def test_to_mask(self):
+        center = PixCoord(3, 4)
+        reg = CirclePixelRegion(center, 2)
+        mask = reg.to_mask(mode='exact')
+        assert_allclose(np.sum(mask.data), 4 * np.pi)
 
 
-def test_transformation():
-    skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='galactic')
-    skycircle = CircleSkyRegion(skycoord, 2 * u.arcsec)
+class TestCircleSkyRegion:
+    def test_str(self):
+        center = SkyCoord(3 * u.deg, 4 * u.deg)
+        reg = CircleSkyRegion(center, 2 * u.arcsec)
 
-    headerfile = get_pkg_data_filename('data/example_header.fits')
-    h = getheader(headerfile)
-    wcs = WCS(h)
+        if ASTROPY_LT_13:
+            assert str(reg) == 'CircleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>\nradius: 2.0 arcsec'
+        else:
+            assert str(reg) == 'CircleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    ( 3.,  4.)>\nradius: 2.0 arcsec'
 
-    pixcircle = skycircle.to_pixel(wcs)
+    def test_transformation(self):
+        skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='galactic')
+        skycircle = CircleSkyRegion(skycoord, 2 * u.arcsec)
 
-    assert_allclose(pixcircle.center.x, -50.5)
-    assert_allclose(pixcircle.center.y, 299.5)
-    assert_allclose(pixcircle.radius, 0.027777777777828305)
+        headerfile = get_pkg_data_filename('data/example_header.fits')
+        h = getheader(headerfile)
+        wcs = WCS(h)
 
-    skycircle2 = pixcircle.to_sky(wcs)
+        pixcircle = skycircle.to_pixel(wcs)
 
-    assert_quantity_allclose(skycircle.center.data.lon, skycircle2.center.data.lon)
-    assert_quantity_allclose(skycircle.center.data.lat, skycircle2.center.data.lat)
-    assert_quantity_allclose(skycircle2.radius, skycircle.radius)
+        assert_allclose(pixcircle.center.x, -50.5)
+        assert_allclose(pixcircle.center.y, 299.5)
+        assert_allclose(pixcircle.radius, 0.027777777777828305)
 
+        skycircle2 = pixcircle.to_sky(wcs)
 
-def test_to_mask():
-    center = PixCoord(3, 4)
-    reg = CirclePixelRegion(center, 2)
-    mask = reg.to_mask(mode='exact')
-    assert_allclose(np.sum(mask.data), 4 * np.pi)
+        assert_quantity_allclose(skycircle.center.data.lon, skycircle2.center.data.lon)
+        assert_quantity_allclose(skycircle.center.data.lat, skycircle2.center.data.lat)
+        assert_quantity_allclose(skycircle2.radius, skycircle.radius)

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -16,17 +16,9 @@ from .utils import ASTROPY_LT_13
 
 try:
     import matplotlib
-
     HAS_MATPLOTLIB = True
 except:
     HAS_MATPLOTLIB = False
-
-try:
-    import wcsaxes
-
-    HAS_WCSAXES = True
-except:
-    HAS_WCSAXES = False
 
 
 def test_circle_pixel():
@@ -65,31 +57,6 @@ def test_transformation():
     assert_quantity_allclose(skycircle.center.data.lon, skycircle2.center.data.lon)
     assert_quantity_allclose(skycircle.center.data.lat, skycircle2.center.data.lat)
     assert_quantity_allclose(skycircle2.radius, skycircle.radius)
-
-
-# Todo : restructure test to use same circle everywhere
-# see https://github.com/astropy/regions/pull/20
-@pytest.mark.skipif('not HAS_MATPLOTLIB')
-@pytest.mark.skipif('not HAS_WCSAXES')
-def test_plot():
-    import matplotlib.pyplot as plt
-
-    skycoord = SkyCoord(1.983333 * u.deg, -1.99 * u.deg, frame='galactic')
-    c = CircleSkyRegion(skycoord, 20 * u.arcsec)
-    c.visual.update(color='red')
-    headerfile = get_pkg_data_filename('data/example_header.fits')
-    h = getheader(headerfile)
-    wcs = WCS(h)
-    fig = plt.figure()
-    ax = fig.add_axes([0.1, 0.1, 0.8, 0.8], projection=wcs)
-    p = c.as_patch(ax, alpha=0.6)
-
-    assert_allclose(p.center[0], skycoord.icrs.ra.value)
-    assert_allclose(p.center[1], skycoord.icrs.dec.value)
-    assert p.get_facecolor() == (1, 0, 0, 0.6)
-
-    c.plot(ax, alpha=0.6)
-
 
 
 def test_to_mask():

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -6,14 +6,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from ...core import PixCoord
 from ..ellipse import EllipsePixelRegion, EllipseSkyRegion
-from .utils import ASTROPY_LT_13
-
-try:
-    import matplotlib
-
-    HAS_MATPLOTLIB = True
-except:
-    HAS_MATPLOTLIB = False
+from .utils import ASTROPY_LT_13, HAS_MATPLOTLIB
 
 
 class TestEllipsePixelRegion:
@@ -40,15 +33,22 @@ class TestEllipsePixelRegion:
 
 
 class TestEllipseSkyRegion:
-    def test_str(self):
+    def setup(self):
         center = SkyCoord(3, 4, unit='deg')
-        reg = EllipseSkyRegion(center, 3 * u.deg, 4 * u.deg, 5 * u.deg)
+        self.reg = EllipseSkyRegion(
+            center=center,
+            major=4 * u.deg,
+            minor=3 * u.deg,
+            angle=5 * u.deg,
+        )
+
+    def test_str(self):
 
         if ASTROPY_LT_13:
             expected = ('EllipseSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                        '    (3.0, 4.0)>\nminor: 3.0 deg\nmajor: 4.0 deg\nangle: 5.0 deg')
+                        '    (3.0, 4.0)>\nmajor: 4.0 deg\nminor: 3.0 deg\nangle: 5.0 deg')
         else:
             expected = ('EllipseSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                        '    ( 3.,  4.)>\nminor: 3.0 deg\nmajor: 4.0 deg\nangle: 5.0 deg')
+                        '    ( 3.,  4.)>\nmajor: 4.0 deg\nminor: 3.0 deg\nangle: 5.0 deg')
 
-        assert str(reg) == expected
+        assert str(self.reg) == expected

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -7,22 +7,24 @@ from ..ellipse import EllipsePixelRegion, EllipseSkyRegion
 from .utils import ASTROPY_LT_13
 
 
-def test_ellipse_pixel():
-    center = PixCoord(3, 4)
-    reg = EllipsePixelRegion(center, 3, 4, 5 * u.deg)
+class TestEllipsePixelRegion:
+    def test_str(self):
+        center = PixCoord(3, 4)
+        reg = EllipsePixelRegion(center, 3, 4, 5 * u.deg)
 
-    assert str(reg) == 'EllipsePixelRegion\ncenter: PixCoord(x=3, y=4)\nminor: 3\nmajor: 4\nangle: 5.0 deg'
+        assert str(reg) == 'EllipsePixelRegion\ncenter: PixCoord(x=3, y=4)\nminor: 3\nmajor: 4\nangle: 5.0 deg'
 
 
-def test_ellipse_sky():
-    center = SkyCoord(3, 4, unit='deg')
-    reg = EllipseSkyRegion(center, 3 * u.deg, 4 * u.deg, 5 * u.deg)
+class TestEllipseSkyRegion:
+    def test_str(self):
+        center = SkyCoord(3, 4, unit='deg')
+        reg = EllipseSkyRegion(center, 3 * u.deg, 4 * u.deg, 5 * u.deg)
 
-    if ASTROPY_LT_13:
-        expected = ('EllipseSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                    '    (3.0, 4.0)>\nminor: 3.0 deg\nmajor: 4.0 deg\nangle: 5.0 deg')
-    else:
-        expected = ('EllipseSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                    '    ( 3.,  4.)>\nminor: 3.0 deg\nmajor: 4.0 deg\nangle: 5.0 deg')
+        if ASTROPY_LT_13:
+            expected = ('EllipseSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
+                        '    (3.0, 4.0)>\nminor: 3.0 deg\nmajor: 4.0 deg\nangle: 5.0 deg')
+        else:
+            expected = ('EllipseSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
+                        '    ( 3.,  4.)>\nminor: 3.0 deg\nmajor: 4.0 deg\nangle: 5.0 deg')
 
-    assert str(reg) == expected
+        assert str(reg) == expected

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -1,18 +1,42 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose
+from astropy.tests.helper import pytest
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from ...core import PixCoord
 from ..ellipse import EllipsePixelRegion, EllipseSkyRegion
 from .utils import ASTROPY_LT_13
 
+try:
+    import matplotlib
+
+    HAS_MATPLOTLIB = True
+except:
+    HAS_MATPLOTLIB = False
+
 
 class TestEllipsePixelRegion:
-    def test_str(self):
+    def setup(self):
         center = PixCoord(3, 4)
-        reg = EllipsePixelRegion(center, 3, 4, 5 * u.deg)
+        self.reg = EllipsePixelRegion(
+            center=center,
+            major=4,
+            minor=3,
+            angle=5 * u.deg,
+        )
 
-        assert str(reg) == 'EllipsePixelRegion\ncenter: PixCoord(x=3, y=4)\nminor: 3\nmajor: 4\nangle: 5.0 deg'
+    def test_str(self):
+        expected = 'EllipsePixelRegion\ncenter: PixCoord(x=3, y=4)\nmajor: 4\nminor: 3\nangle: 5.0 deg'
+        assert str(self.reg) == expected
+
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
+    def test_as_patch(self):
+        patch = self.reg.as_patch()
+        assert_allclose(patch.center, (3, 4))
+        assert_allclose(patch.width, 8)
+        assert_allclose(patch.height, 6)
+        assert_allclose(patch.angle, 5)
 
 
 class TestEllipseSkyRegion:

--- a/regions/shapes/tests/test_masks.py
+++ b/regions/shapes/tests/test_masks.py
@@ -1,25 +1,29 @@
-# This file sets up detailed tests for computing masks with reference images
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This file sets up detailed tests for computing masks with reference images.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
 import itertools
-import pytest
-
-from regions.core import PixCoord
-from regions.shapes.circle import CirclePixelRegion
-from regions.shapes.ellipse import EllipsePixelRegion
-from regions.shapes.rectangle import RectanglePixelRegion
-from astropy.io import fits
+from astropy.tests.helper import pytest
 from astropy import units as u
+from ...core import PixCoord
+from ...shapes.circle import CirclePixelRegion
+from ...shapes.ellipse import EllipsePixelRegion
+from ...shapes.rectangle import RectanglePixelRegion
 
+REGIONS = [
+    CirclePixelRegion(PixCoord(3.981987, 4.131378), 3.3411),
+    EllipsePixelRegion(PixCoord(3.981987, 4.131378), 3.3411, 2.2233, angle=32 * u.deg),
+    RectanglePixelRegion(PixCoord(3.981987, 4.131378), 4.3411, 5.2233, angle=32 * u.deg),
+]
 
-REGIONS = [CirclePixelRegion(PixCoord(3.981987, 4.131378), 3.3411),
-           EllipsePixelRegion(PixCoord(3.981987, 4.131378), 3.3411, 2.2233, angle=32 * u.deg),
-           RectanglePixelRegion(PixCoord(3.981987, 4.131378), 4.3411, 5.2233, angle=32 * u.deg)]
-
-MODES = [{'mode': 'center'},
-         {'mode': 'exact'},
-         {'mode': 'subpixels', 'subpixels': 1},
-         {'mode': 'subpixels', 'subpixels': 5},
-         {'mode': 'subpixels', 'subpixels': 18}]
+MODES = [
+    {'mode': 'center'},
+    {'mode': 'exact'},
+    {'mode': 'subpixels', 'subpixels': 1},
+    {'mode': 'subpixels', 'subpixels': 5},
+    {'mode': 'subpixels', 'subpixels': 18},
+]
 
 
 def label(value):

--- a/regions/shapes/tests/test_masks.py
+++ b/regions/shapes/tests/test_masks.py
@@ -12,9 +12,9 @@ from ...shapes.ellipse import EllipsePixelRegion
 from ...shapes.rectangle import RectanglePixelRegion
 
 REGIONS = [
-    CirclePixelRegion(PixCoord(3.981987, 4.131378), 3.3411),
-    EllipsePixelRegion(PixCoord(3.981987, 4.131378), 3.3411, 2.2233, angle=32 * u.deg),
-    RectanglePixelRegion(PixCoord(3.981987, 4.131378), 4.3411, 5.2233, angle=32 * u.deg),
+    CirclePixelRegion(PixCoord(3.981987, 4.131378), radius=3.3411),
+    EllipsePixelRegion(PixCoord(3.981987, 4.131378), major=2.2233, minor=3.3411, angle=32 * u.deg),
+    RectanglePixelRegion(PixCoord(3.981987, 4.131378), width=5.2233, height=4.3411, angle=32 * u.deg),
 ]
 
 MODES = [

--- a/regions/shapes/tests/test_masks.py
+++ b/regions/shapes/tests/test_masks.py
@@ -36,9 +36,18 @@ def label(value):
     else:
         return '-'.join('{0}_{1}'.format(key, value) for key, value in sorted(value.items()))
 
-
-@pytest.mark.array_compare(fmt='text', write_kwargs={'fmt': '%12.8e'})
-@pytest.mark.parametrize(('region', 'mode'), itertools.product(REGIONS, MODES), ids=label)
+# There's a bug in numpy: `numpy.savetxt` doesn't accept unicode
+# on Python 2. Bytes works on Python 2 and 3, so we're using that here.
+# https://github.com/numpy/numpy/pull/4053#issuecomment-263808221
+@pytest.mark.array_compare(
+    fmt='text',
+    write_kwargs={'fmt': b'%12.8e'},
+)
+@pytest.mark.parametrize(
+    ('region', 'mode'),
+    itertools.product(REGIONS, MODES),
+    ids=label,
+)
 def test_to_mask(region, mode):
     try:
         mask = region.to_mask(**mode)

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -7,19 +7,25 @@ from .utils import ASTROPY_LT_13
 
 
 class TestPointPixelRegion:
-    def test_str(self):
+    def setup(self):
         center = PixCoord(3, 4)
-        reg = PointPixelRegion(center)
+        self.reg = PointPixelRegion(center)
 
-        assert str(reg) == 'PointPixelRegion\ncenter: PixCoord(x=3, y=4)'
+    def test_str(self):
+        expected = 'PointPixelRegion\ncenter: PixCoord(x=3, y=4)'
+        assert str(self.reg) == expected
 
 
 class TestPointSkyRegion:
-    def test_str(self):
+    def setup(self):
         center = SkyCoord(3, 4, unit='deg')
-        reg = PointSkyRegion(center)
+        self.reg = PointSkyRegion(center)
+
+    def test_str(self):
 
         if ASTROPY_LT_13:
-            assert str(reg) == 'PointSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>'
+            expected = 'PointSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>'
         else:
-            assert str(reg) == 'PointSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    ( 3.,  4.)>'
+            expected = 'PointSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    ( 3.,  4.)>'
+
+        assert str(self.reg) == expected

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -6,18 +6,20 @@ from ..point import PointPixelRegion, PointSkyRegion
 from .utils import ASTROPY_LT_13
 
 
-def test_ellipse_pixel():
-    center = PixCoord(3, 4)
-    reg = PointPixelRegion(center)
+class TestPointPixelRegion:
+    def test_str(self):
+        center = PixCoord(3, 4)
+        reg = PointPixelRegion(center)
 
-    assert str(reg) == 'PointPixelRegion\ncenter: PixCoord(x=3, y=4)'
+        assert str(reg) == 'PointPixelRegion\ncenter: PixCoord(x=3, y=4)'
 
 
-def test_ellipse_sky():
-    center = SkyCoord(3, 4, unit='deg')
-    reg = PointSkyRegion(center)
+class TestPointSkyRegion:
+    def test_str(self):
+        center = SkyCoord(3, 4, unit='deg')
+        reg = PointSkyRegion(center)
 
-    if ASTROPY_LT_13:
-        assert str(reg) == 'PointSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>'
-    else:
-        assert str(reg) == 'PointSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    ( 3.,  4.)>'
+        if ASTROPY_LT_13:
+            assert str(reg) == 'PointSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>'
+        else:
+            assert str(reg) == 'PointSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    ( 3.,  4.)>'

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -9,79 +9,75 @@ from ..polygon import PolygonPixelRegion, PolygonSkyRegion
 from .utils import ASTROPY_LT_13
 
 
-@pytest.fixture
-def pix_poly():
-    vertices = PixCoord([3, 4, 3], [3, 4, 4])
-    return PolygonPixelRegion(vertices)
+class TestPolygonPixelRegion:
+    def setup(self):
+        vertices = PixCoord([3, 4, 3], [3, 4, 4])
+        self.poly = PolygonPixelRegion(vertices)
+
+    def test_str(self):
+        expected = 'PolygonPixelRegion\nvertices: PixCoord(x=[3 4 3], y=[3 4 4])'
+        assert str(self.poly) == expected
+
+    def _test_basic(self):
+        """
+        TODO: implement these tests!
+
+        Just make sure that things don't crash, but no test of numerical accuracy
+        """
+
+        poly1 = PolygonPixelRegion(([10, 20, 20, 10, 10], [20, 20, 10, 10, 20]))
+
+        poly2 = PolygonPixelRegion(([15, 25, 25, 15, 15], [23, 23, 13, 13, 23]))
+
+        assert_allclose(poly1.area, 100)
+        assert_allclose(poly2.area, 100)
+
+        assert PixCoord(13, 12) in poly1
+        assert not PixCoord(13, 12) in poly2
+
+        coords = PixCoord([13, 8], [15, 15])
+        assert_equal(poly1.contains(coords), [False, True])
+
+        # poly3 = poly1.union(poly2)
+        # poly4 = poly1.intersection(poly2)
+        # assert_allclose(poly3.area, 165)
+        # assert_allclose(poly4.area, 35)
 
 
-@pytest.fixture
-def sky_poly():
-    vertices = SkyCoord([3, 4, 3] * u.deg, [3, 4, 4] * u.deg)
-    return PolygonSkyRegion(vertices)
+class TestPolygonSkyRegion:
+    def setup(self):
+        vertices = SkyCoord([3, 4, 3] * u.deg, [3, 4, 4] * u.deg)
+        self.poly = PolygonSkyRegion(vertices)
 
+    def test_str(self):
+        if ASTROPY_LT_13:
+            expected = ('PolygonSkyRegion\nvertices: <SkyCoord (ICRS): (ra, dec) in deg\n'
+                        '    [(3.0, 3.0), (4.0, 4.0), (3.0, 4.0)]>')
+        else:
+            expected = ('PolygonSkyRegion\nvertices: <SkyCoord (ICRS): (ra, dec) in deg\n'
+                        '    [( 3.,  3.), ( 4.,  4.), ( 3.,  4.)]>')
+        assert str(self.poly) == expected
 
-def test_polygon_pixel(pix_poly):
-    expected = 'PolygonPixelRegion\nvertices: PixCoord(x=[3 4 3], y=[3 4 4])'
-    assert str(pix_poly) == expected
+    def _test_basic(self):
+        """
+        TODO: implement these tests!
 
+        Just make sure that things don't crash, but no test of numerical accuracy
+        """
 
-def test_polygon_sky(sky_poly):
-    if ASTROPY_LT_13:
-        expected = ('PolygonSkyRegion\nvertices: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                    '    [(3.0, 3.0), (4.0, 4.0), (3.0, 4.0)]>')
-    else:
-        expected = ('PolygonSkyRegion\nvertices: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                    '    [( 3.,  3.), ( 4.,  4.), ( 3.,  4.)]>')
-    assert str(sky_poly) == expected
+        coords1 = SkyCoord([10, 20, 20, 10, 10] * u.deg, [20, 20, 10, 10, 20] * u.deg)
+        poly1 = PolygonSkyRegion(coords1)
 
+        coords1 = SkyCoord([15, 25, 25, 15, 15] * u.deg, [23, 23, 13, 13, 23] * u.deg)
+        poly2 = PolygonSkyRegion(coords1)
 
-def _test_polygon_basic():
-    """
-    TODO: implement these tests!
+        assert_quantity_allclose(poly1.area, 42 * u.sr)
+        assert_quantity_allclose(poly2.area, 42 * u.sr)
 
-    Just make sure that things don't crash, but no test of numerical accuracy
-    """
+        # TODO: test contains
 
-    poly1 = PolygonPixelRegion(([10, 20, 20, 10, 10], [20, 20, 10, 10, 20]))
+        poly3 = poly1.union(poly2)
+        poly4 = poly1.intersection(poly2)
 
-    poly2 = PolygonPixelRegion(([15, 25, 25, 15, 15], [23, 23, 13, 13, 23]))
-
-    assert_allclose(poly1.area, 100)
-    assert_allclose(poly2.area, 100)
-
-    assert PixCoord(13, 12) in poly1
-    assert not PixCoord(13, 12) in poly2
-
-    coords = PixCoord([13, 8], [15, 15])
-    assert_equal(poly1.contains(coords), [False, True])
-
-    # poly3 = poly1.union(poly2)
-    # poly4 = poly1.intersection(poly2)
-    # assert_allclose(poly3.area, 165)
-    # assert_allclose(poly4.area, 35)
-
-
-def _test_polygon_sky_basic():
-    """
-    TODO: implement these tests!
-
-    Just make sure that things don't crash, but no test of numerical accuracy
-    """
-
-    coords1 = SkyCoord([10, 20, 20, 10, 10] * u.deg, [20, 20, 10, 10, 20] * u.deg)
-    poly1 = PolygonSkyRegion(coords1)
-
-    coords1 = SkyCoord([15, 25, 25, 15, 15] * u.deg, [23, 23, 13, 13, 23] * u.deg)
-    poly2 = PolygonSkyRegion(coords1)
-
-    assert_quantity_allclose(poly1.area, 42 * u.sr)
-    assert_quantity_allclose(poly2.area, 42 * u.sr)
-
-    # TODO: test contains
-
-    poly3 = poly1.union(poly2)
-    poly4 = poly1.intersection(poly2)
-
-    assert_quantity_allclose(poly3.area, 42 * u.sr)
-    assert_quantity_allclose(poly4.area, 42 * u.sr)
+        assert_quantity_allclose(poly3.area, 42 * u.sr)
+        assert_quantity_allclose(poly4.area, 42 * u.sr)

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -1,28 +1,52 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose
+from astropy.tests.helper import pytest
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from ...core import PixCoord
 from ..rectangle import RectanglePixelRegion, RectangleSkyRegion
-from .utils import ASTROPY_LT_13
+from .utils import ASTROPY_LT_13, HAS_MATPLOTLIB
 
 
 class TestRectanglePixelRegion:
-    def test_str(self):
+    def setup(self):
         center = PixCoord(3, 4)
-        reg = RectanglePixelRegion(center, 3, 4, 5 * u.deg)
+        self.reg = RectanglePixelRegion(
+            center=center,
+            width=4,
+            height=3,
+            angle=5 * u.deg,
+        )
 
-        assert str(reg) == 'RectanglePixelRegion\ncenter: PixCoord(x=3, y=4)\nheight: 3\nwidth: 4\nangle: 5.0 deg'
+    def test_str(self):
+        expected = 'RectanglePixelRegion\ncenter: PixCoord(x=3, y=4)\nwidth: 4\nheight: 3\nangle: 5.0 deg'
+        assert str(self.reg) == expected
+
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
+    def test_as_patch(self):
+        patch = self.reg.as_patch()
+        assert_allclose(patch.xy, (3, 4))
+        assert_allclose(patch.get_width(), 4)
+        assert_allclose(patch.get_height(), 3)
+        assert_allclose(patch._angle, 5)
 
 
 class TestRectangleSkyRegion:
-    def test_str(self):
+    def setup(self):
         center = SkyCoord(3, 4, unit='deg')
-        reg = RectangleSkyRegion(center, 3 * u.deg, 4 * u.deg, 5 * u.deg)
+        self.reg = RectangleSkyRegion(
+            center=center,
+            width=4 * u.deg,
+            height=3 * u.deg,
+            angle=5 * u.deg,
+        )
+
+    def test_str(self):
         if ASTROPY_LT_13:
             expected = ('RectangleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                        '    (3.0, 4.0)>\nheight: 3.0 deg\nwidth: 4.0 deg\nangle: 5.0 deg')
+                        '    (3.0, 4.0)>\nwidth: 4.0 deg\nheight: 3.0 deg\nangle: 5.0 deg')
         else:
             expected = ('RectangleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                        '    ( 3.,  4.)>\nheight: 3.0 deg\nwidth: 4.0 deg\nangle: 5.0 deg')
-        assert str(reg) == expected
+                        '    ( 3.,  4.)>\nwidth: 4.0 deg\nheight: 3.0 deg\nangle: 5.0 deg')
+        assert str(self.reg) == expected

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -29,7 +29,13 @@ class TestRectanglePixelRegion:
         assert_allclose(patch.xy, (3, 4))
         assert_allclose(patch.get_width(), 4)
         assert_allclose(patch.get_height(), 3)
-        assert_allclose(patch._angle, 5)
+        # `matplotlib.patches.Rectangle` currently doesn't expose `angle`.
+        # See https://github.com/matplotlib/matplotlib/issues/7536
+        # In the far future, when it's available in the matplotlib versions
+        # we support, we could re-activate a tests here.
+        # For now, we could also add an assert on `patch.get_verts()` if
+        # it's considered important to test that the rotation was done correctly.
+        # assert_allclose(patch._angle, 5)
 
 
 class TestRectangleSkyRegion:

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -7,20 +7,22 @@ from ..rectangle import RectanglePixelRegion, RectangleSkyRegion
 from .utils import ASTROPY_LT_13
 
 
-def test_ellipse_pixel():
-    center = PixCoord(3, 4)
-    reg = RectanglePixelRegion(center, 3, 4, 5 * u.deg)
+class TestRectanglePixelRegion:
+    def test_str(self):
+        center = PixCoord(3, 4)
+        reg = RectanglePixelRegion(center, 3, 4, 5 * u.deg)
 
-    assert str(reg) == 'RectanglePixelRegion\ncenter: PixCoord(x=3, y=4)\nheight: 3\nwidth: 4\nangle: 5.0 deg'
+        assert str(reg) == 'RectanglePixelRegion\ncenter: PixCoord(x=3, y=4)\nheight: 3\nwidth: 4\nangle: 5.0 deg'
 
 
-def test_ellipse_sky():
-    center = SkyCoord(3, 4, unit='deg')
-    reg = RectangleSkyRegion(center, 3 * u.deg, 4 * u.deg, 5 * u.deg)
-    if ASTROPY_LT_13:
-        expected = ('RectangleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                    '    (3.0, 4.0)>\nheight: 3.0 deg\nwidth: 4.0 deg\nangle: 5.0 deg')
-    else:
-        expected = ('RectangleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                    '    ( 3.,  4.)>\nheight: 3.0 deg\nwidth: 4.0 deg\nangle: 5.0 deg')
-    assert str(reg) == expected
+class TestRectangleSkyRegion:
+    def test_str(self):
+        center = SkyCoord(3, 4, unit='deg')
+        reg = RectangleSkyRegion(center, 3 * u.deg, 4 * u.deg, 5 * u.deg)
+        if ASTROPY_LT_13:
+            expected = ('RectangleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
+                        '    (3.0, 4.0)>\nheight: 3.0 deg\nwidth: 4.0 deg\nangle: 5.0 deg')
+        else:
+            expected = ('RectangleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
+                        '    ( 3.,  4.)>\nheight: 3.0 deg\nwidth: 4.0 deg\nangle: 5.0 deg')
+        assert str(reg) == expected

--- a/regions/shapes/tests/utils.py
+++ b/regions/shapes/tests/utils.py
@@ -4,3 +4,15 @@ from distutils.version import LooseVersion
 import astropy
 
 ASTROPY_LT_13 = LooseVersion(astropy.__version__) < LooseVersion('1.3')
+
+try:
+    import matplotlib
+    HAS_MATPLOTLIB = True
+except:
+    HAS_MATPLOTLIB = False
+
+try:
+    import shapely
+    HAS_SHAPELY = True
+except:
+    HAS_SHAPELY = False

--- a/regions/shapes/tests/utils.py
+++ b/regions/shapes/tests/utils.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from distutils.version import LooseVersion
 
 import astropy


### PR DESCRIPTION
This PR:

- [x] Removes sky region `as_patch` and `plot` as discussed in #76 and #77 
- [x] Group XYZRegion class tests in TestXYZRegion classes
- [x] Implement `EllipsePixelRegion.as_patch` (and add example to docstring)
- [x] Implement `RectanglePixelRegion.as_patch` (and add example to docstring)
- [x] Change to major / minor argument order in ellipse to be consistent with MPL / ds9 / photutils
- [x] Change to width / height argument order in rectangle to be consistent with MPL / ds9 / photutils
- [x] Add tests for pixel region `as_patch` methods
- [x] Updates the region MPL plot examples in the docs (to address #76)
- [x] Updates docs matplotlib plotting section with more info / examples
