### PR TITLE
Improve pixel region contains imlementation and tests

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -29,6 +29,8 @@ Some functions for region-based calculations (e.g. filtering a table of sky or
 pixel positions) as well as functions for region serialisation (e.g. to and from
 ds9 region string format) are available.
 
+.. _gs-ds:
+
 Dataset
 =======
 
@@ -112,16 +114,28 @@ forth between sky and pixel coordinates:
 This is an object-oriented thin wrapper around the functionality provided by `~astropy.wcs.WCS`
 and `astropy.wcs.utils`.
 
-Just like for `~astropy.coordinates.SkyCoord`, it is possible to use `~regions.PixCoord` objects
-to represent arrays of pixel coordinates:
+It is possible to create `~astropy.coordinates.SkyCoord` and `~regions.PixCoord` objects
+that represent arrays of pixel coordinates, and operations like transforming between sky-
+and pixel or region containment checks work as expected (i.e. return arrays of the same
+shape as the inputs, and perform operations on array entries independently.
 
 .. code-block:: python
 
+    # One-dimensional array of pixel coordinates
     >>> pixcoord = PixCoord(x=[0, 1], y=[2, 3])
     >>> pixcoord
     PixCoord(x=[0 1], y=[2 3])
-    >>> pixcoord.isscalar
-    False
+
+    # Two-dimensional array pixel coordinates:
+    >>> pixcoord = PixCoord(
+    ...     x=[[1, 2, 3], [4, 5, 6]],
+    ...     y=[[11, 12, 13], [14, 15, 16]]
+    ... )
+    >>> print(pixcoord)
+    PixCoord(x=[[1 2 3]
+     [4 5 6]], y=[[11 12 13]
+     [14 15 16]])
+
 
 To represent angles both on the sky and in an image, `~astropy.coordinates.Angle` objects
 or `~astropy.units.Quantity` objects with angular units can be used.
@@ -815,6 +829,8 @@ expose the intermediate "region list", which contains the extra attributes.
     and stored as region data members. These need to be documented and tests added,
     or removed.
 
+.. _gs-mpl:
+
 Matplotlib plotting
 ===================
 
@@ -871,6 +887,7 @@ after the polygon region classes are developed.
 
 An example of how to plot sky regions on a sky image is shown above.
 
+.. _gs-what-next:
 
 What next?
 ==========

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -72,10 +72,47 @@ class PixCoord(object):
         else:
             return np.array(val)
 
+    @staticmethod
+    def _validate(val, name, expected='any'):
+        """Validate that a given object is an appropriate `PixCoord`.
+
+        This is used for input validation throughout the regions package,
+        especially in the `__init__` method of pixel region classes.
+
+        Parameters
+        ----------
+        val : `PixCoord`
+            The object to check
+        name : str
+            Parameter name (used for error messages)
+        expected : {'any', 'scalar', 'not scalar'}
+            What kind of PixCoord to check for
+
+        Returns
+        -------
+        val : `PixCoord`
+            The input object (at the moment unmodified, might do fix-ups here later)
+        """
+        if not isinstance(val, PixCoord):
+            raise TypeError('{} must be a PixCoord'.format(name))
+
+        if expected == 'any':
+            pass
+        elif expected == 'scalar':
+            if not val.isscalar:
+                raise ValueError('{} must be a scalar PixCoord'.format(name))
+        elif expected == 'not scalar':
+            if val.isscalar:
+                raise ValueError('{} must be a non-scalar PixCoord'.format(name))
+        else:
+            raise ValueError('Invalid argument for `expected`: {}'.format(expected))
+
+        return val
+
     @property
     def isscalar(self):
         """Is this pixcoord a scalar? (a bool property)"""
-        return np.isscalar(self.x)
+        return np.isscalar(self.x) and np.isscalar(self.y)
 
     def __repr__(self):
         data = dict(name=self.__class__.__name__, x=self.x, y=self.y)

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -13,17 +13,11 @@ class PixCoord(object):
 
     This class can represent scalar or array pixel coordinates.
 
-    TODO: see examples below and / or in high-level docs section.
-
     The data members are either numbers or Numpy arrays
     (not `~astropy.units.Quantity` objects with unit "pixel").
 
     Given a `astropy.wcs.WCS` object, it can be transformed to and from a
     `~astropy.coordinates.SkyCoord` object.
-
-    TODO: 2-dim or n-dim arrays of pixel coordinates are not supported yet.
-    Having those would be very useful, e.g. for arrays of pixel coordinates in
-    a 2-dim image.
 
     Parameters
     ----------
@@ -34,23 +28,8 @@ class PixCoord(object):
 
     Examples
     --------
-    >>> from regions import PixCoord
 
-    Scalar pixel coordinate:
-
-    >>> pixcoord = PixCoord(x=1, y=11)
-    >>> print(pixcoord)
-    PixCoord
-    x : 1
-    y : 11
-
-    Array pixel coordinates:
-
-    >>> pixcoord = PixCoord(x=[1, 2], y=[11, 12])
-    >>> print(pixcoord)
-    PixCoord
-    x : [1 2]
-    y : [11 12]
+    Usage examples are provided in the :ref:`gs-coord` section of the docs.
     """
 
     def __init__(self, x, y):
@@ -166,7 +145,7 @@ class PixCoord(object):
         """Convert this coord object to a `shapely.geometry.Point` object.
         """
         if not self.isscalar:
-            raise TypeError('Scalar PixCoord cannot be converted to Shapely.')
+            raise TypeError('Non-scalar PixCoord cannot be converted to Shapely.')
 
         from shapely.geometry import Point
         return Point(self.x, self.y)

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 from astropy.tests.helper import pytest
 from ..._utils.examples import make_example_dataset
@@ -20,7 +21,7 @@ def wcs():
     return dataset.wcs
 
 
-def test_pixcoord_scalar_basics():
+def test_pixcoord_basics_scalar():
     p = PixCoord(x=1, y=2)
 
     assert p.x == 1
@@ -38,7 +39,7 @@ def test_pixcoord_scalar_basics():
         p[0]
 
 
-def test_pixcoord_array_basics():
+def test_pixcoord_basics_array_1d():
     p = PixCoord(x=[1, 2, 3], y=[11, 22, 33])
 
     assert_equal(p.x, [1, 2, 3])
@@ -68,7 +69,30 @@ def test_pixcoord_array_basics():
     assert_equal(p4.y, [22, 33])
 
 
-def test_pixcoord_scalar_sky(wcs):
+def test_pixcoord_basics_array_2d():
+    p = PixCoord(
+        [[1, 2, 3], [4, 5, 6]],
+        [[11, 12, 13], [14, 15, 16]],
+    )
+
+    assert_equal(p.x, [[1, 2, 3], [4, 5, 6]])
+    assert_equal(p.y, [[11, 12, 13], [14, 15, 16]])
+
+    assert p.isscalar is False
+
+    # TODO: this repr with the newline isn't nice ... improve it somehow?
+    expected = ('PixCoord(x=[[1 2 3]\n [4 5 6]], '
+                'y=[[11 12 13]\n [14 15 16]])')
+    assert str(p) == expected
+    assert repr(p) == expected
+
+    assert len(p) == 2
+
+    # TODO: does `__iter__` and `__getitem__` make sense for 2d array case?
+    # (see tests above)
+
+
+def test_pixcoord_to_sky_scalar(wcs):
     p = PixCoord(x=18, y=9)
 
     s = p.to_sky(wcs=wcs)
@@ -77,11 +101,19 @@ def test_pixcoord_scalar_sky(wcs):
     assert_allclose(s.data.lat.deg, 10.003028030623508)
 
     p2 = PixCoord.from_sky(skycoord=s, wcs=wcs)
-    assert_allclose(p2.x, 18)
-    assert_allclose(p2.y, 9)
+    # This is what comes out for `x` and `y` at the moment:
+    # a 0-dim Numpy array with one number.
+    # As explained here, `np.isscalar(np.array(42))` is `False`:
+    # http://stackoverflow.com/questions/773030/why-are-0d-arrays-in-numpy-not-considered-scalar
+    assert isinstance(p2.x, np.ndarray)
+    assert p2.x.shape == tuple()
+    assert p2.x.ndim == 0
+    assert not p2.isscalar
+    assert_allclose(p2.x, p.x)
+    assert_allclose(p2.y, p.y)
 
 
-def test_pixcoord_array_sky(wcs):
+def test_pixcoord_to_sky_array_1d(wcs):
     p = PixCoord(x=[17, 18], y=[8, 9])
 
     s = p.to_sky(wcs=wcs)
@@ -90,26 +122,57 @@ def test_pixcoord_array_sky(wcs):
     assert_allclose(s.data.lat.deg, [0, 10.003028])
 
     p2 = PixCoord.from_sky(skycoord=s, wcs=wcs)
-    assert_allclose(p2.x, [17, 18])
-    assert_allclose(p2.y, [8, 9])
+    assert isinstance(p2.x, np.ndarray)
+    assert p2.x.shape == (2, )
+    assert not p2.isscalar
+    assert_allclose(p2.x, p.x)
+    assert_allclose(p2.y, p.y)
 
 
-def test_pixcoord_separation():
-    # check scalar
+def test_pixcoord_to_sky_array_2d(wcs):
+    # p = PixCoord(x=[[17, 17, 17], [18, 18, 18]], y=[[8, 8, 8], [9, 9, 9]])
+    p = PixCoord(x=[[17, 18]], y=[[8, 9]])
+
+    s = p.to_sky(wcs=wcs)
+    assert s.name == 'galactic'
+    # assert_allclose(s.data.lon.deg, [[0, 0, 0], [349.88094, 349.88094, 349.88094]])
+    # assert_allclose(s.data.lat.deg, [[0, 0, 0], [10.003028, 10.003028, 10.003028]])
+    assert_allclose(s.data.lon.deg, [[0, 349.88094]])
+    assert_allclose(s.data.lat.deg, [[0, 10.003028]])
+
+    p2 = PixCoord.from_sky(skycoord=s, wcs=wcs)
+    assert isinstance(p2.x, np.ndarray)
+    assert p2.x.shape == (1, 2)
+    assert not p2.isscalar
+    assert_allclose(p2.x, p.x)
+    assert_allclose(p2.y, p.y)
+
+
+def test_pixcoord_separation_scalar():
     p1 = PixCoord(x=1, y=2)
     p2 = PixCoord(x=4, y=6)
     sep = p1.separation(p2)
     assert_allclose(sep, 5)
 
-    # check array
+
+def test_pixcoord_separation_array_1d():
     p1 = PixCoord(x=[1, 1], y=[2, 2])
     p2 = PixCoord(x=[4, 4], y=[6, 6])
     sep = p1.separation(p2)
     assert_allclose(sep, [5, 5])
 
 
+def test_pixcoord_separation_array_2d():
+    p1 = PixCoord(x=[[1, 1]], y=[[2, 2]])
+    p2 = PixCoord(x=[[4, 4]], y=[[6, 6]])
+    sep = p1.separation(p2)
+    assert isinstance(sep, np.ndarray)
+    assert sep.shape == (1, 2)
+    assert_allclose(sep, [[5, 5]])
+
+
 @pytest.mark.skipif('not HAS_SHAPELY')
-def test_pixcoord_shapely():
+def test_pixcoord_shapely_scalar():
     from shapely.geometry.point import Point
     p = PixCoord(x=1, y=2)
     s = p.to_shapely()
@@ -121,6 +184,9 @@ def test_pixcoord_shapely():
     assert p2.x == 1
     assert p2.y == 2
 
+
+@pytest.mark.skipif('not HAS_SHAPELY')
+def test_pixcoord_shapely_array():
     p = PixCoord(x=[1, 2, 3], y=[11, 22, 33])
     with pytest.raises(TypeError):
         p.to_shapely()

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -37,7 +37,7 @@ class PointPixelRegion(PixelRegion):
         raise NotImplementedError
 
     @property
-    def bounding_box(self, mode='center'):
+    def bounding_box(self):
         # TODO: needs to be implemented
         raise NotImplementedError
 

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 
-from astropy.wcs.utils import skycoord_to_pixel
+from astropy.wcs.utils import skycoord_to_pixel, pixel_to_skycoord
 
 from ..core import PixelRegion, SkyRegion, Mask, BoundingBox, PixCoord
 from .._geometry import polygonal_overlap_grid
@@ -50,8 +50,13 @@ class PolygonPixelRegion(PixelRegion):
         raise NotImplementedError
 
     def to_sky(self, wcs, mode='local', tolerance=None):
-        # TODO: needs to be implemented
-        raise NotImplementedError
+        if mode != 'local':
+            raise NotImplementedError
+        if tolerance is not None:
+            raise NotImplementedError
+
+        vertices_sky = pixel_to_skycoord(self.vertices.x, self.vertices.y, wcs)
+        return PolygonSkyRegion(vertices=vertices_sky)
 
     @property
     def bounding_box(self):
@@ -130,11 +135,11 @@ class PolygonSkyRegion(SkyRegion):
         raise NotImplementedError
 
     def to_pixel(self, wcs, mode='local', tolerance=None):
+        if mode != 'local':
+            raise NotImplementedError
+        if tolerance is not None:
+            raise NotImplementedError
 
-        if mode == 'local':
-            x, y = skycoord_to_pixel(self.vertices, wcs)
-            vertices_pix = PixCoord(x, y)
-            return PolygonPixelRegion(vertices_pix)
-        else:
-
-            raise NotImplementedError()
+        x, y = skycoord_to_pixel(self.vertices, wcs)
+        vertices_pix = PixCoord(x, y)
+        return PolygonPixelRegion(vertices_pix)

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -69,6 +69,11 @@ class PolygonPixelRegion(PixelRegion):
             mode = 'subpixels'
             subpixels = 1
 
+        if mode == 'subpixels':
+            use_exact = 0
+        else:
+            use_exact = 1
+
         # Find bounding box and mask size
         bbox = self.bounding_box
         ny, nx = bbox.shape
@@ -79,16 +84,13 @@ class PolygonPixelRegion(PixelRegion):
         ymin = float(bbox.iymin) - 0.5
         ymax = float(bbox.iymax) - 0.5
 
-        if mode == 'subpixels':
-            use_exact = 0
-        else:
-            use_exact = 1
+        vx = np.asarray(self.vertices.x, dtype=float)
+        vy = np.asarray(self.vertices.y, dtype=float)
 
         fraction = polygonal_overlap_grid(
-            xmin, xmax, ymin, ymax, nx, ny,
-            self.vertices.x.astype(float),
-            self.vertices.y.astype(float),
-            use_exact, subpixels)
+            xmin, xmax, ymin, ymax,
+            nx, ny, vx, vy, use_exact, subpixels,
+        )
 
         return Mask(fraction, bbox=bbox)
 

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -24,8 +24,7 @@ class PolygonPixelRegion(PixelRegion):
     """
 
     def __init__(self, vertices, meta=None, visual=None):
-        # TODO: test that vertices is a 1D PixCoord
-        self.vertices = vertices
+        self.vertices = PixCoord._validate(vertices, name='vertices', expected='not scalar')
         self.meta = meta or {}
         self.visual = visual or {}
         self._repr_params = [('vertices', self.vertices)]
@@ -36,15 +35,12 @@ class PolygonPixelRegion(PixelRegion):
         raise NotImplementedError
 
     def contains(self, pixcoord):
-        if pixcoord.isscalar:
-            x = np.array([pixcoord.x], dtype=float)
-            y = np.array([pixcoord.y], dtype=float)
-        else:
-            x = pixcoord.x.astype(float)
-            y = pixcoord.y.astype(float)
-        return points_in_polygon(x, y,
-                                 self.vertices.x.astype(float),
-                                 self.vertices.y.astype(float)).astype(bool)
+        pixcoord = PixCoord._validate(pixcoord, 'pixcoord')
+        x = np.atleast_1d(np.asarray(pixcoord.x, dtype=float))
+        y = np.atleast_1d(np.asarray(pixcoord.y, dtype=float))
+        vx = np.asarray(self.vertices.x, dtype=float)
+        vy = np.asarray(self.vertices.y, dtype=float)
+        return points_in_polygon(x, y, vx, vy).astype(bool)
 
     def to_shapely(self):
         # TODO: needs to be implemented

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -40,7 +40,10 @@ class PolygonPixelRegion(PixelRegion):
         y = np.atleast_1d(np.asarray(pixcoord.y, dtype=float))
         vx = np.asarray(self.vertices.x, dtype=float)
         vy = np.asarray(self.vertices.y, dtype=float)
-        return points_in_polygon(x, y, vx, vy).astype(bool)
+
+        shape = x.shape
+        mask = points_in_polygon(x.flatten(), y.flatten(), vx, vy).astype(bool)
+        return mask.reshape(shape)
 
     def to_shapely(self):
         # TODO: needs to be implemented

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -54,7 +54,7 @@ class PolygonPixelRegion(PixelRegion):
         raise NotImplementedError
 
     @property
-    def bounding_box(self, mode='center'):
+    def bounding_box(self):
         xmin = self.vertices.x.min()
         xmax = self.vertices.x.max()
         ymin = self.vertices.y.min()

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -6,11 +6,18 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.utils.data import get_pkg_data_filename
-from astropy.io.fits import getheader
+from astropy.io import fits
 from astropy.wcs import WCS
 from ...core import PixCoord
 from ..circle import CirclePixelRegion, CircleSkyRegion
 from .utils import ASTROPY_LT_13, HAS_MATPLOTLIB
+
+
+@pytest.fixture(scope='session')
+def wcs():
+    filename = get_pkg_data_filename('data/example_header.fits')
+    header = fits.getheader(filename)
+    return WCS(header)
 
 
 class TestCirclePixelRegion:
@@ -87,13 +94,9 @@ class TestCircleSkyRegion:
         assert repr(self.reg) == reg_repr
         assert str(self.reg) == reg_str
 
-    def test_transformation(self):
+    def test_transformation(self, wcs):
         skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='galactic')
         skycircle = CircleSkyRegion(skycoord, 2 * u.arcsec)
