### PR TITLE
fixed `contains` and made centre a 0D skycoord object

### DIFF
--- a/regions/io/ds9/core.py
+++ b/regions/io/ds9/core.py
@@ -133,7 +133,7 @@ class Shape(object):
         frame = coordinates.frame_transform_graph.lookup_name(self.coordsys)
 
         lon, lat = zip(*parsed_angles)
-        if hasattr(lon, '__len__') and hasattr(lon, '__lat__') and len(lon) == 1 and len(lat == 1):
+        if hasattr(lon, '__len__') and hasattr(lat, '__len__') and len(lon) == 1 and len(lat) == 1:
             # force entries to be scalar if they are length-1
             lon, lat = u.Quantity(lon[0]), u.Quantity(lat[0])
         else:

--- a/regions/io/ds9/tests/test_ds9_language.py
+++ b/regions/io/ds9/tests/test_ds9_language.py
@@ -194,12 +194,13 @@ def test_issue134_regression():
     regions = parser.shapes
     assert regions[0].to_region().radius.value == 30.4
 
+
 def test_issue65_regression():
     regstr = 'J2000; circle 188.5557102 12.0314056 1" # color=red'
     parser = DS9Parser(regstr)
     parser.run()
     regions = parser.shapes
     reg = regions[0].to_region()
-    assert reg.center.ra.value[0] == 188.5557102
-    assert reg.center.dec.value[0] == 12.0314056
+    assert reg.center.ra.value == 188.5557102
+    assert reg.center.dec.value == 12.0314056
     assert reg.radius.value == 1.0

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -40,10 +40,10 @@ class CirclePixelRegion(PixelRegion):
     def contains(self, pixcoord):
         pixcoord = PixCoord._validate(pixcoord, name='pixcoord')
         in_circle = self.center.separation(pixcoord) < self.radius
-        if self.meta.get('inverted', False) is False:
-            return in_circle
-        else:
+        if self.meta.get('inverted', False):
             return not in_circle
+        else:
+            return in_circle
 
     def to_shapely(self):
         return self.center.to_shapely().buffer(self.radius)

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -83,3 +83,10 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
         assert_quantity_allclose(skycircle.center.data.lon, skycircle2.center.data.lon)
         assert_quantity_allclose(skycircle.center.data.lat, skycircle2.center.data.lat)
         assert_quantity_allclose(skycircle2.radius, skycircle.radius)
+
+    def test_dimension_center(self):
+        center = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+        radius = 2 * u.arcsec
+        with pytest.raises(ValueError) as err:
+            CircleSkyRegion(center, radius)
+        assert 'the centre should be a 0D SkyCoord object' in str(err)


### PR DESCRIPTION
It fixes two things:
1. `contains` function did not check for inverted regions.
2. Centre of the region was not a 0D skycoord object.