### PR TITLE
Change PixCoord.isscalar to match SkyCoord behaviour

### DIFF
--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -91,7 +91,12 @@ class PixCoord(object):
     @property
     def isscalar(self):
         """Is this pixcoord a scalar? (a bool property)"""
-        return np.isscalar(self.x) and np.isscalar(self.y)
+        # TODO: what's the best solution to implement this?
+        # Maybe we should sub-class ShapedLikeNDArray?
+        # See https://github.com/astropy/regions/issues/108
+        # This is a temp solution that matches the bahaviour of SkyCoord
+        return np.asanyarray(self.x).shape == ()
+        # return np.isscalar(self.x) and np.isscalar(self.y)
 
     def __repr__(self):
         data = dict(name=self.__class__.__name__, x=self.x, y=self.y)

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -101,14 +101,10 @@ def test_pixcoord_to_sky_scalar(wcs):
     assert_allclose(s.data.lat.deg, 10.003028030623508)
 
     p2 = PixCoord.from_sky(skycoord=s, wcs=wcs)
-    # This is what comes out for `x` and `y` at the moment:
-    # a 0-dim Numpy array with one number.
-    # As explained here, `np.isscalar(np.array(42))` is `False`:
-    # http://stackoverflow.com/questions/773030/why-are-0d-arrays-in-numpy-not-considered-scalar
     assert isinstance(p2.x, np.ndarray)
     assert p2.x.shape == tuple()
     assert p2.x.ndim == 0
-    assert not p2.isscalar
+    assert p2.isscalar
     assert_allclose(p2.x, p.x)
     assert_allclose(p2.y, p.y)
 


### PR DESCRIPTION
This is a minimal change to the `PixCoord.isscalar` implementation, to make it's behaviour match the one from `SkyCoord.isscalar`.

I plan to merge this if CI tests pass, and then keep #108 open for discussion what the proper long-term solution here is.