### PR TITLE
Handling dimension and broadcast of x and y in PixCoord.

### DIFF
--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -37,19 +37,11 @@ class PixCoord(object):
         self.x = self._standardize_coordinate(x)
         self.y = self._standardize_coordinate(y)
 
-        for a, b in ((x, y), (y, x)):
-            z, shape = a, np.asanyarray(a).shape
-            if shape == () or shape == (1,):
-                while np.asanyarray(z).shape != np.asanyarray(b).shape:
-                    z = np.append(z, a)
-
-                if self.x is a:
-                    self.x = z
-                else:
-                    self.y = z
-
         if np.asanyarray(self.x).shape != np.asanyarray(self.y).shape:
-            raise ValueError('Input parameters x and y must be of same dimensions')
+            try:
+                self.x, self.y = np.broadcast_arrays(self.x, self.y)
+            except ValueError:
+                raise ValueError('Input parameters x and y cannot be broadcast')
 
     @staticmethod
     def _standardize_coordinate(val):

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -11,7 +11,7 @@ __all__ = ['PixCoord']
 class PixCoord(object):
     """Pixel coordinates.
 
-    This class can represent scalar or array pixel coordinates.
+    This class can represent scalar or array pixel of coordinates.
 
     The data members are either numbers or Numpy arrays
     (not `~astropy.units.Quantity` objects with unit "pixel").
@@ -33,6 +33,8 @@ class PixCoord(object):
     """
 
     def __init__(self, x, y):
+        if np.asanyarray(x).shape != np.asanyarray(y).shape:
+            raise ValueError('{} and {} must be of same dimensions'.format(x, y))
         self.x = self._standardize_coordinate(x)
         self.y = self._standardize_coordinate(y)
 
@@ -49,6 +51,8 @@ class PixCoord(object):
         if isinstance(val, numbers.Number):
             return val
         else:
+            if np.asanyarray(val).shape == ():
+                return float(val)
             return np.array(val)
 
     @staticmethod
@@ -90,13 +94,7 @@ class PixCoord(object):
 
     @property
     def isscalar(self):
-        """Is this pixcoord a scalar? (a bool property)"""
-        # TODO: what's the best solution to implement this?
-        # Maybe we should sub-class ShapedLikeNDArray?
-        # See https://github.com/astropy/regions/issues/108
-        # This is a temp solution that matches the bahaviour of SkyCoord
-        return np.asanyarray(self.x).shape == ()
-        # return np.isscalar(self.x) and np.isscalar(self.y)
+        return np.isscalar(self.x)
 
     def __repr__(self):
         data = dict(name=self.__class__.__name__, x=self.x, y=self.y)

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -11,7 +11,7 @@ __all__ = ['PixCoord']
 class PixCoord(object):
     """Pixel coordinates.
 
-    This class can represent scalar or array of pixel coordinates.
+    This class can represent scalar or array pixel coordinates.
 
     The data members are either numbers or Numpy arrays
     (not `~astropy.units.Quantity` objects with unit "pixel").

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -34,31 +34,12 @@ class PixCoord(object):
 
     def __init__(self, x, y):
 
-        self.x = self._standardize_coordinate(x)
-        self.y = self._standardize_coordinate(y)
+        x, y = np.broadcast_arrays(x, y)
 
-        if np.asanyarray(self.x).shape != np.asanyarray(self.y).shape:
-            try:
-                self.x, self.y = np.broadcast_arrays(self.x, self.y)
-            except ValueError:
-                raise ValueError('Input parameters x and y cannot be broadcast')
-
-    @staticmethod
-    def _standardize_coordinate(val):
-        """Standardize coordinate.
-
-        Output should be either:
-        * Scalar Python number
-        * Numpy array
-
-        That's it, nothing else allowed!
-        """
-        if isinstance(val, numbers.Number):
-            return val
+        if x.shape == ():
+            self.x, self.y = np.asscalar(x), np.asscalar(y)
         else:
-            if np.asanyarray(val).shape == ():
-                return float(val)
-            return np.array(val)
+            self.x, self.y = x, y
 
     @staticmethod
     def _validate(val, name, expected='any'):

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -33,10 +33,23 @@ class PixCoord(object):
     """
 
     def __init__(self, x, y):
-        if np.asanyarray(x).shape != np.asanyarray(y).shape:
-            raise ValueError('{} and {} must be of same dimensions'.format(x, y))
+
         self.x = self._standardize_coordinate(x)
         self.y = self._standardize_coordinate(y)
