### PR TITLE
Initial implementation of CircleSkyRegion.to_pixel in full mode

### DIFF
--- a/regions/_geometry/__init__.py
+++ b/regions/_geometry/__init__.py
@@ -3,6 +3,7 @@
 Geometry subpackage for low-level geometry functions.
 """
 
+from .rotate_polygon import *
 from .circular_overlap import *
 from .elliptical_overlap import *
 from .rectangular_overlap import *

--- a/regions/_geometry/rotate_polygon.py
+++ b/regions/_geometry/rotate_polygon.py
@@ -1,0 +1,34 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+
+from astropy import units as u
+from astropy.coordinates.representation import UnitSphericalRepresentation
+from astropy.coordinates.matrix_utilities import rotation_matrix
+
+__all__ = ['rotate_polygon']
+
+
+def rotate_polygon(lon, lat, lon0, lat0):
+    """
+    Given a polygon with vertices defined by (lon, lat), rotate the polygon
+    such that the North pole of the spherical coordinates is now at (lon0,
+    lat0). Therefore, to end up with a polygon centered on (lon0, lat0), the
+    polygon should initially be drawn around the North pole.
+    """
+
+    # Create a representation object
+    polygon = UnitSphericalRepresentation(lon=lon, lat=lat)
+
+    # Determine rotation matrix to make it so that the circle is centered
+    # on the correct longitude/latitude.
+    m1 = rotation_matrix(-(0.5 * np.pi * u.radian - lat0), axis='y')
+    m2 = rotation_matrix(-lon0, axis='z')
+    transform_matrix = np.matmul(m2, m1)
+
+    # Apply 3D rotation
+    polygon = polygon.to_cartesian()
+    polygon = polygon.transform(transform_matrix)
+    polygon = UnitSphericalRepresentation.from_cartesian(polygon)
+
+    return polygon.lon, polygon.lat

--- a/regions/_geometry/rotate_polygon.py
+++ b/regions/_geometry/rotate_polygon.py
@@ -4,7 +4,13 @@ import numpy as np
 
 from astropy import units as u
 from astropy.coordinates.representation import UnitSphericalRepresentation
-from astropy.coordinates.matrix_utilities import rotation_matrix
+
+try:
+    from astropy.coordinates.matrix_utilities import rotation_matrix as rotation_array
+    def rotation_matrix(*args, **kwargs):
+        return np.matrix(rotation_array(*args, **kwargs))
+except ImportError:  # Astropy < 1.3
+    from astropy.coordinates.angles import rotation_matrix
 
 __all__ = ['rotate_polygon']
 
@@ -24,7 +30,7 @@ def rotate_polygon(lon, lat, lon0, lat0):
     # on the correct longitude/latitude.
     m1 = rotation_matrix(-(0.5 * np.pi * u.radian - lat0), axis='y')
     m2 = rotation_matrix(-lon0, axis='z')
-    transform_matrix = np.matmul(m2, m1)
+    transform_matrix = m2 * m1
 
     # Apply 3D rotation
     polygon = polygon.to_cartesian()

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -7,11 +7,11 @@ import numpy as np
 
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
-from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
+from astropy.wcs.utils import pixel_to_skycoord
 
-from .polygon import PolygonPixelRegion
+from .polygon import PolygonSkyRegion
 
-from ..core import PixelRegion, SkyRegion, Mask, BoundingBox, PixCoord
+from ..core import PixelRegion, SkyRegion, Mask, BoundingBox
 from .._utils.wcs_helpers import skycoord_to_pixel_scale_angle
 from .._geometry import circular_overlap_grid, rotate_polygon
 
@@ -158,6 +158,36 @@ class CircleSkyRegion(SkyRegion):
     def contains(self, skycoord):
         return self.center.separation(skycoord) < self.radius
 
+    def to_polygon(self, points=100):
+        """
+        Convert the circle to a polygon.
+
+        Parameters
+        ----------
+        points : int, optional
+            Number of points in the final polygon.
+        """
+
+        # TODO: avoid converting to unit spherical or spherical if already
+        #       using a spherical representation
+
+        # Extract longitude/latitude, either from a tuple of two quantities, or
+        # a single 2-element Quantity.
+        rep = self.center.represent_as('unitspherical')
+        longitude, latitude = rep.lon, rep.lat
+
+        # Start off by generating the circle around the North pole
+        lon = np.linspace(0., 2 * np.pi, points + 1)[:-1] * u.radian
+        lat = np.repeat(0.5 * np.pi - self.radius.to(u.radian).value, points) * u.radian
+
+        # Now rotate it to the correct longitude/latitude
+        lon, lat = rotate_polygon(lon, lat, longitude, latitude)
+
+        # Make a new SkyCoord
+        vertices_sky = SkyCoord(lon, lat, frame=self.center)
+
+        return PolygonSkyRegion(vertices_sky)
+
     def to_pixel(self, wcs, mode='local', tolerance=100):
         """
         Given a WCS, convert the circle to a best-approximation circle in pixel
