### PR TITLE
Fix ds9 metadata parsing: locals override globals

### DIFF
--- a/regions/io/read_ds9.py
+++ b/regions/io/read_ds9.py
@@ -509,7 +509,7 @@ def meta_parser(meta_str):
     sometimes the values can also be whitespace separated.
     """
     meta_token_split = [x for x in meta_token.split(meta_str.strip()) if x]
-    equals_inds = [i for i, x in enumerate(meta_token_split) if x is '=']
+    equals_inds = [i for i, x in enumerate(meta_token_split) if x == '=']
     result = {meta_token_split[ii - 1]:
               " ".join(meta_token_split[ii + 1:jj - 1 if jj is not None else None])
               for ii, jj in zip(equals_inds, equals_inds[1:] + [None])}

--- a/regions/io/read_ds9.py
+++ b/regions/io/read_ds9.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import string
 import itertools
 import re
+import copy
 from astropy import units as u
 from astropy import coordinates
 from astropy.coordinates import BaseCoordinateFrame
@@ -301,8 +302,10 @@ def ds9_string_to_region_list(region_string, errors='strict'):
                 # set some global metadata from the 'global' header
                 _, global_meta = parsed
             elif parsed:
-                region_type, coordlist, meta, composite, include = parsed
-                meta.update(global_meta)
+                # local meta must override global meta
+                meta = copy.copy(global_meta)
+                region_type, coordlist, meta_, composite, include = parsed
+                meta.update(meta_)
                 meta['include'] = include
                 log.debug("Region type = {0}.  Composite={1}"
                           .format(region_type, composite))

--- a/regions/io/read_ds9.py
+++ b/regions/io/read_ds9.py
@@ -508,7 +508,7 @@ def meta_parser(meta_str):
     meta_token_split = [x for x in meta_token.split(meta_str.strip()) if x]
     equals_inds = [i for i, x in enumerate(meta_token_split) if x is '=']
     result = {meta_token_split[ii - 1]:
-                  " ".join(meta_token_split[ii + 1:jj - 1 if jj is not None else None])
+              " ".join(meta_token_split[ii + 1:jj - 1 if jj is not None else None])
               for ii, jj in zip(equals_inds, equals_inds[1:] + [None])}
 
     return result

--- a/regions/io/tests/test_ds9_language.py
+++ b/regions/io/tests/test_ds9_language.py
@@ -164,3 +164,11 @@ def test_global_parser():
                                 'select': '1',
                                 'fixed': '0', 'width': '1', 'edit': '1',
                                 'delete': '1'}
+
+def test_ds9_color():
+    """Color parsing test"""
+    ds9_str = '# Region file format: DS9 astropy/regions\nfk5\ncircle(42.0000,43.0000,3.0000) # color=green\ncircle(43.0000,43.0000,3.0000) # color=orange\n'
+    regions = ds9_string_to_objects(ds9_str)
+
+    assert regions[0].visual['color'] == 'green'
+    assert regions[1].visual['color'] == 'orange'

--- a/regions/io/tests/test_ds9_language.py
+++ b/regions/io/tests/test_ds9_language.py
@@ -172,3 +172,21 @@ def test_ds9_color():
 
     assert regions[0].visual['color'] == 'green'
     assert regions[1].visual['color'] == 'orange'
+
+def test_ds9_color_override_global():
+    """Color parsing test in the presence of a global"""
+    global_test_str = str('global color=blue dashlist=8 3 width=1'
+                          ' font="helvetica 10 normal roman" select=1'
+                          ' highlite=1 dash=0 fixed=0 edit=1 move=1'
+                          ' delete=1 include=1 source=1')
+
+    ds9_str = '# Region file format: DS9 astropy/regions\n{global_str}\nfk5\n'
+    reg1str = "circle(42.0000,43.0000,3.0000) # color=green"
+    reg2str = "circle(43.0000,43.0000,3.0000) # color=orange"
+    reg3str = "circle(43.0000,43.0000,3.0000)"
+    ds9_str = ds9_str.format(global_str=global_test_str) + "\n".join([reg1str, reg2str, reg3str])
+    regions = ds9_string_to_objects(ds9_str)
+
+    assert regions[0].visual['color'] == 'green'
+    assert regions[1].visual['color'] == 'orange'
+    assert regions[2].visual['color'] == 'blue'


### PR DESCRIPTION
Previously, globals were incorrectly overriding locally specified metadata (color, linestyle, etc)