### PR TITLE
Remove area abstract property from region base class

### DIFF
--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -134,12 +134,6 @@ class PixelRegion(Region):
             arrays. In future this could also be a `PixCoord` instance.
         """
 
-    @abc.abstractproperty
-    def area(self):
-        """
-        Returns the area of the region as a `~astropy.units.Quantity`.
-        """
-
     @abc.abstractmethod
     def to_sky(self, wcs, mode='local', tolerance=None):
         """
@@ -298,12 +292,6 @@ class SkyRegion(Region):
         ----------
         skycoord : `~astropy.coordinates.SkyCoord`
             The position or positions to check
-        """
-
-    @abc.abstractproperty
-    def area(self):
-        """
-        Returns the area of the region as a `~astropy.units.Quantity`.
         """
 
     @abc.abstractmethod

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -1,3 +1,5 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy import units as u
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -39,6 +39,7 @@ class CirclePixelRegion(PixelRegion):
 
     @property
     def area(self):
+        """Region area (float)."""
         return math.pi * self.radius ** 2
 
     def contains(self, pixcoord):
@@ -132,6 +133,7 @@ class CircleSkyRegion(SkyRegion):
 
     @property
     def area(self):
+        """Region area (`~astropy.units.Quantity`)"""
         return math.pi * self.radius ** 2
 
     def contains(self, skycoord):

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -66,6 +66,7 @@ class EllipsePixelRegion(PixelRegion):
 
     @property
     def area(self):
+        """Region area (float)"""
         return math.pi * self.major * self.minor
 
     def contains(self, pixcoord):
@@ -171,8 +172,8 @@ class EllipseSkyRegion(SkyRegion):
 
     @property
     def area(self):
-        # TODO: needs to be implemented
-        raise NotImplementedError
+        """Region sky area approximation (`~astropy.units.Quantity`)"""
+        return math.pi * self.major * self.minor
 
     def contains(self, skycoord):
         # TODO: needs to be implemented

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -22,10 +22,6 @@ class PointPixelRegion(PixelRegion):
         self.visual = visual or {}
         self._repr_params = None
 
-    @property
-    def area(self):
-        return 0
-
     def contains(self, pixcoord):
         return False
 
@@ -66,10 +62,6 @@ class PointSkyRegion(SkyRegion):
         self.meta = meta or {}
         self.visual = visual or {}
         self._repr_params = None
-
-    @property
-    def area(self):
-        return 0
 
     def contains(self, skycoord):
         return False

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -29,10 +29,11 @@ class PolygonPixelRegion(PixelRegion):
         self.visual = visual or {}
         self._repr_params = [('vertices', self.vertices)]
 
-    @property
-    def area(self):
-        # TODO: needs to be implemented
-        raise NotImplementedError
+    # # TODO: needs to be implemented
+    # @property
+    # def area(self):
+    #     """Region area (float)."""
+    #     raise NotImplementedError
 
     def contains(self, pixcoord):
         pixcoord = PixCoord._validate(pixcoord, 'pixcoord')
@@ -124,11 +125,6 @@ class PolygonSkyRegion(SkyRegion):
         self.meta = meta or {}
         self.visual = visual or {}
         self._repr_params = [('vertices', self.vertices)]
-
-    @property
-    def area(self):
-        # TODO: needs to be implemented
-        raise NotImplementedError
 
     def contains(self, skycoord):
         # TODO: needs to be implemented

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -67,6 +67,7 @@ class RectanglePixelRegion(PixelRegion):
 
     @property
     def area(self):
+        """Region area (float)"""
         return self.width * self.height
 
     def contains(self, pixcoord):
@@ -191,6 +192,7 @@ class RectangleSkyRegion(SkyRegion):
 
     @property
     def area(self):
+        """Region area (`~astropy.units.Quantity`)"""
         return self.width * self.height
 
     def contains(self, skycoord):

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -58,7 +58,7 @@ def test_pix_area(region):
     try:
         area = region.area
         assert not isinstance(area, u.Quantity)
-    except NotImplementedError:
+    except AttributeError:
         pytest.xfail()
 
 
@@ -104,7 +104,7 @@ def test_sky_area(region):
     try:
         area = region.area
         assert isinstance(area, u.Quantity)
-    except NotImplementedError:
+    except AttributeError:
         pytest.xfail()
 
 

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -27,7 +27,7 @@ PIXEL_REGIONS = [
 
 SKY_REGIONS = [
     CircleSkyRegion(ICRS(3 * u.deg, 4 * u.deg), radius=5 * u.deg),
-    EllipseSkyRegion(ICRS(3 * u.deg, 4 * u.deg), major=7, minor=5, angle=3 * u.deg),
+    EllipseSkyRegion(ICRS(3 * u.deg, 4 * u.deg), major=7 * u.deg, minor=5 * u.deg, angle=3 * u.deg),
     PolygonSkyRegion(ICRS([1, 4, 3] * u.deg, [2, 4, 4] * u.deg)),
     RectangleSkyRegion(ICRS(6 * u.deg, 5 * u.deg), width=3 * u.deg, height=5 * u.deg)
 ]


### PR DESCRIPTION
This PR is a first small step towards implementing the changes suggested in #107.

For now I'll just remove area abstract property from region base class, because that's the simplest change and (I hope) not controversial. I'll leave the more substantial changes to `contains`, `to_sky` and `to_pix` for later.