-
-        headerfile = get_pkg_data_filename('data/example_header.fits')
-        h = getheader(headerfile)
-        wcs = WCS(h)
 
         pixcircle = skycircle.to_pixel(wcs)
 

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -44,7 +44,7 @@ class TestPolygonPixelRegion:
         pixcoord = PixCoord([1, 1], [1, 2])
         actual = self.reg.contains(pixcoord)
         expected = [True, False]
-        assert_equal(result, )
+        assert_equal(actual, expected)
 
         with pytest.raises(ValueError) as exc:
             pixcoord in self.reg
@@ -58,25 +58,6 @@ class TestPolygonPixelRegion:
         actual = self.reg.contains(pixcoord)
         expected = [[True, True, True], [False, False, False]]
         assert_equal(actual, expected)
-
-    def _test_basic(self):
-        poly1 = PolygonPixelRegion(([10, 20, 20, 10, 10], [20, 20, 10, 10, 20]))
-
-        poly2 = PolygonPixelRegion(([15, 25, 25, 15, 15], [23, 23, 13, 13, 23]))
-
-        # assert_allclose(poly1.area, 100)
-        # assert_allclose(poly2.area, 100)
-
-        assert PixCoord(13, 12) in poly1
-        assert not PixCoord(13, 12) in poly2
-
-        coords = PixCoord([13, 8], [15, 15])
-        assert_equal(poly1.contains(coords), [False, True])
-
-        # poly3 = poly1.union(poly2)
-        # poly4 = poly1.intersection(poly2)
-        # assert_allclose(poly3.area, 165)
-        # assert_allclose(poly4.area, 35)
 
 
 class TestPolygonSkyRegion:
