### PR TITLE
ds9 reader corrections/improvements

### DIFF
--- a/regions/io/read_ds9.py
+++ b/regions/io/read_ds9.py
@@ -7,6 +7,8 @@ from astropy import units as u
 from astropy import coordinates
 from astropy.coordinates import BaseCoordinateFrame
 from astropy import log
+from astropy.utils.exceptions import AstropyUserWarning
+from warnings import warn
 from ..shapes import circle, rectangle, polygon, ellipse, point
 from ..core import PixCoord
 
@@ -192,9 +194,11 @@ def ds9_region_list_to_objects(region_list):
             else:
                 raise ValueError("No central coordinate")
         else:
-            log.warn("Skipping region with coords {0} because its type '{1}'"
-                     " is not recognized."
-                     .format(str(coord_list), region_type))
+            warn("Skipping region with coords {0} because its type '{1}'"
+                 " is not recognized."
+                 .format(str(coord_list), region_type),
+                 AstropyUserWarning
+                )
             continue
         reg.vizmeta = {key: meta[key] for key in meta.keys() if key in viz_keywords}
         reg.meta = {key: meta[key] for key in meta.keys() if key not in viz_keywords}

--- a/regions/io/read_ds9.py
+++ b/regions/io/read_ds9.py
@@ -27,6 +27,11 @@ class DS9RegionParserWarning(AstropyUserWarning):
     warnings
     """
 
+class DS9RegionParserError(ValueError):
+    """
+    A generic error class for DS9 region parsing
+    """
+
 def read_ds9(filename, errors='strict'):
     """Read a ds9 region file in as a list of region objects.
 
@@ -36,7 +41,7 @@ def read_ds9(filename, errors='strict'):
         The file path
     errors : ``warn``, ``ignore``, ``strict``
       The error handling scheme to use for handling parsing errors.
-      The default is 'strict', which will raise a ``ValueError``.
+      The default is 'strict', which will raise a ``DS9RegionParserError``.
       ``warn`` will raise a warning, and ``ignore`` will do nothing
       (i.e., be silent).
 
@@ -173,7 +178,7 @@ def ds9_region_list_to_objects(region_list):
             elif isinstance(coord_list[0], PixCoord):
                 reg = circle.CirclePixelRegion(coord_list[0], coord_list[1])
             else:
-                raise ValueError("No central coordinate")
+                raise DS9RegionParserError("No central coordinate")
         elif region_type == 'ellipse':
             # Do not read elliptical annuli for now
             if len(coord_list) > 4:
@@ -183,28 +188,28 @@ def ds9_region_list_to_objects(region_list):
             elif isinstance(coord_list[0], PixCoord):
                 reg = ellipse.EllipsePixelRegion(coord_list[0], coord_list[1], coord_list[2], coord_list[3])
             else:
-                raise ValueError("No central coordinate")
+                raise DS9RegionParserError("No central coordinate")
         elif region_type == 'polygon':
             if isinstance(coord_list[0], BaseCoordinateFrame):
                 reg = polygon.PolygonSkyRegion(coord_list[0])
             elif isinstance(coord_list[0], PixCoord):
                 reg = polygon.PolygonPixelRegion(coord_list[0])
             else:
-                raise ValueError("No central coordinate")
+                raise DS9RegionParserError("No central coordinate")
         elif region_type in ('rectangle', 'box'):
             if isinstance(coord_list[0], BaseCoordinateFrame):
                 reg = rectangle.RectangleSkyRegion(coord_list[0], coord_list[1], coord_list[2], coord_list[3])
             elif isinstance(coord_list[0], PixCoord):
                 reg = rectangle.RectanglePixelRegion(coord_list[0], coord_list[1], coord_list[2], coord_list[3])
             else:
