### PR TITLE
Implement to_pix and to_mask for compound regions

### DIFF
--- a/regions/core/__init__.py
+++ b/regions/core/__init__.py
@@ -3,6 +3,6 @@
 """
 from .core import *
 from .pixcoord import *
-from .compound import *
 from .mask import *
 from .bounding_box import *
+from .compound import *

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -11,13 +11,17 @@ class CompoundPixelRegion(PixelRegion):
     Represents the logical combination of two regions in pixel coordinates.
     """
 
-    def __init__(self, region1, operator, region2):
+    def __init__(self, region1, region2, operator):
+        if not isinstance(region1, PixelRegion):
+            raise TypeError("region1 must be a PixelRegion")
+        if not isinstance(region2, PixelRegion):
+            raise TypeError("region2 must be a PixelRegion")
+        if not callable(operator):
+            raise TypeError("operator must be callable")
+
         self.region1 = region1
         self.region2 = region2
         self.operator = operator
-        if not callable(operator):
-            raise TypeError("The operator passed to a compound region must "
-                            "be callable.")
         self._repr_params = [('component 1', self.region1),
                              ('component 2', self.region2),
                              ('operator', self.operator),
@@ -38,7 +42,13 @@ class CompoundPixelRegion(PixelRegion):
             ixmin=min(mask1.bbox.ixmin, mask2.bbox.ixmin),
             ixmax=max(mask1.bbox.ixmax, mask2.bbox.ixmax),
             iymin=min(mask1.bbox.iymin, mask2.bbox.iymin),
-            iymax=max(mask1.bbox.iymax, mask2.bbox.iymax))
+            iymax=max(mask1.bbox.iymax, mask2.bbox.iymax)
+        )
+
+        bbox_borders = np.array([bbox.ixmin, bbox.ixmax, bbox.iymin, bbox.iymax]) 
+        if (bbox_borders < 0).any():
+            raise NotImplementedError("Bounding box must be within array for "
+                                      "compound regions, see ")
 
         # Pad mask1.data and mask2.data to get the same shape
         padded_data = list()
@@ -51,7 +61,7 @@ class CompoundPixelRegion(PixelRegion):
                                       ((ptop, pbottom), (pleft, pright)),
                                       'constant'))
 
-        data = self.operator(*np.array(padded_data, dtype=np.bool))
+        data = self.operator(*np.array(padded_data, dtype=np.int))
         return Mask(data=data, bbox=bbox)
 
     def to_sky(self, wcs):
