### PR TITLE
Bounding box edges must be scalar

### DIFF
--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -105,10 +105,10 @@ class BoundingBox(object):
         BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
         """
 
-        ixmin = np.floor(xmin + 0.5).astype(int)
-        ixmax = np.floor(xmax + 1.5).astype(int)
-        iymin = np.floor(ymin + 0.5).astype(int)
-        iymax = np.floor(ymax + 1.5).astype(int)
+        ixmin = int(np.floor(xmin + 0.5))
+        ixmax = int(np.floor(xmax + 1.5))
+        iymin = int(np.floor(ymin + 0.5))
+        iymax = int(np.floor(ymax + 1.5))
 
         return cls(ixmin, ixmax, iymin, iymax)
 


### PR DESCRIPTION
Prior to this fix, attempting to make a cutout resulted in errors like this:

```
Traceback (most recent call last):
File "<ipython-input-282-00fe094081c8>", line 7, in <module>
cutout = mask.cutout(data)
File "/Users/adam/repos/astropy-regions/regions/core/mask.py", line 154, in cutout
    cutout = data[self.bbox.slices]
TypeError: only integer scalar arrays can be converted to a scalar index
```