-                raise ValueError("No central coordinate")
+                raise DS9RegionParserError("No central coordinate")
         elif region_type == 'point':
             if isinstance(coord_list[0], BaseCoordinateFrame):
                 reg = point.PointSkyRegion(coord_list[0])
             elif isinstance(coord_list[0], PixCoord):
                 reg = point.PointPixelRegion(coord_list[0])
             else:
-                raise ValueError("No central coordinate")
+                raise DS9RegionParserError("No central coordinate")
         else:
             # Note: this should effectively never happen, because it would
             # imply that the line_parser found a region that didn't match the
@@ -325,7 +330,7 @@ def line_parser(line, coordsys=None, errors='strict'):
     errors : ``warn``, ``ignore``, ``strict``
       The error handling scheme to use for handling skipped entries
       in a region file that were not parseable.
-      The default is 'strict', which will raise a ``ValueError``.
+      The default is 'strict', which will raise a ``DS9RegionParserError``.
       ``warn`` will raise a warning, and ``ignore`` will do nothing
       (i.e., be silent).
 
@@ -368,7 +373,8 @@ def line_parser(line, coordsys=None, errors='strict'):
         return region_type  # outer loop has to do something with the coordinate system information
     elif region_type in language_spec:
         if coordsys is None:
-            raise ValueError("No coordinate system specified and a region has been found.")
+            raise DS9RegionParserError("No coordinate system specified and a"
+                                       " region has been found.")
 
         if "||" in line:
             composite = True
@@ -432,7 +438,7 @@ def line_parser(line, coordsys=None, errors='strict'):
             message = ("Region type '{0}' was identified, but it is not one of "
                        "the known region types.".format(region_type))
             if errors == 'strict':
-                raise ValueError(message)
+                raise DS9RegionParserError(message)
             else:
                 warn(message, DS9RegionParserWarning)
 

--- a/regions/io/read_ds9.py
+++ b/regions/io/read_ds9.py
@@ -497,7 +497,7 @@ def meta_parser(meta_str):
     meta_token_split = [x for x in meta_token.split(meta_str.strip()) if x]
     equals_inds = [i for i, x in enumerate(meta_token_split) if x is '=']
     result = {meta_token_split[ii - 1]:
-                  " ".join(meta_token_split[ii + 1:jj - 1 if jj is not None else None])
+              " ".join(meta_token_split[ii + 1:jj - 1 if jj is not None else None])
               for ii, jj in zip(equals_inds, equals_inds[1:] + [None])}
 
     return result

--- a/regions/io/read_ds9.py
+++ b/regions/io/read_ds9.py
@@ -20,6 +20,12 @@ __all__ = [
 ]
 
 
+class DS9RegionParserWarning(AstropyUserWarning):
+    """
+    A generic warning class for DS9 region parsing inherited from astropy's
+    warnings
+    """
+
 def read_ds9(filename):
     """Read a ds9 region file in as a list of region objects.
 
@@ -202,7 +208,7 @@ def ds9_region_list_to_objects(region_list):
             warn("Skipping region with coords {0} because its type '{1}'"
                  " is not recognized."
                  .format(str(coord_list), region_type),
-                 AstropyUserWarning
+                 DS9RegionParserWarning
                 )
             continue
         reg.visual = {key: meta[key] for key in meta.keys() if key in viz_keywords}
@@ -335,7 +341,7 @@ def line_parser(line, coordsys=None, errors='strict'):
             # but otherwise, this should probably always raise a warning?
             # at least until we identify common cases for it
             warn("No region type found for line '{0}'.".format(line),
-                 AstropyUserWarning)
+                 DS9RegionParserWarning)
         return
 
     if region_type in coordinate_systems:
@@ -397,18 +403,18 @@ def line_parser(line, coordsys=None, errors='strict'):
 
             return region_type, parsed_return, parsed_meta, composite, include
     else:
-        # it is not clear when it is OK to warn
-        # This: # Region file format: DS9 astropy/regions
-        # should not result in a warning, but this
-        # rectfangle(1,2,3,4)
-        # probably should!
+        # This will raise warnings even if the first line is acceptable,
+        # e.g. something like:
+        # # Region file format: DS9 version 4.1
+        # That behavior is unfortunate, but there's not a great workaround
+        # except to let the user set `errors='ignore'`
         if errors in ('warn','strict'):
             message = ("Region type '{0}' was identified, but it is not one of "
                        "the known region types.".format(region_type))
             if errors == 'strict':
                 raise ValueError(message)
             else:
-                warn(message, AstropyUserWarning)
+                warn(message, DS9RegionParserWarning)
 
 
 def type_parser(string_rep, specification, coordsys):

--- a/regions/io/read_ds9.py
+++ b/regions/io/read_ds9.py
@@ -211,13 +211,16 @@ def ds9_region_list_to_objects(region_list):
     return output_list
 
 
-def ds9_string_to_objects(region_string):
+def ds9_string_to_objects(region_string, warn_skipped=False):
     """Parse ds9 region string to region objects
 
     Parameters
     ----------
     region_string : str
         DS9 region string
