### PR TITLE
Centralize __repr__ and __str__ in base Region class

### DIFF
--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -34,18 +34,23 @@ class Region(object):
     """
 
     def __repr__(self):
-        params = []
-        for key, val in self._repr_params:
-            params.append('{0}={1}'.format(key, val))
-        params = ','.join(params)
+        if hasattr(self, 'center'):
+            params = [repr(self.center)]
+        else:
+            params = []
+        if self._repr_params is not None:
+            for key, val in self._repr_params:
+                params.append('{0}={1}'.format(key, val))
+        params = ', '.join(params)
 
-        return '<{0}({1}, {2})>'.format(self.__class__.__name__, self.center,
-                                        params)
+        return '<{0}({1})>'.format(self.__class__.__name__, params)
 
     def __str__(self):
-        cls_info = [('Region', self.__class__.__name__),
-                    ('center', self.center)]
-        cls_info += self._repr_params
+        cls_info = [('Region', self.__class__.__name__)]
+        if hasattr(self, 'center'):
+            cls_info.append(('center', self.center))
+        if self._repr_params is not None:
+            cls_info += self._repr_params
         fmt = ['{0}: {1}'.format(key, val) for key, val in cls_info]
 
         return '\n'.join(fmt)

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -33,6 +33,23 @@ class Region(object):
     Base class for all regions.
     """
 
