### PR TITLE
ds9 reader: scalar coordinates

### DIFF
--- a/regions/io/read_ds9.py
+++ b/regions/io/read_ds9.py
@@ -410,7 +410,7 @@ def line_parser(line, coordsys=None, errors='strict'):
             frame = coordinates.frame_transform_graph.lookup_name(coordsys_name_mapping[coordsys])
 
             lon, lat = zip(*parsed_angles)
-            if len(lon) == 1 and len(lat) == 1:
+            if hasattr(lon, '__len__') and hasattr(lon, '__lat__') and len(lon) == 1 and len(lat==1):
                 # force entries to be scalar if they are length-1
                 lon, lat = u.Quantity(lon[0]), u.Quantity(lat[0])
             else:


### PR DESCRIPTION
This is a minor fix to ds9 regions that forces regions with a single coordinate
(circle, point, etc.) to have scalar coordinates.

This will *also* fix the issue noted in #97