+    warn_skipped : bool
+        Print a warning if there is a skipped (commented) line?
+        Can set to ``False`` or ``'raise'`` if you want an exception instead.
 
     Returns
     -------
@@ -228,7 +231,7 @@ def ds9_string_to_objects(region_string):
     --------
     TODO
     """
-    region_list = ds9_string_to_region_list(region_string)
+    region_list = ds9_string_to_region_list(region_string, warn_skipped=warn_skipped)
     regions = ds9_region_list_to_objects(region_list)
     return regions
 

--- a/regions/io/read_ds9.py
+++ b/regions/io/read_ds9.py
@@ -388,7 +388,7 @@ def line_parser(line, coordsys=None, warn_skipped=False):
         # rectfangle(1,2,3,4)
         # probably should!
         if warn_skipped:
-            message = ("Region type {0} was identified, but it is not one of "
+            message = ("Region type '{0}' was identified, but it is not one of "
                        "the known region types.".format(region_type))
             if warn_skipped == 'raise':
                 raise ValueError(message)

--- a/regions/io/read_ds9.py
+++ b/regions/io/read_ds9.py
@@ -148,7 +148,7 @@ def ds9_region_list_to_objects(region_list):
     regions : list
         List of `regions.Region` objects
     """
-    viz_keywords = ['color', 'dashed', 'width', 'point', 'font', 'text']
+    viz_keywords = ['color', 'dashed', 'width', 'point', 'font']
 
     output_list = []
     for region_type, coord_list, meta in region_list:
@@ -200,7 +200,7 @@ def ds9_region_list_to_objects(region_list):
                  AstropyUserWarning
                 )
             continue
-        reg.vizmeta = {key: meta[key] for key in meta.keys() if key in viz_keywords}
+        reg.visual = {key: meta[key] for key in meta.keys() if key in viz_keywords}
         reg.meta = {key: meta[key] for key in meta.keys() if key not in viz_keywords}
         output_list.append(reg)
     return output_list

--- a/regions/io/read_ds9.py
+++ b/regions/io/read_ds9.py
@@ -17,6 +17,7 @@ __all__ = [
     'ds9_string_to_objects',
     'ds9_string_to_region_list',
     'ds9_region_list_to_objects',
+    'DS9RegionParserWarning',
 ]
 
 

--- a/regions/io/read_ds9.py
+++ b/regions/io/read_ds9.py
@@ -319,8 +319,12 @@ def line_parser(line, coordsys=None, warn_skipped=False):
         include = region_type_search.groups()[0]
         region_type = region_type_search.groups()[1]
     else:
-        warn("No region type found for {0}".format(line),
-             AstropyUserWarning)
+        # if there's no line, it's just blank, so don't warn
+        if line:
+            # but otherwise, this should probably always raise a warning?
+            # at least until we identify common cases for it
+            warn("No region type found for line '{0}'.".format(line),
+                 AstropyUserWarning)
         return
 
     if region_type in coordinate_systems:

