### PR TITLE
ds9 reader: ellipses are stored with radii but read as width/height

### DIFF
--- a/regions/io/ds9/core.py
+++ b/regions/io/ds9/core.py
@@ -68,7 +68,7 @@ class Shape(object):
     """
     shape_to_sky_region = dict(
         circle=shapes.CircleSkyRegion,
-        ellipse=shapes.EllipseSkyRegion,
+        ellipse=shapes.Ds9EllipseSkyRegion,
         box=shapes.RectangleSkyRegion,
         polygon=shapes.PolygonSkyRegion,
         annulus=shapes.CircleAnnulusSkyRegion,
@@ -77,7 +77,7 @@ class Shape(object):
     )
     shape_to_pixel_region = dict(
         circle=shapes.CirclePixelRegion,
-        ellipse=shapes.EllipsePixelRegion,
+        ellipse=shapes.Ds9EllipsePixelRegion,
         box=shapes.RectanglePixelRegion,
         polygon=shapes.PolygonPixelRegion,
         annulus=shapes.CircleAnnulusPixelRegion,

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -13,7 +13,8 @@ from .._geometry import elliptical_overlap_grid
 from .._utils.wcs_helpers import skycoord_to_pixel_scale_angle
 
 
-__all__ = ['EllipsePixelRegion', 'EllipseSkyRegion']
+__all__ = ['EllipsePixelRegion', 'EllipseSkyRegion', 'Ds9EllipsePixelRegion',
+           'Ds9EllipseSkyRegion']
 
 
 class EllipsePixelRegion(PixelRegion):
@@ -225,3 +226,18 @@ class EllipseSkyRegion(SkyRegion):
         return EllipsePixelRegion(center, width, height,
                                   angle=self.angle + (north_angle - 90 * u.deg),
                                   meta=self.meta, visual=self.visual)
+
+class Ds9EllipseSkyRegion(EllipseSkyRegion):
+    def __init__(self, center, halfwidth, halfheight, angle=0*u.deg, meta=None,
+                 visual=None):
+        super(Ds9EllipseSkyRegion, self).__init__(center, 2*halfwidth,
+                                                  2*halfheight, angle=angle,
+                                                  meta=meta, visual=visual)
+
+class Ds9EllipsePixelRegion(EllipsePixelRegion):
+    def __init__(self, center, halfwidth, halfheight, angle=0*u.deg, meta=None,
+                 visual=None):
+        super(Ds9EllipsePixelRegion, self).__init__(center, 2*halfwidth,
+                                                    2*halfheight, angle=angle,
+                                                    meta=meta, visual=visual)
+


### PR DESCRIPTION
The ds9 reader is getting ellipses wrong right now; it is interpreting the stored 'radius' as a diameter.

I'll try to figure out how to handle this.