@@ -187,30 +217,7 @@ class CircleSkyRegion(SkyRegion):
 
         elif mode == 'full':
 
-            # TODO: avoid converting to unit spherical or spherical if already
-            #       using a spherical representation
-
-            # Extract longitude/latitude, either from a tuple of two quantities, or
-            # a single 2-element Quantity.
-            rep = self.center.represent_as('unitspherical')
-            longitude, latitude = rep.lon, rep.lat
-
-            # Start off by generating the circle around the North pole
-            lon = np.linspace(0., 2 * np.pi, tolerance + 1)[:-1] * u.radian
-            lat = np.repeat(0.5 * np.pi - self.radius.to(u.radian).value, tolerance) * u.radian
-
-            # Now rotate it to the correct longitude/latitude
-            lon, lat = rotate_polygon(lon, lat, longitude, latitude)
-
-            # Make a new SkyCoord
-            vertices_sky = SkyCoord(lon, lat, frame=self.center)
-
-            # Convert to PixCoord
-            x, y = skycoord_to_pixel(vertices_sky, wcs)
-            vertices_pix = PixCoord(x, y)
-
-            # Make polygon
-            return PolygonPixelRegion(vertices_pix)
+            return self.to_polygon(points=tolerance).to_pixel(wcs)
 
         else:
             raise ValueError('mode should be one of local/affine/full')

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -158,7 +158,7 @@ class CircleSkyRegion(SkyRegion):
     def contains(self, skycoord):
         return self.center.separation(skycoord) < self.radius
 
-    def to_pixel(self, wcs, mode='local', tolerance=None):
+    def to_pixel(self, wcs, mode='local', tolerance=100):
         """
         Given a WCS, convert the circle to a best-approximation circle in pixel
         dimensions.
@@ -169,7 +169,7 @@ class CircleSkyRegion(SkyRegion):
             A world coordinate system
         mode : 'local' or not
             not implemented
-        tolerance : None
+        tolerance : int
             not implemented
 
         Returns
@@ -203,7 +203,7 @@ class CircleSkyRegion(SkyRegion):
             lon, lat = rotate_polygon(lon, lat, longitude, latitude)
 
             # Make a new SkyCoord
-            vertices_sky = SkyCoord(lon, lat, frame=self.center.frame)
+            vertices_sky = SkyCoord(lon, lat, frame=self.center)
 
             # Convert to PixCoord
             x, y = skycoord_to_pixel(vertices_sky, wcs)

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -3,12 +3,17 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import math
 
-from astropy.coordinates import Angle
-from astropy.wcs.utils import pixel_to_skycoord
+import numpy as np
 
-from ..core import PixelRegion, SkyRegion, Mask, BoundingBox
+from astropy import units as u
+from astropy.coordinates import Angle, SkyCoord
+from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
+
+from .polygon import PolygonPixelRegion
+
+from ..core import PixelRegion, SkyRegion, Mask, BoundingBox, PixCoord
 from .._utils.wcs_helpers import skycoord_to_pixel_scale_angle
-from .._geometry import circular_overlap_grid
+from .._geometry import circular_overlap_grid, rotate_polygon
 
 __all__ = ['CirclePixelRegion', 'CircleSkyRegion']
 
@@ -172,12 +177,40 @@ class CircleSkyRegion(SkyRegion):
         CirclePixelRegion
         """
 
-        if mode != 'local':
-            raise NotImplementedError
-        if tolerance is not None:
-            raise NotImplementedError
+        if mode == 'local':
+            center, scale, _ = skycoord_to_pixel_scale_angle(self.center, wcs)
+            radius = self.radius.to('deg').value * scale
+            return CirclePixelRegion(center, radius)
 