@@ -102,27 +83,3 @@ class TestPolygonSkyRegion:
 
         assert repr(self.poly) == reg_repr
         assert str(self.poly) == reg_str
-
-    def _test_basic(self):
-        """
-        TODO: implement these tests!
-
-        Just make sure that things don't crash, but no test of numerical accuracy
-        """
-
-        coords1 = SkyCoord([10, 20, 20, 10, 10] * u.deg, [20, 20, 10, 10, 20] * u.deg)
-        poly1 = PolygonSkyRegion(coords1)
-
-        coords1 = SkyCoord([15, 25, 25, 15, 15] * u.deg, [23, 23, 13, 13, 23] * u.deg)
-        poly2 = PolygonSkyRegion(coords1)
-
-        assert_quantity_allclose(poly1.area, 42 * u.sr)
-        assert_quantity_allclose(poly2.area, 42 * u.sr)
-
-        # TODO: test contains
-
-        poly3 = poly1.union(poly2)
-        poly4 = poly1.intersection(poly2)
-
-        assert_quantity_allclose(poly3.area, 42 * u.sr)
-        assert_quantity_allclose(poly4.area, 42 * u.sr)

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -44,14 +44,12 @@ class TestPolygonPixelRegion:
         pixcoord = PixCoord([1, 1], [1, 2])
         actual = self.reg.contains(pixcoord)
         expected = [True, False]
