### PR TITLE
Fix BoundingBox from_float() upper bounds

### DIFF
--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -116,9 +116,9 @@ class BoundingBox(object):
         """
 
         ixmin = int(np.floor(xmin + 0.5))
-        ixmax = int(np.floor(xmax + 1.5))
+        ixmax = int(np.ceil(xmax + 0.5))
         iymin = int(np.floor(ymin + 0.5))
-        iymax = int(np.floor(ymax + 1.5))
+        iymax = int(np.ceil(ymax + 0.5))
 
         return cls(ixmin, ixmax, iymin, iymax)
 

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -74,7 +74,7 @@ class BoundingBox(object):
         self.iymax = iymax
 
     @classmethod
-    def _from_float(cls, xmin, xmax, ymin, ymax):
+    def from_float(cls, xmin, xmax, ymin, ymax):
         """
         Return the smallest bounding box that fully contains a given
         rectangle defined by float coordinate values.
@@ -108,10 +108,10 @@ class BoundingBox(object):
         Examples
         --------
         >>> from regions import BoundingBox
-        >>> BoundingBox._from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
+        >>> BoundingBox.from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
         BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=21)
 
-        >>> BoundingBox._from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
+        >>> BoundingBox.from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
         BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
         """
 

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -49,10 +49,10 @@ def test_bounding_box_inputs():
 
 def test_bounding_box_from_float():
     # This is the example from the method docstring
-    bbox = BoundingBox._from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
+    bbox = BoundingBox.from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
     assert bbox == BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=21)
 
-    bbox = BoundingBox._from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
+    bbox = BoundingBox.from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
     assert bbox == BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
 
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -74,7 +74,7 @@ class CirclePixelRegion(PixelRegion):
         ymin = self.center.y - self.radius
         ymax = self.center.y + self.radius
 
-        return BoundingBox._from_float(xmin, xmax, ymin, ymax)
+        return BoundingBox.from_float(xmin, xmax, ymin, ymax)
 
     def to_mask(self, mode='center', subpixels=1):
 

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -92,7 +92,7 @@ class EllipsePixelRegion(PixelRegion):
         ymin = self.center.y - max(self.major, self.minor)
         ymax = self.center.y + max(self.major, self.minor)
 
-        return BoundingBox._from_float(xmin, xmax, ymin, ymax)
+        return BoundingBox.from_float(xmin, xmax, ymin, ymax)
 
     def to_mask(self, mode='center', subpixels=5):
 

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -60,7 +60,7 @@ class PolygonPixelRegion(PixelRegion):
         xmax = self.vertices.x.max()
         ymin = self.vertices.y.min()
         ymax = self.vertices.y.max()
-        return BoundingBox._from_float(xmin, xmax, ymin, ymax)
+        return BoundingBox.from_float(xmin, xmax, ymin, ymax)
 
     def to_mask(self, mode='center', subpixels=5):
 

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -95,7 +95,7 @@ class RectanglePixelRegion(PixelRegion):
         ymin = self.center.y - radius
         ymax = self.center.y + radius
 
-        return BoundingBox._from_float(xmin, xmax, ymin, ymax)
+        return BoundingBox.from_float(xmin, xmax, ymin, ymax)
 
     def to_mask(self, mode='center', subpixels=5):
 


### PR DESCRIPTION
This is yet another fix for `BoundingBox.from_float()`.  In the case where the upper bound is at the pixel edge (e.g. xmax=2.5), the code was effectively rounding *up* and then adding 1.  In those cases, the bounding box upper bound is too large by one pixel.

In other words, the lower and upper bounds were treating x.5 pixel inputs the same (rounding the same way).  But because these represent boundaries, we want them to "round inward".

Example:
```python
from regions.core import PixCoord
from regions.shapes.circle import CirclePixelRegion
center = PixCoord(25.0, 25.0)
reg = CirclePixelRegion(center, 4.5)    # NOTE the half-pixel radius here
mask = reg.to_mask(mode='exact')
plt.imshow(mask)
```

New:
![bbox_new](https://cloud.githubusercontent.com/assets/4992897/22529757/a952161c-e8a6-11e6-9af3-116fd4596bf4.png)

Old:
![bbox_old](https://cloud.githubusercontent.com/assets/4992897/22529765/ae8a7962-e8a6-11e6-80c6-9264c02e3e58.png)
