### PR TITLE
Adding python 3.6 to CI builds

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -4,5 +4,4 @@ channels:
 dependencies:
 - matplotlib
 - astropy
-- wcsaxes
 - cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: python
 
 python:
     - 2.7
+    - 3.3
     - 3.4
     - 3.5
+    - 3.6
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -33,25 +35,23 @@ env:
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'
-        # Try all python versions with the latest numpy
-        - SETUP_CMD='test'
 
 matrix:
     include:
 
         # Do a coverage test in Python 3.
-        - python: 3.5
+        - python: 3.6
           env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - python: 2.7
           env: SETUP_CMD='build_docs -w'
-        - python: 3.5
+        - python: 3.6
           env: SETUP_CMD='build_docs -w'
 
         # Do a test without the optional dependencies
-        - python: 3.5
+        - python: 3.6
           env: SETUP_CMD='test'
                CONDA_DEPENDENCIES='Cython'
 
@@ -59,40 +59,30 @@ matrix:
         # Try Astropy development version
         - python: 2.7
           env: ASTROPY_VERSION=development
-        - python: 3.5
+        - python: 3.6
           env: ASTROPY_VERSION=development
 
-        # Python 3.3 doesn't have numpy 1.10 in conda, but it can be put
-        # back into the main matrix once the numpy build is available in the
-        # astropy-ci-extras channel (or in the one provided in the
-        # CONDA_CHANNELS environmental variable).
-        - python: 3.3
-          env: SETUP_CMD='egg_info'
-               CONDA_DEPENDENCIES='Cython'
-        - python: 3.3
-          env: SETUP_CMD='test' NUMPY_VERSION=1.9
-               CONDA_DEPENDENCIES='Cython'
 
         # Try older numpy versions
-        - python: 2.7
+        - python: 3.5
           env: NUMPY_VERSION=1.10
-        - python: 2.7
+        - python: 3.4
           env: NUMPY_VERSION=1.9
-        - python: 2.7
+        - python: 3.3
           env: NUMPY_VERSION=1.8
         - python: 2.7
           env: NUMPY_VERSION=1.7
 
         # Try numpy pre-release
-        - python: 3.5
+        - python: 3.6
           env: NUMPY_VERSION=prerelease
 
         # Do a PEP8 test with pycodestyle
-        - python: 3.5
+        - python: 3.6
           env: MAIN_CMD='pycodestyle regions --count' SETUP_CMD=''
 
     allow_failures:
-        - python: 3.5
+        - python: 3.6
           env: NUMPY_VERSION=prerelease
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,14 @@ matrix:
         # Do a coverage test in Python 3.
         - python: 3.6
           env: SETUP_CMD='test --coverage'
-
+               CONDA_CHANNELS='conda-forge astropy'
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - python: 2.7
           env: SETUP_CMD='build_docs -w'
         - python: 3.6
           env: SETUP_CMD='build_docs -w'
-
+               CONDA_CHANNELS='conda-forge astropy'
         # Do a test without the optional dependencies
         - python: 3.6
           env: SETUP_CMD='test'
@@ -61,7 +61,7 @@ matrix:
           env: ASTROPY_VERSION=development
         - python: 3.6
           env: ASTROPY_VERSION=development
-
+               CONDA_CHANNELS='conda-forge astropy'
 
         # Try older numpy versions
         - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,8 @@ matrix:
         - python: 3.4
           env: NUMPY_VERSION=1.9
         - python: 3.3
-          env: NUMPY_VERSION=1.8
+          env: NUMPY_VERSION=1.8 PIP_DEPENDENCIES='wcsaxes pytest-arraydiff'
+               CONDA_DEPENDENCIES='Cython shapely'
         - python: 2.7
           env: NUMPY_VERSION=1.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - MAIN_CMD='python setup.py'
-        - PIP_DEPENDENCIES='https://github.com/astrofrog/pytest-arraydiff/archive/master.zip'
-        - CONDA_DEPENDENCIES='Cython shapely wcsaxes'
+        - PIP_DEPENDENCIES=''
+        - CONDA_DEPENDENCIES='Cython shapely wcsaxes pytest-arraydiff'
         - CONDA_CHANNELS='astropy'
         - SETUP_XVFB=True
 
@@ -53,7 +53,7 @@ matrix:
         # Do a test without the optional dependencies
         - python: 3.6
           env: SETUP_CMD='test'
-               CONDA_DEPENDENCIES='Cython'
+               CONDA_DEPENDENCIES='Cython pytest-arraydiff'
 
 
         # Try Astropy development version
@@ -80,10 +80,6 @@ matrix:
         # Do a PEP8 test with pycodestyle
         - python: 3.6
           env: MAIN_CMD='pycodestyle regions --count' SETUP_CMD=''
-
-    allow_failures:
-        - python: 3.6
-          env: NUMPY_VERSION=prerelease
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
     - 3.6