-        center, scale, _ = skycoord_to_pixel_scale_angle(self.center, wcs)
-        radius = self.radius.to('deg').value * scale
+        elif mode == 'affine':
+            raise NotImplementedError()
 
-        return CirclePixelRegion(center, radius)
+        elif mode == 'full':
+
+            # TODO: avoid converting to unit spherical or spherical if already
+            #       using a spherical representation
+
+            # Extract longitude/latitude, either from a tuple of two quantities, or
+            # a single 2-element Quantity.
+            rep = self.center.represent_as('unitspherical')
+            longitude, latitude = rep.lon, rep.lat
+
+            # Start off by generating the circle around the North pole
+            lon = np.linspace(0., 2 * np.pi, tolerance + 1)[:-1] * u.radian
+            lat = np.repeat(0.5 * np.pi - self.radius.to(u.radian).value, tolerance) * u.radian
+
+            # Now rotate it to the correct longitude/latitude
+            lon, lat = rotate_polygon(lon, lat, longitude, latitude)
+
+            # Make a new SkyCoord
+            vertices_sky = SkyCoord(lon, lat, frame=self.center.frame)
+
+            # Convert to PixCoord
+            x, y = skycoord_to_pixel(vertices_sky, wcs)
+            vertices_pix = PixCoord(x, y)
+
+            # Make polygon
+            return PolygonPixelRegion(vertices_pix)
+
+        else:
+            raise ValueError('mode should be one of local/affine/full')

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -4,7 +4,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 
-from ..core import PixelRegion, SkyRegion, Mask, BoundingBox
+from astropy.wcs.utils import skycoord_to_pixel
+
+from ..core import PixelRegion, SkyRegion, Mask, BoundingBox, PixCoord
 from .._geometry import polygonal_overlap_grid
 from .._geometry.pnpoly import points_in_polygon
 
@@ -141,5 +143,11 @@ class PolygonSkyRegion(SkyRegion):
         raise NotImplementedError
 
     def to_pixel(self, wcs, mode='local', tolerance=None):
-        # TODO: needs to be implemented
-        raise NotImplementedError
+
+        if mode == 'local':
+            x, y = skycoord_to_pixel(self.vertices, wcs)
+            vertices_pix = PixCoord(x, y)
+            return PolygonPixelRegion(vertices_pix)
+        else:
+
+            raise NotImplementedError()


### PR DESCRIPTION
This will likely require some more discussion, but it is a first implementation of the ``full`` mode in ``CircleSkyRegion.to_pixel`` based on the code in WCSAxes. Basically we start by setting up a spherical circle with the right radius and then rotating it in 3D to the correct coordinates, then converting the polygon to pixel coordinates.

The main point I'd like to discuss is how to set the precision of this conversion. At the moment, the API specifies ``tolerance`` but that is ill defined, and requiring a final tolerance in pixel space would require iterating. Instead, I think we could do what I'm doing here and have a parameter that specifies the number of points to use in the polygon since in full mode the shapes always get converted to a polygon. I think in that case we should rename from ``tolerance`` to something else. This is much easier to implement.

Here's an example of this code in action:

```python
from regions import CircleSkyRegion

from astropy import units as u
from astropy.coordinates import SkyCoord
from astropy.wcs import WCS

import matplotlib.pyplot as plt

wcs = WCS('2MASS_k.fits')

c = SkyCoord(1 * u.deg, 2 * u.deg, frame='galactic')

fig = plt.figure()
ax = fig.add_subplot(1, 1, 1, aspect='equal')

for radius in [1, 5, 10, 20]:

    reg = CircleSkyRegion(c, radius=radius * u.deg)

    pix1 = reg.to_pixel(wcs, mode='local')
    pix2 = reg.to_pixel(wcs, mode='full', tolerance=200)

    ax.add_patch(pix1.as_patch(edgecolor='blue', facecolor='none'))
    ax.add_patch(pix2.as_patch(edgecolor='green', facecolor='none'))

ax.set_xlim(-20000, 20000)
ax.set_ylim(-20000, 20000)
fig.savefig('circles.png')
```

![circles](https://cloud.githubusercontent.com/assets/314716/20775415/aca44f72-b752-11e6-853e-ebeb56836c1d.png)

This also needs some kind of tests of course - not sure what the best way to test this would be?

@cdeil - obviously this doesn't have to go in 0.2, so no need to wait for it.