### PR TITLE
Add _repr_params to CompoundRegions

### DIFF
--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -14,6 +14,10 @@ class CompoundPixelRegion(PixelRegion):
         self.region1 = region1
         self.region2 = region2
         self.operator = operator
+        self._repr_params = [('component 1', self.region1),
+                             ('component 2', self.region2),
+                             ('operator', self.operator),
+                            ]
 
     def __contains__(self, pixcoord):
         raise NotImplementedError
@@ -40,6 +44,10 @@ class CompoundSkyRegion(SkyRegion):
         self.region1 = region1
         self.region2 = region2
         self.operator = operator
+        self._repr_params = [('component 1', self.region1),
+                             ('component 2', self.region2),
+                             ('operator', self.operator),
+                            ]
 
     def contains(self, skycoord):
         return self.operator(self.region1.contains(skycoord),

--- a/regions/core/tests/test_compound.py
+++ b/regions/core/tests/test_compound.py
@@ -43,3 +43,6 @@ def test_compound():
 
     diff = c1 ^ c2 ^ c3
     assert (diff.contains(coords) == [True, True, False, True]).all()
+
+
+    assert 'Compound' in str(union)


### PR DESCRIPTION
The ``__str__`` method of the compound sky and pixel region was broken, because it is implemented in the base class and calls into an attribute ``_repr_params`` which was not defined for the compound regions.