@@ -65,12 +64,13 @@ matrix:
 
         # Try older numpy versions
         - python: 3.5
+          env: NUMPY_VERSION=1.11
+        - python: 3.5
           env: NUMPY_VERSION=1.10
         - python: 3.4
           env: NUMPY_VERSION=1.9
-        - python: 3.3
-          env: NUMPY_VERSION=1.8 PIP_DEPENDENCIES='pytest-arraydiff'
-               CONDA_DEPENDENCIES='Cython shapely matplotlib<2.0'
+        - python: 2.7
+          env: NUMPY_VERSION=1.8
         - python: 2.7
           env: NUMPY_VERSION=1.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
         - SETUP_CMD='test'
         - MAIN_CMD='python setup.py'
         - PIP_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython shapely wcsaxes pytest-arraydiff'
+        - CONDA_DEPENDENCIES='Cython shapely pytest-arraydiff'
         - CONDA_CHANNELS='astropy'
         - SETUP_XVFB=True
 
@@ -69,7 +69,7 @@ matrix:
         - python: 3.4
           env: NUMPY_VERSION=1.9
         - python: 3.3
-          env: NUMPY_VERSION=1.8 PIP_DEPENDENCIES='wcsaxes pytest-arraydiff'
+          env: NUMPY_VERSION=1.8 PIP_DEPENDENCIES='pytest-arraydiff'
                CONDA_DEPENDENCIES='Cython shapely'
         - python: 2.7
           env: NUMPY_VERSION=1.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ matrix:
           env: NUMPY_VERSION=1.9
         - python: 3.3
           env: NUMPY_VERSION=1.8 PIP_DEPENDENCIES='pytest-arraydiff'
-               CONDA_DEPENDENCIES='Cython shapely'
+               CONDA_DEPENDENCIES='Cython shapely matplotlib<2.0'
         - python: 2.7
           env: NUMPY_VERSION=1.7
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,14 +19,14 @@ environment:
 
   matrix:
 
-      # We test Python 2.7 and 3.5 because 2.7 is the supported Python 2
-      # release of Astropy and Python 3.5 is the latest Python 3 release.
+      # We test Python 2.7 and 3.6 because 2.7 is the supported Python 2
+      # release of Astropy and Python 3.6 is the latest Python 3 release.
 
       - PYTHON_VERSION: "2.7"
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 
-      - PYTHON_VERSION: "3.5"
+      - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,6 @@ setup_cfg = dict(conf.items('metadata'))
 del intersphinx_mapping['scipy']
 del intersphinx_mapping['h5py']
 intersphinx_mapping['photutils'] = ('http://photutils.readthedocs.io/en/latest/', None)
-intersphinx_mapping['wcsaxes'] = ('http://wcsaxes.readthedocs.io/en/latest/', None)
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.2'

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -867,8 +867,7 @@ method. To plot them, convert them to a pixel region first:
 We do plan to add extensive documentation on sky region plotting, or to
 add methods on sky region to do it directly in the future
 (see https://github.com/astropy/regions/issues/76 ),
-after the polygon region classes are developed and ``wcsaxes`` is merged
-in the Astropy core package.
+after the polygon region classes are developed.
 
 An example of how to plot sky regions on a sky image is shown above.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -83,5 +83,5 @@ Optional dependencies
 The following packages are optional dependencies, install if needed:
 
 * `shapely`_ for advanced pixel region operations
-* `matplotlib`_ and `wcsaxes`_ for plotting regions
+* `matplotlib`_ for plotting regions
 * maybe `spherical_geometry`_ for polygons (not used yet)

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -3,6 +3,5 @@
 .. _photutils: http://photutils.readthedocs.io/en/latest/photutils/aperture.html
 .. _matplotlib: http://matplotlib.org/
 .. _shapely: http://toblerity.org/shapely/manual.html
-.. _wcsaxes: http://wcsaxes.readthedocs.io/en/latest/
 .. _Github repository: https://github.com/astropy/regions
 .. _Region documentation: http://astropy-regions.readthedocs.io/en/latest/

--- a/regions/conftest.py
+++ b/regions/conftest.py
@@ -23,7 +23,6 @@ enable_deprecations_as_exceptions()
 # astropy affiliated packages.
 try:
     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
-    PYTEST_HEADER_MODULES['wcsaxes'] = 'wcsaxes'
     del PYTEST_HEADER_MODULES['h5py']
     del PYTEST_HEADER_MODULES['Pandas']
 except KeyError:

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,6 @@ setup(name=PACKAGENAME,
       extras_require=dict(
           plot=[
               'matplotlib',
-              'wcsaxes',
           ],
           test=[
               'pytest-mpl',


### PR DESCRIPTION
Probably we need to wait a bit more until all the dependencies become available on python 3.6.

This PR also removes the dependency on standalone wcsaxes package, closing #104. 