### PR TITLE
Fix incorrect region number counting in regions_pyregi…

### DIFF
--- a/dev/regions_pyregion_comparison.py
+++ b/dev/regions_pyregion_comparison.py
@@ -18,9 +18,12 @@ from regions import read_ds9, write_ds9, DS9RegionParserError
 import pyregion
 import timeit
 import numpy as np
+import re
 
 TEST_FILE_DIR = Path('../regions/io/tests/data')
 REPETITIONS = 1
+
+p_region_count = re.compile(r"[^=\)]\(")
 
 results = list()
 
@@ -31,7 +34,7 @@ for filename in TEST_FILE_DIR.glob('*.reg'):
     n_regions = 0
     with open(str(filename)) as origin_file:
         for line in origin_file:
-            n_regions += line.count("(")
+            n_regions += len(p_region_count.findall(line))
 
     # regions
     try:


### PR DESCRIPTION
in dev/regions_pyregion_comparison.py, the number of regions are calculated by counting the occurence of "(". This overestimates for the following cases

> panda(18:13:25.141,+31:21:31.32,51.8442,90.2623,1,0",4.995",1) # panda=(51.8442 90.2623 180.262 270.262)(0" 4.995" 9.99") text={Panda 2}

The patch only counts "(" not preceded by "=" or ")".
