### PR TITLE
Use new section name tool:pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,8 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
-minversion = 2.2
+[tool:pytest]
+minversion = 3.0.0
 norecursedirs = build docs/_build
 addopts = --arraydiff -p no:warnings
 # TODO: re-activate doctests.


### PR DESCRIPTION
[pytest] section in setup.cfg files is deprecated and pytest options can be specified with a [tool:pytest] section (https://docs.pytest.org/en/latest/goodpractices.html).