@@ -77,13 +87,18 @@ class CompoundSkyRegion(SkyRegion):
     Represents the logical combination of two regions in sky coordinates.
     """
 
-    def __init__(self, region1, operator, region2):
+    def __init__(self, region1, region2, operator):
+        if not isinstance(region1, SkyRegion):
+            raise TypeError("region1 must be a SkyRegion")
+        if not isinstance(region2, SkyRegion):
+            raise TypeError("region2 must be a SkyRegion")
+        if not callable(operator):
+            raise TypeError("operator must be callable")
+
         self.region1 = region1
         self.region2 = region2
         self.operator = operator
-        if not callable(operator):
-            raise TypeError("The operator passed to a compound region must "
-                            "be callable.")
+
         self._repr_params = [('component 1', self.region1),
                              ('component 2', self.region2),
                              ('operator', self.operator),

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -45,6 +45,7 @@ class CompoundPixelRegion(PixelRegion):
             iymax=max(mask1.bbox.iymax, mask2.bbox.iymax)
         )
 
+        # Bounding boxes must not extend over array, see #168
         bbox_borders = np.array([bbox.ixmin, bbox.ixmax, bbox.iymin, bbox.iymax]) 
         if (bbox_borders < 0).any():
             raise NotImplementedError("Bounding box must be within array for "

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -46,10 +46,10 @@ class CompoundPixelRegion(PixelRegion):
         )
 
         # Bounding boxes must not extend over array, see #168
-        bbox_borders = np.array([bbox.ixmin, bbox.ixmax, bbox.iymin, bbox.iymax]) 
+        bbox_borders = np.array([bbox.ixmin, bbox.ixmax, bbox.iymin, bbox.iymax])
         if (bbox_borders < 0).any():
             raise NotImplementedError("Bounding box must be within array for "
-                                      "compound regions, see ")
+                                      "compound regions, see #168")
 
         # Pad mask1.data and mask2.data to get the same shape
         padded_data = list()

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -27,6 +27,9 @@ class CompoundPixelRegion(PixelRegion):
         raise NotImplementedError
 
     def to_mask(self, mode='center', subpixels=1):
+        if mode != 'center':
+            raise NotImplementedError
+
         mask1 = self.region1.to_mask(mode=mode, subpixels=subpixels)
         mask2 = self.region2.to_mask(mode=mode, subpixels=subpixels)
 
@@ -51,7 +54,12 @@ class CompoundPixelRegion(PixelRegion):
         data = self.operator(*np.array(padded_data, dtype=np.bool))
         return Mask(data=data, bbox=bbox)
 
-    def to_sky(self, wcs, mode='local', tolerance=None):
+    def to_sky(self, wcs):
+        skyreg1 = self.region1.to_sky(wcs=wcs)
+        skyreg2 = self.region2.to_sky(wcs=wcs)
+        return CompoundSkyRegion(region1=skyreg1,
+                                 operator=self.operator,
+                                 region2=skyreg2)
         raise NotImplementedError
 
     def as_patch(self, **kwargs):

--- a/regions/core/tests/test_compound.py
+++ b/regions/core/tests/test_compound.py
@@ -31,7 +31,7 @@ def test_compound_pixel():
     assert_allclose(mask.data[:,7], [0, 0, 0, 0, 0, 0, 0, 0, 0])
     assert_allclose(mask.data[:,6], [0, 1, 1, 1, 1, 1, 1, 1, 0])
 
-    # Circle bigger than map, see 
+    # Circle bigger than map, see #168
     pixcoord3 = PixCoord(1, 1)
     c3 = CirclePixelRegion(pixcoord3, 4)
     union2 = c1 | c3

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import math
 import operator
 
@@ -8,7 +9,8 @@ from astropy import wcs
 from astropy import coordinates
 from astropy import units as u
 
-from ..core import CompoundPixelRegion, CompoundSkyRegion
+from .._utils.wcs_helpers import skycoord_to_pixel_scale_angle
+from ..core import CompoundPixelRegion, CompoundSkyRegion, PixCoord
 from ..shapes import CirclePixelRegion, CircleSkyRegion
 
 __all__ = ['CircleAnnulusPixelRegion', 'CircleAnnulusSkyRegion']
@@ -32,7 +34,7 @@ class CircleAnnulusPixelRegion(CompoundPixelRegion):
         region1 = CirclePixelRegion(center, inner_radius)
         region2 = CirclePixelRegion(center, outer_radius)
         super(CircleAnnulusPixelRegion, self).__init__(
-            region1=region1, operator=operator.xor, region2=region2)
+            region1=region1, region2=region2, operator=operator.xor)
         self._repr_params = [('inner radius', region1.radius),
                              ('outer radius', region2.radius),
                              ('center', region2.center)]
@@ -88,3 +90,11 @@ class CircleAnnulusSkyRegion(CompoundSkyRegion):
     @property
     def outer_radius(self):
         return self.region2.radius
+
+    def to_pixel(self, wcs):
+        center, scale, _ = skycoord_to_pixel_scale_angle(self.center, wcs)
+        # FIXME: The following line is needed to get a scalar PixCoord
+        center = PixCoord(float(center.x), float(center.y))
+        inner_radius = self.inner_radius.to('deg').value * scale
+        outer_radius = self.outer_radius.to('deg').value * scale
+        return CircleAnnulusPixelRegion(center, inner_radius, outer_radius)

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -8,6 +8,7 @@ import numpy as np
 from astropy import wcs
 from astropy import coordinates
 from astropy import units as u
+from astropy.wcs.utils import pixel_to_skycoord
 
 from .._utils.wcs_helpers import skycoord_to_pixel_scale_angle
 from ..core import CompoundPixelRegion, CompoundSkyRegion, PixCoord
@@ -54,6 +55,13 @@ class CircleAnnulusPixelRegion(CompoundPixelRegion):
 
     def bounding_box(self):
         return self.region2.bounding_box()
+
+    def to_sky(self, wcs):
+        center = pixel_to_skycoord(self.center.x, self.center.y, wcs)
+        _, scale, _ = skycoord_to_pixel_scale_angle(center, wcs)
+        inner_radius = self.inner_radius / scale * u.deg
+        outer_radius = self.outer_radius / scale * u.deg
+        return CircleAnnulusSkyRegion(center, inner_radius, outer_radius)
 
 
 class CircleAnnulusSkyRegion(CompoundSkyRegion):

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -15,6 +15,10 @@ def test_init_pixel():
     annulus = CircleAnnulusPixelRegion(pixcoord, 2, 3)
     assert 'inner' in str(annulus)
 
+    skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='icrs')
+    wcs = make_simple_wcs(skycoord, 5 * u.arcsec, 20)
+    skyannulus = annulus.to_sky(wcs=wcs)
+    assert isinstance(skyannulus, CircleAnnulusSkyRegion)
 
 def test_init_sky():
 
@@ -39,3 +43,7 @@ def test_init_sky():
 
     assert 'Annulus' in str(annulus)
     assert 'inner' in str(annulus)
+
+    pixannulus = annulus.to_pixel(wcs=wcs)
+    assert isinstance(pixannulus, CircleAnnulusPixelRegion)
+

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -46,4 +46,3 @@ def test_init_sky():
 
     pixannulus = annulus.to_pixel(wcs=wcs)
     assert isinstance(pixannulus, CircleAnnulusPixelRegion)
-


### PR DESCRIPTION
This PR implements
* ``to_pixel`` for ``CompoundSkyRegion``
* ``to_mask`` for ``CompoundPixelRegion``
* ``to_pixel`` for ``CircleAnnulusSkyRegion``, since I didn't know if it's possible to return a ``CircleAnnulusPixelRegion`` instance when calling the ``to_pixel`` method on the mother class (``CompoundSkyRegion``)\