### PR TITLE
Make BoundingBox inputs integer

### DIFF
--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
+from astropy.io.fits.util import _is_int
 
 
 __all__ = ['BoundingBox']
@@ -53,6 +54,15 @@ class BoundingBox(object):
     """
 
     def __init__(self, ixmin, ixmax, iymin, iymax):
+        if not _is_int(ixmin):
+            raise TypeError('ixmin must be an integer')
+        if not _is_int(ixmax):
+            raise TypeError('ixmax must be an integer')
+        if not _is_int(iymin):
+            raise TypeError('iymin must be an integer')
+        if not _is_int(iymax):
+            raise TypeError('iymax must be an integer')
+
         if ixmin > ixmax:
             raise ValueError('ixmin must be <= ixmax')
         if iymin > iymax:

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -30,6 +30,23 @@ def test_bounding_box_init_minmax():
         BoundingBox(1, 100, 100, 1)
 
 
+def test_bounding_box_inputs():
+    with pytest.raises(TypeError):
+        BoundingBox([1], [10], [2], [9])
+    with pytest.raises(TypeError):
+        BoundingBox([1, 2], 10, 2, 9)
+    with pytest.raises(TypeError):
+        BoundingBox(1.0, 10.0, 2.0, 9.0)
+    with pytest.raises(TypeError):
+        BoundingBox(1.3, 10, 2, 9)
+    with pytest.raises(TypeError):
+        BoundingBox(1, 10.3, 2, 9)
+    with pytest.raises(TypeError):
+        BoundingBox(1, 10, 2.3, 9)
+    with pytest.raises(TypeError):
+        BoundingBox(1, 10, 2, 9.3)
+
+
 def test_bounding_box_from_float():
     # This is the example from the method docstring
     bbox = BoundingBox._from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)


### PR DESCRIPTION
This is a followup to #97 to ensure the inputs to `BoundingBox` are integer.

Note that `int()` is called on the inputs, which means floats will be silently truncated.  Do we also want to raise an exception for floats where e.g., ``int(ixmin) != ixmin``?