+
+        for a, b in ((x, y), (y, x)):
+            z, shape = a, np.asanyarray(a).shape
+            if shape == () or shape == (1,):
+                while np.asanyarray(z).shape != np.asanyarray(b).shape:
+                    z = np.append(z, a)
+
+                if self.x is a:
+                    self.x = z
+                else:
+                    self.y = z
+
+        if np.asanyarray(self.x).shape != np.asanyarray(self.y).shape:
+            raise ValueError('Input parameters x and y must be of same dimensions')
 
     @staticmethod
     def _standardize_coordinate(val):

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -11,7 +11,7 @@ __all__ = ['PixCoord']
 class PixCoord(object):
     """Pixel coordinates.
 
-    This class can represent scalar or array pixel of coordinates.
+    This class can represent scalar or array of pixel coordinates.
 
     The data members are either numbers or Numpy arrays
     (not `~astropy.units.Quantity` objects with unit "pixel").

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -23,17 +23,21 @@ def wcs():
 
 def test_pixcoord_basic_dimension():
     with pytest.raises(ValueError) as err :
-        PixCoord(np.array([1, 2]), 3)
-    assert '[1 2] and 3 must be of same dimensions' in str(err)
+        PixCoord(np.array([1, 2]), [3, 4, 5, 6])
+    assert 'Input parameters x and y must be of same dimensions' in str(err)
 
 
 def test_pixcoord_basics_scalar():
     p = PixCoord(x=1, y=2)
+    p1 = PixCoord(x=np.array(1), y=2)
+    p2 = PixCoord(x=np.array(1), y=np.array(2))
 
     assert p.x == 1
     assert p.y == 2
 
-    assert p.isscalar is True
+    assert p.isscalar
+    assert p1.isscalar
+    assert p2.isscalar
 
     assert str(p) == 'PixCoord(x=1, y=2)'
     assert repr(p) == 'PixCoord(x=1, y=2)'
@@ -47,16 +51,25 @@ def test_pixcoord_basics_scalar():
 
 def test_pixcoord_basics_array_1d():
     p = PixCoord(x=[1, 2, 3], y=[11, 22, 33])
+    p1 = PixCoord(x=1, y=[1, 2, 3])
 
     assert_equal(p.x, [1, 2, 3])
     assert_equal(p.y, [11, 22, 33])
 
-    assert p.isscalar is False
+    assert_equal(p1.x, [1, 1, 1])
+    assert_equal(p1.y, [1, 2, 3])
+
+    assert not p.isscalar
+    assert not p1.isscalar
 
     assert str(p) == 'PixCoord(x=[1 2 3], y=[11 22 33])'
+    assert str(p1) == 'PixCoord(x=[1 1 1], y=[1 2 3])'
+
     assert repr(p) == 'PixCoord(x=[1 2 3], y=[11 22 33])'
+    assert repr(p1) == 'PixCoord(x=[1 1 1], y=[1 2 3])'
 
     assert len(p) == 3
+    assert len(p1) == 3
 
     # Test `__iter__` via assertions on the last element
     p2 = [_ for _ in p][-1]

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -101,9 +101,7 @@ def test_pixcoord_to_sky_scalar(wcs):
     assert_allclose(s.data.lat.deg, 10.003028030623508)
 
     p2 = PixCoord.from_sky(skycoord=s, wcs=wcs)
-    assert isinstance(p2.x, np.ndarray)
-    assert p2.x.shape == tuple()
-    assert p2.x.ndim == 0
+    assert isinstance(p2.x, float)
     assert p2.isscalar
     assert_allclose(p2.x, p.x)
     assert_allclose(p2.y, p.y)

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -24,7 +24,7 @@ def wcs():
 def test_pixcoord_basic_dimension():
     with pytest.raises(ValueError) as err :
         PixCoord(np.array([1, 2]), [3, 4, 5, 6])
-    assert 'Input parameters x and y must be of same dimensions' in str(err)
+    assert 'Input parameters x and y cannot be broadcast' in str(err)
 
 
 def test_pixcoord_basics_scalar():

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -22,9 +22,8 @@ def wcs():
 
 
 def test_pixcoord_basic_dimension():
-    with pytest.raises(ValueError) as err :
+    with pytest.raises(ValueError):
         PixCoord(np.array([1, 2]), [3, 4, 5, 6])
-    assert 'Input parameters x and y cannot be broadcast' in str(err)
 
 
 def test_pixcoord_basics_scalar():

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -21,6 +21,12 @@ def wcs():
     return dataset.wcs
 
 
+def test_pixcoord_basic_dimension():
+    with pytest.raises(ValueError) as err :
+        PixCoord(np.array([1, 2]), 3)
+    assert '[1 2] and 3 must be of same dimensions' in str(err)
+
+
 def test_pixcoord_basics_scalar():
     p = PixCoord(x=1, y=2)
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -127,7 +127,5 @@ class CircleSkyRegion(SkyRegion):
 
     def to_pixel(self, wcs):
         center, scale, _ = skycoord_to_pixel_scale_angle(self.center, wcs)
-        # FIXME: The following line is needed to get a scalar PixCoord
-        center = PixCoord(float(center.x), float(center.y))
         radius = self.radius.to('deg').value * scale
         return CirclePixelRegion(center, radius, self.meta, self.visual)


### PR DESCRIPTION

1. converting 0d numpy arrays to float.
2. Checking whether x and y have same dimensions.
3. making more SkyCoord like : `p = PixCoord(1, [1, 2])` is valid and p.x becomes [1, 1]
4. added tests for above.
