### PR TITLE
Validate `center` to be PixCoord instance at region creation

### DIFF
--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -62,7 +62,7 @@ class EllipsePixelRegion(PixelRegion):
     def __init__(self, center, width, height, angle=0. * u.deg, meta=None,
                  visual=None):
         # TODO: use quantity_input to check that angle is an angle
-        self.center = center
+        self.center = PixCoord._validate(center, name='center', expected='scalar')
         self.width = width
         self.height = height
         self.angle = angle

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -20,8 +20,7 @@ class PointPixelRegion(PixelRegion):
     """
 
     def __init__(self, center, meta=None, visual=None):
-        # TODO: test that center is a 0D PixCoord
-        self.center = center
+        self.center = PixCoord._validate(center, name='center', expected='scalar')
         self.meta = meta or {}
         self.visual = visual or {}
         self._repr_params = None

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -60,7 +60,7 @@ class RectanglePixelRegion(PixelRegion):
 
     def __init__(self, center, width, height, angle=0 * u.deg, meta=None, visual=None):
         # TODO: use quantity_input to check that angle is an angle
-        self.center = center
+        self.center = PixCoord._validate(center, name='center', expected='scalar')
         self.width = width
         self.height = height
         self.angle = angle


### PR DESCRIPTION
Otherwise, when a region (e.g., ``RectanglePixelRegion``) created with wrong ``center`` type (e.g., a plain tuple ``(3, 4)``), then obscure error messages appear, such as:

```
<ipython-input-13-b9cc2ab6eb98> in <module>()
----> 1 region.contains(pixcoords)

/home/aly/.local/lib/python3.5/site-packages/regions/shapes/rectangle.py in contains(self, pixcoord)
     78         cos_angle = np.cos(self.angle)
     79         sin_angle = np.sin(self.angle)
---> 80         dx = pixcoord.x - self.center.x
     81         dy = pixcoord.y - self.center.y
     82         dx_rot = cos_angle * dx + sin_angle * dy

AttributeError: 'tuple' object has no attribute 'x'
```