+    def __repr__(self):
+        params = []
+        for key, val in self._repr_params:
+            params.append('{0}={1}'.format(key, val))
+        params = ','.join(params)
+
+        return '<{0}({1}, {2})>'.format(self.__class__.__name__, self.center,
+                                        params)
+
+    def __str__(self):
+        cls_info = [('Region', self.__class__.__name__),
+                    ('center', self.center)]
+        cls_info += self._repr_params
+        fmt = ['{0}: {1}'.format(key, val) for key, val in cls_info]
+
+        return '\n'.join(fmt)
+
     @abc.abstractmethod
     def intersection(self, other):
         """

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -36,15 +36,7 @@ class CirclePixelRegion(PixelRegion):
         self.radius = radius
         self.meta = meta or {}
         self.visual = visual or {}
-
-    def __repr__(self):
-        data = dict(
-            name=self.__class__.__name__,
-            center=self.center,
-            radius=self.radius,
-        )
-        fmt = '{name}\ncenter: {center}\nradius: {radius}'
-        return fmt.format(**data)
+        self._repr_params = [('radius', self.radius)]
 
     @property
     def area(self):
@@ -141,15 +133,7 @@ class CircleSkyRegion(SkyRegion):
         self.radius = radius
         self.meta = meta or {}
         self.visual = visual or {}
-
-    def __repr__(self):
-        data = dict(
-            name=self.__class__.__name__,
-            center=self.center,
-            radius=self.radius,
-        )
-        fmt = '{name}\ncenter: {center}\nradius: {radius}'
-        return fmt.format(**data)
+        self._repr_params = [('radius', self.radius)]
 
     @property
     def area(self):

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -61,17 +61,8 @@ class EllipsePixelRegion(PixelRegion):
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
-
-    def __repr__(self):
-        data = dict(
-            name=self.__class__.__name__,
-            center=self.center,
-            major=self.major,
-            minor=self.minor,
-            angle=self.angle,
-        )
-        fmt = '{name}\ncenter: {center}\nmajor: {major}\nminor: {minor}\nangle: {angle}'
-        return fmt.format(**data)
+        self._repr_params = [('major', self.major), ('minor', self.minor),
+                             ('angle', self.angle)]
 
     @property
     def area(self):
@@ -175,17 +166,8 @@ class EllipseSkyRegion(SkyRegion):
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
-
-    def __repr__(self):
-        data = dict(
-            name=self.__class__.__name__,
-            center=self.center,
-            major=self.major,
-            minor=self.minor,
-            angle=self.angle,
-        )
-        fmt = '{name}\ncenter: {center}\nmajor: {major}\nminor: {minor}\nangle: {angle}'
-        return fmt.format(**data)
+        self._repr_params = [('major', self.major), ('minor', self.minor),
+                             ('angle', self.angle)]
 
     @property
     def area(self):

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -20,14 +20,7 @@ class PointPixelRegion(PixelRegion):
         self.center = center
         self.meta = meta or {}
         self.visual = visual or {}
-
-    def __repr__(self):
-        data = dict(
-            name=self.__class__.__name__,
-            center=self.center,
-        )
-        fmt = '{name}\ncenter: {center}'
-        return fmt.format(**data)
+        self._repr_params = None
 
     @property
     def area(self):
@@ -72,14 +65,7 @@ class PointSkyRegion(SkyRegion):
         self.center = center
         self.meta = meta or {}
         self.visual = visual or {}
-
-    def __repr__(self):
-        data = dict(
-            name=self.__class__.__name__,
-            center=self.center,
-        )
-        fmt = '{name}\ncenter: {center}'
-        return fmt.format(**data)
+        self._repr_params = None
 
     @property
     def area(self):

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -28,14 +28,7 @@ class PolygonPixelRegion(PixelRegion):
         self.vertices = vertices
         self.meta = meta or {}
         self.visual = visual or {}
-
-    def __repr__(self):
-        data = dict(
-            name=self.__class__.__name__,
-            vertices=self.vertices,
-        )
-        fmt = '{name}\nvertices: {vertices}'
-        return fmt.format(**data)
+        self._repr_params = [('vertices', self.vertices)]
 
     @property
     def area(self):
@@ -124,14 +117,7 @@ class PolygonSkyRegion(SkyRegion):
         self.vertices = vertices
         self.meta = meta or {}
         self.visual = visual or {}
-
-    def __repr__(self):
-        data = dict(
-            name=self.__class__.__name__,
-            vertices=self.vertices,
-        )
-        fmt = '{name}\nvertices: {vertices}'
-        return fmt.format(**data)
+        self._repr_params = [('vertices', self.vertices)]
 
     @property
     def area(self):

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -62,17 +62,8 @@ class RectanglePixelRegion(PixelRegion):
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
-
-    def __repr__(self):
-        data = dict(
-            name=self.__class__.__name__,
-            center=self.center,
-            width=self.width,
-            height=self.height,
-            angle=self.angle,
-        )
-        fmt = '{name}\ncenter: {center}\nwidth: {width}\nheight: {height}\nangle: {angle}'
-        return fmt.format(**data)
+        self._repr_params = [('width', self.width), ('height', self.height),
+                             ('angle', self.angle)]
 
     @property
     def area(self):
@@ -195,17 +186,8 @@ class RectangleSkyRegion(SkyRegion):
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
-
-    def __repr__(self):
-        data = dict(
-            name=self.__class__.__name__,
-            center=self.center,
-            width=self.width,
-            height=self.height,
-            angle=self.angle,
-        )
-        fmt = '{name}\ncenter: {center}\nwidth: {width}\nheight: {height}\nangle: {angle}'
-        return fmt.format(**data)
+        self._repr_params = [('width', self.width), ('height', self.height),
+                             ('angle', self.angle)]
 
     @property
     def area(self):

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -18,9 +18,13 @@ class TestCirclePixelRegion:
         center = PixCoord(3, 4)
         self.reg = CirclePixelRegion(center, 2)
 
-    def test_str(self):
-        expected = 'CirclePixelRegion\ncenter: PixCoord(x=3, y=4)\nradius: 2'
-        assert str(self.reg) == expected
+    def test_repr_str(self):
+        reg_repr = '<CirclePixelRegion(PixCoord(x=3, y=4), radius=2)>'
+        assert repr(self.reg) == reg_repr
+
+        reg_str = ('Region: CirclePixelRegion\ncenter: PixCoord(x=3, y=4)\n'
+                   'radius: 2')
+        assert str(self.reg) == reg_str
 
     def test_to_mask(self):
         mask = self.reg.to_mask(mode='exact')
@@ -38,13 +42,22 @@ class TestCircleSkyRegion:
         center = SkyCoord(3 * u.deg, 4 * u.deg)
         self.reg = CircleSkyRegion(center, 2 * u.arcsec)
 
-    def test_str(self):
+    def test_repr_str(self):
         if ASTROPY_LT_13:
-            expected = 'CircleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>\nradius: 2.0 arcsec'
+            reg_repr = ('<CircleSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+                        'deg\n    (3.0, 4.0)>, radius=2.0 arcsec)>')
+            reg_str = ('Region: CircleSkyRegion\ncenter: <SkyCoord (ICRS): '
+                       '(ra, dec) in deg\n    (3.0, 4.0)>\nradius: 2.0 '
+                       'arcsec')
         else:
-            expected = 'CircleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    ( 3.,  4.)>\nradius: 2.0 arcsec'
+            reg_repr = ('<CircleSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+                        'deg\n    ( 3.,  4.)>, radius=2.0 arcsec)>')
+            reg_str = ('Region: CircleSkyRegion\ncenter: <SkyCoord (ICRS): '
+                       '(ra, dec) in deg\n    ( 3.,  4.)>\nradius: 2.0 '
+                       'arcsec')
 
-        assert str(self.reg) == expected
+        assert repr(self.reg) == reg_repr
+        assert str(self.reg) == reg_str
 
     def test_transformation(self):
         skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='galactic')

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -19,9 +19,14 @@ class TestEllipsePixelRegion:
             angle=5 * u.deg,
         )
 
-    def test_str(self):
-        expected = 'EllipsePixelRegion\ncenter: PixCoord(x=3, y=4)\nmajor: 4\nminor: 3\nangle: 5.0 deg'
-        assert str(self.reg) == expected
+    def test_repr_str(self):
+        reg_repr = ('<EllipsePixelRegion(PixCoord(x=3, y=4), major=4, minor=3'
+                    ', angle=5.0 deg)>')
+        assert repr(self.reg) == reg_repr
+
+        reg_str = ('Region: EllipsePixelRegion\ncenter: PixCoord(x=3, y=4)\n'
+                   'major: 4\nminor: 3\nangle: 5.0 deg')
+        assert str(self.reg) == reg_str
 
     @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def test_as_patch(self):
@@ -42,13 +47,21 @@ class TestEllipseSkyRegion:
             angle=5 * u.deg,
         )
 
-    def test_str(self):
-
+    def test_repr_str(self):
         if ASTROPY_LT_13:
-            expected = ('EllipseSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                        '    (3.0, 4.0)>\nmajor: 4.0 deg\nminor: 3.0 deg\nangle: 5.0 deg')
+            reg_repr = ('<EllipseSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+                        'deg\n    (3.0, 4.0)>, major=4.0 deg, minor=3.0 deg,'
+                        ' angle=5.0 deg)>')
+            reg_str = ('Region: EllipseSkyRegion\ncenter: <SkyCoord (ICRS): '
+                       '(ra, dec) in deg\n    (3.0, 4.0)>\nmajor: 4.0 deg\n'
+                       'minor: 3.0 deg\nangle: 5.0 deg')
         else:
-            expected = ('EllipseSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                        '    ( 3.,  4.)>\nmajor: 4.0 deg\nminor: 3.0 deg\nangle: 5.0 deg')
+            reg_repr = ('<EllipseSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+                        'deg\n    ( 3.,  4.)>, major=4.0 deg, minor=3.0 deg,'
+                        ' angle=5.0 deg)>')
+            reg_str = ('Region: EllipseSkyRegion\ncenter: <SkyCoord (ICRS): '
+                       '(ra, dec) in deg\n    ( 3.,  4.)>\nmajor: 4.0 deg\n'
+                       'minor: 3.0 deg\nangle: 5.0 deg')
 
-        assert str(self.reg) == expected
+        assert repr(self.reg) == reg_repr
+        assert str(self.reg) == reg_str

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -11,9 +11,12 @@ class TestPointPixelRegion:
         center = PixCoord(3, 4)
         self.reg = PointPixelRegion(center)
 
-    def test_str(self):
-        expected = 'PointPixelRegion\ncenter: PixCoord(x=3, y=4)'
-        assert str(self.reg) == expected
+    def test_repr_str(self):
+        reg_repr = '<PointPixelRegion(PixCoord(x=3, y=4))>'
+        assert repr(self.reg) == reg_repr
+
+        reg_str = 'Region: PointPixelRegion\ncenter: PixCoord(x=3, y=4)'
+        assert str(self.reg) == reg_str
 
 
 class TestPointSkyRegion:
@@ -21,11 +24,17 @@ class TestPointSkyRegion:
         center = SkyCoord(3, 4, unit='deg')
         self.reg = PointSkyRegion(center)
 
-    def test_str(self):
-
+    def test_repr_str(self):
         if ASTROPY_LT_13:
-            expected = 'PointSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    (3.0, 4.0)>'
+            reg_repr = ('<PointSkyRegion(<SkyCoord (ICRS): (ra, dec) in deg\n'
+                        '    (3.0, 4.0)>)>')
+            reg_str = ('Region: PointSkyRegion\ncenter: <SkyCoord (ICRS): '
+                       '(ra, dec) in deg\n    (3.0, 4.0)>')
         else:
-            expected = 'PointSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n    ( 3.,  4.)>'
+            reg_repr = ('<PointSkyRegion(<SkyCoord (ICRS): (ra, dec) in deg\n'
+                        '    ( 3.,  4.)>)>')
+            reg_str = ('Region: PointSkyRegion\ncenter: <SkyCoord (ICRS): '
+                       '(ra, dec) in deg\n    ( 3.,  4.)>')
 
-        assert str(self.reg) == expected
+        assert repr(self.reg) == reg_repr
+        assert str(self.reg) == reg_str

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -14,9 +14,14 @@ class TestPolygonPixelRegion:
         vertices = PixCoord([3, 4, 3], [3, 4, 4])
         self.poly = PolygonPixelRegion(vertices)
 
-    def test_str(self):
-        expected = 'PolygonPixelRegion\nvertices: PixCoord(x=[3 4 3], y=[3 4 4])'
-        assert str(self.poly) == expected
+    def test_repr_str(self):
+        reg_repr = ('<PolygonPixelRegion(vertices=PixCoord(x=[3 4 3], '
+                    'y=[3 4 4]))>')
+        assert repr(self.poly) == reg_repr
+
+        reg_str = ('Region: PolygonPixelRegion\nvertices: PixCoord(x=[3 4 3],'
+                   ' y=[3 4 4])')
+        assert str(self.poly) == reg_str
 
     def _test_basic(self):
         """
