### PR TITLE
Converting Shape objects to CRTF string

### DIFF
--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -300,7 +300,7 @@ class RegionMeta(dict):
     valid_keys = ['label', 'symbol', 'include', 'frame', 'range', 'veltype',
                   'restfreq', 'tag', 'comment', 'coord', 'line', 'name',
                   'select', 'highlite', 'fixed', 'edit', 'move', 'rotate',
-                  'delete', 'source', 'background'
+                  'delete', 'source', 'background', 'corr'
                   ]
 
     key_mapping = {'point': 'symbol', 'text': 'label'}

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -300,7 +300,7 @@ class RegionMeta(dict):
     valid_keys = ['label', 'symbol', 'include', 'frame', 'range', 'veltype',
                   'restfreq', 'tag', 'comment', 'coord', 'line', 'name',
                   'select', 'highlite', 'fixed', 'edit', 'move', 'rotate',
-                  'delete', 'source', 'background', 'corr'
+                  'delete', 'source', 'background', 'corr', 'type'
                   ]
 
     key_mapping = {'point': 'symbol', 'text': 'label'}

--- a/regions/io/core.py
+++ b/regions/io/core.py
@@ -111,8 +111,8 @@ class ShapeList(list):
             'rectangle': '{0}rotbox[[{1:FMT}deg, {2:FMT}deg], [{3:FMT}RAD, {4:FMT}RAD], {5:FMT}deg]',
             'polygon': '{0}poly[{1}]',
             'point': '{0}point[[{1:FMT}deg, {2:FMT}deg]]',
-            'symbol': '{0}symbol[[{1:FMT}deg, {2:FMT}deg], {3}]',
-            'text': '{0}text[[{1:FMT}deg, {2:FMT}deg], \'{3}\']',
+            'symbol': '{0}symbol[[{1:FMT}deg, {2:FMT}deg], {symbol}]',
+            'text': '{0}text[[{1:FMT}deg, {2:FMT}deg], \'{text}\']',
             'line': '{0}line[[{1:FMT}deg, {2:FMT}deg], [{3:FMT}deg, {4:FMT}deg]]'
                         }
 
@@ -185,16 +185,16 @@ class ShapeList(list):
             elif shape.region_type == 'point':
                 if 'symbol' in shape.meta.keys():
                     line = crtf_strings['symbol'].format(include, *coord,
-                                                         reverse_symbol_mapping[shape.meta['symbol']])
+                                                         symbol=reverse_symbol_mapping[shape.meta['symbol']])
                 elif 'text' in shape.meta.keys():
-                    line = crtf_strings['text'].format(include, *coord, shape.meta['text'])
+                    line = crtf_strings['text'].format(include, *coord, text=shape.meta['text'])
                 else:
                     line = crtf_strings['point'].format(include, *coord)
             else:
                 line = crtf_strings[shape.region_type].format(include, *coord)
 
             if meta_str.strip():
-                output += "{0}, {1} \n".format(line, meta_str)
+                output += "{0}, {1}\n".format(line, meta_str)
             else:
                 output += "{0}\n".format(line)
 

--- a/regions/io/crtf/core.py
+++ b/regions/io/crtf/core.py
@@ -19,3 +19,30 @@ class CRTFRegionParserError(ValueError):
     """
     A generic error class for CRTF region parsing
     """
+
+
+# Valid symbols for symbol region in CRTF.
+
+valid_symbols = {'.': 'point',
+                 ',': 'pixel',
+                 'o': 'circle',
+                 'v': 'triangle_down',
+                 '^': 'triangle_up',
+                 '<': 'triangle_left',
+                 '>': 'triangle_right',
+                 '1':  'tri_down',
+                 '2': 'tri_up',
+                 '3': 'tri_left',
+                 '4': 'tri_right',
+                 's': 'square',
+                 'p': 'pentagon',
+                 '*': 'star',
+                 'h': 'hexagon1',
+                 'H': 'hexagon2',
+                 '+': 'plus',
+                 'x': 'x',
+                 'D': 'diamond',
+                 'd': 'thin_diamond',
+                 '|': 'vline',
+                 '_': 'hline'
+                }

--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -465,3 +465,5 @@ class CoordinateParser(object):
             return u.Quantity(str.group(1))
         else:
             raise CRTFRegionParserError('Units must be specified for {0} '.format(string_rep))
+
+valid_symbols = CRTFRegionParser.valid_symbols

