### PR TITLE
Add numpy to setup_requires and install_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,8 @@ setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,
-      install_requires=['astropy'],
+      setup_requires=['numpy'],
+      install_requires=['numpy', 'astropy'],
       extras_require=dict(
           plot=[
               'matplotlib',


### PR DESCRIPTION
In https://github.com/gammapy/gammapy/issues/1244 we got a report by @mackaiver that
`pip install gammapy` fails. Gammapy lists `regions` in `setup_requires`, and I think what's happening is that `pip` errors out with
```
Running setup.py bdist_wheel for regions ... error
```
because it executes that without having installed `numpy` first.

This PR adds `numpy` to both `install_requires` and `setup_requires` in the `setup.py` for `regions`. This is following the Astropy core package `setup.py`, which does the same thing.

I'm not sure if this is the proper / best way to handle this issue? @astrofrog @bsipocz or maybe also @drdavella - do you know?

I'm not able to reproduce the issue reported by @mackaiver locally, and he says that it doesn't appear for him with the current regions dev version. I.e. it could also be an old issue in astropy-helpers, or it could still be present and there are just peculiarities or non-determinims in the order that pip installs numpy and regions for some reason. I think maybe the change proposed here is the safe way to handle it?