### PR TITLE
Add clarification to BoundingBox extent docs

### DIFF
--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -148,11 +148,15 @@ class BoundingBox(object):
     @property
     def extent(self):
         """
-        The extent of the mask, defined as the bounding box from the
-        bottom-left corner of the lower-left pixel to the upper-right
-        corner of the upper-right pixel.
+        The extent of the mask, defined as the ``(xmin, xmax, ymin,
+        ymax)`` bounding box from the bottom-left corner of the
+        lower-left pixel to the upper-right corner of the upper-right
+        pixel.
 
-        This can be used for example when plotting using Matplotlib.
+        The upper edges here are the actual pixel positions of the
+        edges, i.e. they are not "exclusive" indices used for python
+        indexing.  This is useful for plotting the bounding box using
+        Matplotlib.
         """
 
         return (


### PR DESCRIPTION
This is a gentle suggestion to simply rename the `extent` property to `edges`.  When I see `extent` I immediately think it's a "size" of some kind, e.g. 3 meters in extent.  I think `edges` is a better name, since it's returning the edges of the bounding box and not a "size".  @astrofrog?