### PR TITLE
Allow Mask input to be array-like

### DIFF
--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -23,14 +23,13 @@ class Mask(object):
 
     Examples
     --------
-
     Usage examples are provided in the :ref:`gs-masks` section of the docs.
     """
 
     def __init__(self, data, bbox):
-        if data.shape != bbox.shape:
-            raise ValueError("Shape of data and bounding box should match")
         self.data = np.asanyarray(data)
+        if self.data.shape != bbox.shape:
+            raise ValueError("Shape of data and bounding box should match")
         self.bbox = bbox
 
     @property


### PR DESCRIPTION
The "array-like" input may not have a `.shape` attribute, so turn it into an `ndarray` first.