### PR TITLE
Update astropy-helpers to v2.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,6 @@ matrix:
 
 
         # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development
         - python: 3.6
           env: ASTROPY_VERSION=development
                CONDA_CHANNELS='conda-forge astropy'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ environment:
       # Cython code, you can set CONDA_DEPENDENCIES=''
       CONDA_CHANNELS: "defaults conda-forge astropy"
       CONDA_DEPENDENCIES: "Cython pytest-arraydiff"
-      PIP_DEPENDENCIES: "shapely"
       ASTROPY_USE_SYSTEM_PYTEST: 1
 
   matrix:


### PR DESCRIPTION
This is an automated update of the astropy-helpers submodule to v2.0.2. This includes both the update of the astropy-helpers sub-module, and the ``ah_bootstrap.py`` file, if needed.

*This is intended to be helpful, but if you would prefer to manage these updates yourself, or if you notice any issues with this automated update, please let @bsipocz or @astrofrog know!*