--- a/regions/io/tests/data/ds9.color.spaces.reg
+++ b/regions/io/tests/data/ds9.color.spaces.reg
@@ -1,0 +1,10 @@
+# Region file format: DS9 version 4.1
+global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1
+fk5
+circle(13:29:52.675, +47:11:45.02, 1") # color=blue
+circle(13:29:52.675, +47:11:45.02, 2") # color=#800
+circle(13:29:52.675, +47:11:45.02, 3") # color=#0a0
+circle(13:29:52.675, +47:11:45.02, 4") # color=#880000
+circle(13:29:52.675, +47:11:45.02, 5") # color=#00aa00
+circle(13:29:52.675, +47:11:45.02, 6") # color=#888800000000
+circle(13:29:52.675, +47:11:45.02, 7") # color=#0000aaaa0000

--- a/regions/io/tests/test_ds9_language.py
+++ b/regions/io/tests/test_ds9_language.py
@@ -133,7 +133,7 @@ def test_missing_region_warns():
 
     # this will warn on both the commented first line and the not_a_region line
     with catch_warnings(AstropyUserWarning) as ASWarn:
-        regions = ds9_string_to_objects(ds9_str, warn_skipped=True)
+        regions = ds9_string_to_objects(ds9_str, errors='warn')
 
     assert len(regions) == 1
     assert len(ASWarn) == 2

--- a/regions/io/tests/test_ds9_language.py
+++ b/regions/io/tests/test_ds9_language.py
@@ -146,10 +146,13 @@ def test_missing_region_warns():
 
 def test_global_parser():
     """ Check that the global_parser does what's expected """
-    global_test_str = ('global color=green dashlist=8 3 width=1'
-                       ' font="helvetica 10 normal roman" select=1'
-                       ' highlite=1 dash=0 fixed=0 edit=1 move=1'
-                       ' delete=1 include=1 source=1')
+    # have to force "str" here because unicode_literals makes this string a
+    # unicode string, even though in python2.7 we don't want it to be.  But in
+    # py3, we don't want it to be bytes.
+    global_test_str = str('global color=green dashlist=8 3 width=1'
+                          ' font="helvetica 10 normal roman" select=1'
+                          ' highlite=1 dash=0 fixed=0 edit=1 move=1'
+                          ' delete=1 include=1 source=1')
     global_parsed = global_parser(global_test_str)
     assert global_parsed[0] == 'global'
     assert global_parsed[1] == {'dash': '0', 'source': '1', 'move': '1',

--- a/regions/io/tests/test_ds9_language.py
+++ b/regions/io/tests/test_ds9_language.py
@@ -129,7 +129,7 @@ def test_ds9_io(tmpdir):
     assert_allclose(reg.radius.value, 3)
 
 def test_missing_region_warns():
-    ds9_str = '# Region file format: DS9 astropy/regions\nfk5\ncircle(42.0000,43.0000,3.0000)\nnot_a_region_type(blah)'
+    ds9_str = '# Region file format: DS9 astropy/regions\nfk5\ncircle(42.0000,43.0000,3.0000)\nnotaregiontype(blah)'
 
     # this will warn on both the commented first line and the not_a_region line
     with catch_warnings(AstropyUserWarning) as ASWarn:
@@ -137,4 +137,4 @@ def test_missing_region_warns():
 
     assert len(regions) == 1
     assert len(ASWarn) == 2
-    assert "Skipping region" in str(ASWarn[1].message)
+    assert "Region type 'notaregiontype'" in str(ASWarn[1].message)


### PR DESCRIPTION
Mostly minor:

 * warn if a region is skipped when reading
 * read 'box' regions (we accepted only 'rectangle' before)
 * allow for whitespace after commas