### PR TITLE
Rename Mask.__init__ argument from mask to data?

### DIFF
--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -10,7 +10,7 @@ class Mask(object):
 
     Parameters
     ----------
-    mask : array_like
+    data : array_like
         A 2D array of a region mask representing the fractional overlap
         of the region on the pixel grid.  This should be the full-sized
         (i.e. not truncated) array that is the direct output of one of
@@ -25,24 +25,23 @@ class Mask(object):
     Usage examples are provided in the :ref:`gs-masks` section of the docs.
     """
 
-    def __init__(self, mask, bbox):
-        if mask.shape != bbox.shape:
-            raise ValueError("shape of mask and bounding box should match")
-        self.data = np.asanyarray(mask)
+    def __init__(self, data, bbox):
+        if data.shape != bbox.shape:
+            raise ValueError("Shape of data and bounding box should match")
+        self.data = np.asanyarray(data)
         self.bbox = bbox
 
     @property
     def shape(self):
         """
-        The shape of the mask array.
+        The shape of the mask data array.
         """
         return self.data.shape
 
     def __array__(self):
         """
-        Array representation of the mask array (e.g., for matplotlib).
+        Array representation of the mask data array (e.g., for matplotlib).
         """
-
         return self.data
 
     def _overlap_slices(self, shape):
@@ -77,7 +76,7 @@ class Mask(object):
         ymin = self.bbox.iymin
         ymax = self.bbox.iymax
 
-        if (xmin >= shape[1] or ymin >= shape[0] or xmax <= 0 or ymax <= 0):
+        if xmin >= shape[1] or ymin >= shape[0] or xmax <= 0 or ymax <= 0:
             # no overlap of the region with the data
             return None, None
 


### PR DESCRIPTION
Currently the Mask API docs look like this:
http://astropy-regions.readthedocs.io/en/latest/api/regions.Mask.html

Looking at that I was confused, because the argument in `__init__` is called `mask`, and it's not visible that it's stored under the attribute name `data`.

@astrofrog @larrybradley - How about renaming the argument to `data`?

What's the best way to make the attribute `data` appear in the API docs?
I think  an `Attributes` section in the class docstring is needed, or we need to make it a property?