@@ -49,14 +54,24 @@ class TestPolygonSkyRegion:
         vertices = SkyCoord([3, 4, 3] * u.deg, [3, 4, 4] * u.deg)
         self.poly = PolygonSkyRegion(vertices)
 
-    def test_str(self):
+    def test_repr_str(self):
         if ASTROPY_LT_13:
-            expected = ('PolygonSkyRegion\nvertices: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                        '    [(3.0, 3.0), (4.0, 4.0), (3.0, 4.0)]>')
+            reg_repr = ('<PolygonSkyRegion(vertices=<SkyCoord (ICRS): (ra, '
+                        'dec) in deg\n    [(3.0, 3.0), (4.0, 4.0), (3.0, '
+                        '4.0)]>)>')
+            reg_str = ('Region: PolygonSkyRegion\nvertices: <SkyCoord (ICRS):'
+                       ' (ra, dec) in deg\n    [(3.0, 3.0), (4.0, 4.0), (3.0,'
+                       ' 4.0)]>')
         else:
-            expected = ('PolygonSkyRegion\nvertices: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                        '    [( 3.,  3.), ( 4.,  4.), ( 3.,  4.)]>')
-        assert str(self.poly) == expected
+            reg_repr = ('<PolygonSkyRegion(vertices=<SkyCoord (ICRS): (ra, '
+                        'dec) in deg\n    [( 3.,  3.), ( 4.,  4.), ( 3.,  '
+                        '4.)]>)>')
+            reg_str = ('Region: PolygonSkyRegion\nvertices: <SkyCoord (ICRS):'
+                       ' (ra, dec) in deg\n    [( 3.,  3.), ( 4.,  4.), ( 3.,'
+                       '  4.)]>')
+
+        assert repr(self.poly) == reg_repr
+        assert str(self.poly) == reg_str
 
     def _test_basic(self):
         """

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -19,9 +19,14 @@ class TestRectanglePixelRegion:
             angle=5 * u.deg,
         )
 
-    def test_str(self):
-        expected = 'RectanglePixelRegion\ncenter: PixCoord(x=3, y=4)\nwidth: 4\nheight: 3\nangle: 5.0 deg'
-        assert str(self.reg) == expected
+    def test_repr_str(self):
+        reg_repr = ('<RectanglePixelRegion(PixCoord(x=3, y=4), width=4, '
+                    'height=3, angle=5.0 deg)>')
+        assert repr(self.reg) == reg_repr
+
+        reg_str = ('Region: RectanglePixelRegion\ncenter: PixCoord(x=3, '
+                   'y=4)\nwidth: 4\nheight: 3\nangle: 5.0 deg')
+        assert str(self.reg) == reg_str
 
     @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def test_as_patch(self):
@@ -50,11 +55,21 @@ class TestRectangleSkyRegion:
             angle=5 * u.deg,
         )
 
-    def test_str(self):
+    def test_repr_str(self):
         if ASTROPY_LT_13:
-            expected = ('RectangleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                        '    (3.0, 4.0)>\nwidth: 4.0 deg\nheight: 3.0 deg\nangle: 5.0 deg')
+            reg_repr = ('<RectangleSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+                        'deg\n    (3.0, 4.0)>, width=4.0 deg, height=3.0 '
+                        'deg, angle=5.0 deg)>')
+            reg_str = ('Region: RectangleSkyRegion\ncenter: <SkyCoord '
+                       '(ICRS): (ra, dec) in deg\n    (3.0, 4.0)>\nwidth: '
+                       '4.0 deg\nheight: 3.0 deg\nangle: 5.0 deg')
         else:
-            expected = ('RectangleSkyRegion\ncenter: <SkyCoord (ICRS): (ra, dec) in deg\n'
-                        '    ( 3.,  4.)>\nwidth: 4.0 deg\nheight: 3.0 deg\nangle: 5.0 deg')
-        assert str(self.reg) == expected
+            reg_repr = ('<RectangleSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+                        'deg\n    ( 3.,  4.)>, width=4.0 deg, height=3.0 '
+                        'deg, angle=5.0 deg)>')
+            reg_str = ('Region: RectangleSkyRegion\ncenter: <SkyCoord '
+                       '(ICRS): (ra, dec) in deg\n    ( 3.,  4.)>\nwidth: '
+                       '4.0 deg\nheight: 3.0 deg\nangle: 5.0 deg')
+
+        assert repr(self.reg) == reg_repr
+        assert str(self.reg) == reg_str


### PR DESCRIPTION
The PR also defines separate `__repr__` and `__str__`.

Example:

```python
>>> from regions import PixCoord, EllipsePixelRegion
>>> cen  = PixCoord(10, 20)
>>> reg = EllipsePixelRegion(cen, major=5., minor=3., angle=45.)
>>> reg
<EllipsePixelRegion(PixCoord(x=10, y=20), major=5.0, minor=3.0, angle=45.0)>

>>> print(reg)
Region: EllipsePixelRegion
center: PixCoord(x=10, y=20)
major: 5.0
minor: 3.0
angle: 45.0
```