-        assert_equal(actual, expected)
+        assert_equal(result, )
 
         with pytest.raises(ValueError) as exc:
             pixcoord in self.reg
         assert 'coord must be scalar' in str(exc)
 
-    # TODO: fix implementation to work with 2D arrays
-    @pytest.mark.xfail
     def test_contains_array_2d(self):
         pixcoord = PixCoord(
             [[1, 1, 1], [1, 1, 1]],

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -11,31 +11,63 @@ from .utils import ASTROPY_LT_13
 
 class TestPolygonPixelRegion:
     def setup(self):
-        vertices = PixCoord([3, 4, 3], [3, 4, 4])
-        self.poly = PolygonPixelRegion(vertices)
+        # We will be using this polygon for basic tests:
+        #
+        # (3,0) *
+        #       |\
+        #       | \
+        #       |  \
+        # (0,0) *---* (2, 0)
+        #
+        vertices = PixCoord([0, 2, 0], [0, 0, 3])
+        self.reg = PolygonPixelRegion(vertices)
+        self.pixcoord_inside = PixCoord(1, 1)
+        self.pixcoord_outside = PixCoord(1, 2)
 
     def test_repr_str(self):
-        reg_repr = ('<PolygonPixelRegion(vertices=PixCoord(x=[3 4 3], '
-                    'y=[3 4 4]))>')
-        assert repr(self.poly) == reg_repr
+        reg_repr = ('<PolygonPixelRegion(vertices=PixCoord(x=[0 2 0], '
+                    'y=[0 0 3]))>')
+        assert repr(self.reg) == reg_repr
 
-        reg_str = ('Region: PolygonPixelRegion\nvertices: PixCoord(x=[3 4 3],'
-                   ' y=[3 4 4])')
-        assert str(self.poly) == reg_str
+        reg_str = ('Region: PolygonPixelRegion\nvertices: PixCoord(x=[0 2 0],'
+                   ' y=[0 0 3])')
+        assert str(self.reg) == reg_str
+
+    def test_contains_scalar(self):
+        assert self.reg.contains(self.pixcoord_inside)
+        assert self.pixcoord_inside in self.reg
+
+        assert not self.reg.contains(self.pixcoord_outside)
+        assert self.pixcoord_outside not in self.reg
+
+    def test_contains_array_1d(self):
+        pixcoord = PixCoord([1, 1], [1, 2])
+        actual = self.reg.contains(pixcoord)
+        expected = [True, False]
+        assert_equal(actual, expected)
+
+        with pytest.raises(ValueError) as exc:
+            pixcoord in self.reg
+        assert 'coord must be scalar' in str(exc)
+
+    # TODO: fix implementation to work with 2D arrays
+    @pytest.mark.xfail
+    def test_contains_array_2d(self):
+        pixcoord = PixCoord(
+            [[1, 1, 1], [1, 1, 1]],
+            [[1, 1, 1], [2, 2, 2]],
+        )
+        actual = self.reg.contains(pixcoord)
+        expected = [[True, True, True], [False, False, False]]
+        assert_equal(actual, expected)
 
     def _test_basic(self):
-        """
-        TODO: implement these tests!
-
-        Just make sure that things don't crash, but no test of numerical accuracy
-        """
-
         poly1 = PolygonPixelRegion(([10, 20, 20, 10, 10], [20, 20, 10, 10, 20]))
 
         poly2 = PolygonPixelRegion(([15, 25, 25, 15, 15], [23, 23, 13, 13, 23]))
 
-        assert_allclose(poly1.area, 100)
-        assert_allclose(poly2.area, 100)
+        # assert_allclose(poly1.area, 100)
+        # assert_allclose(poly2.area, 100)
 
         assert PixCoord(13, 12) in poly1
         assert not PixCoord(13, 12) in poly2


### PR DESCRIPTION
This pull requests contains some clean-up and tests for the pixel region contains implementation.
For now contains is only implemented for circle and polygon, and I'd like to leave the other regions to future PRs.

One thing I would like to fix here is to make polygon contains work with 2-dim PixCoord objects.
This is working for circles, and we're using this functionality in Gammapy here:
http://docs.gammapy.org/en/latest/_modules/gammapy/image/core.html#SkyImage.region_mask

@astrofrog @larrybradley - Do you have time to review this?

Any advice on how to make `PixelPolygonRegion.contains` work for 2-dim `pixcoord` inputs?
I could store the shape, flatten, call `points_in_polygon`, and reshape the output.
Or maybe `points_in_polygon` can be rewritten by just removing the `ndim=1` constraint, and make it work for any input arrays? (really it's a per-element computation, and the shape doesn't matter for the computation)

I'll start by adding unit tests for 2-dim PixCoord, and wait for your feedback on this point before changing `points_in_polygon`.