--- a/regions/io/crtf/setup_package.py
+++ b/regions/io/crtf/setup_package.py
@@ -1,1 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+
+def get_package_data():
+    parser_test = ['data/*.crtf']
+    return {'regions.io.crtf.tests': parser_test}

--- a/regions/io/crtf/tests/data/CRTFgeneral.crtf
+++ b/regions/io/crtf/tests/data/CRTFgeneral.crtf
@@ -1,11 +1,11 @@
 #CRTF0
-global coord=B1950_VLA, frame=BARY, corr=[I, Q], color=blue
+global coord=B1950, frame=BARY, corr=[I, Q], color=blue
 
 # A simple circle region:
-circle[[18h12m24s, -23d11m00s], 2.3arcsec]
+ann circle[[18h12m24s, -23d11m00s], 2.3arcsec]
 
-# A box region, this one only for annotation:
-ann box[[140.0342deg, -12.34243deg], [140.0360deg, -12.34320deg]]
+# A box region, this one only for annotation: (Not Implemented )
+# ann box[[140.0342deg, -12.34243deg], [140.0360deg, -12.34320deg]]
 
 # A rotated box region, for a particular range of velocities:
 rotbox[[12h01m34.1s, 12d23m33s], [3arcmin, 1arcmin], 12deg], range=[-1240km/s, 1240km/s]

--- a/regions/io/crtf/tests/data/CRTFgeneraloutput.crtf
+++ b/regions/io/crtf/tests/data/CRTFgeneraloutput.crtf
@@ -1,7 +1,7 @@
 #CRTF
 global coord=fk4
-+ann circle[[273.10deg, -23.18deg], 0.00deg], frame=bary, color=blue 
-+rotbox[[180.39deg, 12.39deg], [0.05deg, 0.02deg], 12.00deg], frame=bary, color=blue, range=[-1240km/s, 1240km/s] 
-+annulus[[267.76deg, -45.30deg], [0.10deg, 4.12deg]], frame=bary, label=my label here, color=red 
--ellipse[[12.00deg, 45.00deg], [0.25deg, 1.34deg], 2578.31deg], frame=bary, label=removed this, color=green, range=[1.420ghz, 1.421ghz] 
-+symbol[[31.47deg, 11.90deg], d], frame=bary, color=blue, linewidth=2, symsize=2 
++ann circle[[273.10deg, -23.18deg], 0.00deg], frame=bary, color=blue
++rotbox[[180.39deg, 12.39deg], [0.05deg, 0.02deg], 12.00deg], frame=bary, color=blue, range=[-1240km/s, 1240km/s]
++annulus[[267.76deg, -45.30deg], [0.10deg, 4.12deg]], frame=bary, label=my label here, color=red
+-ellipse[[12.00deg, 45.00deg], [0.25deg, 1.34deg], 2578.31deg], frame=bary, label=removed this, color=green, range=[1.420ghz, 1.421ghz]
++symbol[[31.47deg, 11.90deg], d], frame=bary, color=blue, linewidth=2, symsize=2

--- a/regions/io/crtf/tests/data/CRTFgeneraloutput.crtf
+++ b/regions/io/crtf/tests/data/CRTFgeneraloutput.crtf
@@ -1,0 +1,7 @@
+#CRTF
+global coord=fk4
++ann circle[[273.10deg, -23.18deg], 0.00deg], frame=bary, color=blue 
++rotbox[[180.39deg, 12.39deg], [0.05deg, 0.02deg], 12.00deg], frame=bary, color=blue, range=[-1240km/s, 1240km/s] 
++annulus[[267.76deg, -45.30deg], [0.10deg, 4.12deg]], frame=bary, label=my label here, color=red 
+-ellipse[[12.00deg, 45.00deg], [0.25deg, 1.34deg], 2578.31deg], frame=bary, label=removed this, color=green, range=[1.420ghz, 1.421ghz] 
++symbol[[31.47deg, 11.90deg], d], frame=bary, color=blue, linewidth=2, symsize=2 

--- a/regions/io/crtf/tests/test_crtf_language.py
+++ b/regions/io/crtf/tests/test_crtf_language.py
@@ -135,4 +135,12 @@ def test_file_crtf(filename):
     with open(get_pkg_data_filename('data/CRTFgeneraloutput.crtf')) as f:
         ref_output = f.read()
 
-    assert ref_output == actual_output
+    # since metadata is not required to preserve order, we have to do a more
+    # complex comparison
+    desired_lines = [set(line.split(",")) for line in ref_output.split("\n")]
+    actual_lines = [set(line.split(",")) for line in actual_output.split("\n")]
+    for split_line in actual_lines:
+        assert split_line in desired_lines
+
+    for split_line in desired_lines:
+        assert split_line in actual_lines

--- a/regions/io/crtf/tests/test_crtf_language.py
+++ b/regions/io/crtf/tests/test_crtf_language.py
@@ -4,15 +4,17 @@ import pytest
 
 
 import astropy.version as astrov
+from astropy.utils.data import get_pkg_data_filename
 
 
-from ..read import CRTFParser
+from ..read import CRTFParser, read_crtf
+from ..write import crtf_objects_to_string
 from ..core import CRTFRegionParserError
 
 _ASTROPY_MINVERSION = vers.LooseVersion('1.1')
 _ASTROPY_VERSION = vers.LooseVersion(astrov.version)
 
-implemented_region_types = ('ellipse', 'circle', 'rectangle', 'poly', 'point')
+implemented_region_types = ('ellipse', 'circle', 'rectangle', 'poly', 'point', 'text', 'symbol')
 
 
 def test_global_parser():
@@ -121,3 +123,16 @@ def test_valid_region_syntax():
         CRTFParser(reg_str6)
 
     assert "('3arcmin', '') should be a pair of length" in str(err)
+
+
+@pytest.mark.parametrize('filename', ['data/CRTFgeneral.crtf', 'data/CRTFgeneraloutput.crtf'])
+def test_file_crtf(filename):
+
+    filename = get_pkg_data_filename(filename)
+    regs = read_crtf(filename, 'warn')
+    actual_output = crtf_objects_to_string(regs, 'fk4', '.2f')
+
+    with open(get_pkg_data_filename('data/CRTFgeneraloutput.crtf')) as f:
+        ref_output = f.read()
+
+    assert ref_output == actual_output

--- a/regions/io/crtf/write.py
+++ b/regions/io/crtf/write.py
@@ -1,0 +1,68 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from ..core import to_shape_list
+
+__all__ = [
+    'write_crtf',
+    'crtf_objects_to_string',
+]
+
+
+def crtf_objects_to_string(regions, coordsys='fk5', fmt='.6f', radunit='deg'):
+    """
+    Converts list of regions to crtf region string.
+
+    Parameters
+    ----------
+    regions : list
+        List of `regions.Region` objects
+
+    coordsys : str
+        Astropy Coordinate system that overrides the coordinate system frame for all regions.
+
+    fmt : str
+        A python string format defining the output precision.  Default is .6f,
+        which is accurate to 0.0036 arcseconds.
+
+    radunit : str
+        This denotes the unit of the radius.
+
+    Returns
+    -------
+    region_string : str
+        crtf region string
+
+    Examples
+    --------
+    TODO
+    """
+    shapelist = to_shape_list(regions, 'CRTF', coordsys)
+    return shapelist.to_crtf(coordsys, fmt, radunit)
+
+
+def write_crtf(regions, filename='new.crtf', coordsys='fk5', fmt='.6f', radunit='deg'):
+    """
+    Converts list of regions to crtf string and write to file.
+
+    Parameters
+    ----------
+    regions : list
+        List of `regions.Region` objects
+
+    filename : str
+        Filename in which the string is to be written. Default is 'new.crtf'
+
+    coordsys : str #TODO
+        Astropy Coordinate system that overrides the coordinate frames of all regions.
+
+    fmt : str
+        A python string format defining the output precision.  Default is .6f,
+        which is accurate to 0.0036 arcseconds.
+
+    radunit : str
+        This denotes the unit of the radius. Default is deg (degrees)
+    """
+    output = crtf_objects_to_string(regions, coordsys, fmt, radunit)
+    with open(filename, 'w') as fh:
+        fh.write(output)


### PR DESCRIPTION
- Now , symbol and text region are implemented as point regions with extra attributes in meta dict.
- Implemented `to_crtf` in ShapeList class that converts Shape objects to CRTF string.
- Moved `valid_symbols` to `io/crtf/core.py` so that `to_crtf` can also use it without any circular import errors.
- Added round tests to make sure that both reader and writer are working as expected.
- A small change in regex , fixed an overhead assertion so that it doesn't confuse between `ann` (annotation type) and  'ann' in `annulus`.
- Added a new meta key `type` which holds whether a CRTF region is  `reg` (region) or `ann` (annotation). Default is `reg`.  