### PR TITLE
Fix mask bug for regions with negative indices

### DIFF
--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -183,6 +183,8 @@ class Mask(object):
         """
 
         data = np.asanyarray(data)
+        if data.ndim != 2:
+            raise ValueError('data must be a 2D array.')
 
         partial_overlap = False
         if self.bbox.ixmin < 0 or self.bbox.iymin < 0:

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -1,7 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
 import numpy as np
-from astropy import units as u
+import astropy.units as u
+
 
 __all__ = ['Mask']
 
@@ -23,32 +26,37 @@ class Mask(object):
 
     Examples
     --------
-    Usage examples are provided in the :ref:`gs-masks` section of the docs.
+    Usage examples are provided in the :ref:`gs-masks` section of the
+    docs.
     """
 
     def __init__(self, data, bbox):
         self.data = np.asanyarray(data)
         if self.data.shape != bbox.shape:
-            raise ValueError("Shape of data and bounding box should match")
+            raise ValueError('data and bounding box must have the same '
+                             'shape.')
         self.bbox = bbox
+
+    def __array__(self):
+        """
+        Array representation of the mask data array (e.g., for
+        matplotlib).
+        """
+
+        return self.data
 
     @property
     def shape(self):
         """
         The shape of the mask data array.
         """
-        return self.data.shape
 
-    def __array__(self):
-        """
-        Array representation of the mask data array (e.g., for matplotlib).
-        """
-        return self.data
+        return self.data.shape
 
     def _overlap_slices(self, shape):
         """
-        Calculate the slices for the overlapping part of the bounding box
-        and an array of the given shape.
+        Calculate the slices for the overlapping part of the bounding
+        box and an array of the given shape.
 
         Parameters
         ----------

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -173,7 +173,7 @@ class Mask(object):
 
         Returns
         -------
-        result : `~numpy.ndarray`
+        result : `~numpy.ndarray` or `None`
             A 2D array cut out from the input ``data`` representing the
             same cutout region as the region mask.  If there is a
             partial overlap of the region mask with the input data,
@@ -232,7 +232,7 @@ class Mask(object):
 
         Returns
         -------
-        result : `~numpy.ndarray`
+        result : `~numpy.ndarray` or `None`
             A 2D mask-weighted cutout from the input ``data``.  If there
             is a partial overlap of the region mask with the input data,
             pixels outside of the data will be assigned to

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -99,6 +99,23 @@ class Mask(object):
 
         return slices_large, slices_small
 
+    def _to_image_partial_overlap(self, image):
+        """
+        Return an image of the mask in a 2D array, where the mask
+        is not fully within the image (i.e. partial or no overlap).
+        """
+
+        # find the overlap of the mask on the output image shape
+        slices_large, slices_small = self._overlap_slices(image.shape)
+
+        if slices_small is None:
+            return None    # no overlap
+
+        # insert the mask into the output image
+        image[slices_large] = self.data[slices_small]
+
+        return image
+
     def to_image(self, shape):
         """
         Return an image of the mask in a 2D array of the given shape,
@@ -118,20 +135,17 @@ class Mask(object):
         if len(shape) != 2:
             raise ValueError('input shape must have 2 elements.')
 
-        mask = np.zeros(shape)
+        image = np.zeros(shape)
+
+        if self.bbox.ixmin < 0 or self.bbox.iymin < 0:
+            return self._to_image_partial_overlap(image)
 
         try:
-            mask[self.bbox.slices] = self.data
+            image[self.bbox.slices] = self.data
         except ValueError:    # partial or no overlap
-            slices_large, slices_small = self._overlap_slices(shape)
+            image = self._to_image_partial_overlap(image)
 
-            if slices_small is None:
-                return None    # no overlap
-
-            mask = np.zeros(shape)
-            mask[slices_large] = self.data[slices_small]
-
-        return mask
+        return image
 
     def cutout(self, data, fill_value=0.):
         """

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -147,19 +147,29 @@ class Mask(object):
 
         return image
 
-    def cutout(self, data, fill_value=0.):
+    def cutout(self, data, fill_value=0., copy=False):
         """
         Create a cutout from the input data over the mask bounding box,
         taking any edge effects into account.
 
         Parameters
         ----------
-        data : array_like or `~astropy.units.Quantity`
+        data : array_like
             A 2D array on which to apply the region mask.
 
         fill_value : float, optional
             The value is used to fill pixels where the region mask
             does not overlap with the input ``data``.  The default is 0.
+
+        copy : bool, optional
+            If `True` then the returned cutout array will always be hold
+            a copy of the input ``data``.  If `False` and the mask is
+            fully within the input ``data``, then the returned cutout
+            array will be a view into the input ``data``.  In cases
+            where the mask partially overlaps or has no overlap with the
+            input ``data``, the returned cutout array will always hold a
+            copy of the input ``data`` (i.e. this keyword has no
+            effect).
 
         Returns
         -------
@@ -181,7 +191,10 @@ class Mask(object):
         if not partial_overlap:
             # try this for speed -- the result may still be a partial
             # overlap, in which case the next block will be triggered
-            cutout = data[self.bbox.slices]
+            if copy:
+                cutout = np.copy(data[self.bbox.slices])
+            else:
+                cutout = data[self.bbox.slices]
 
         if partial_overlap or (cutout.shape != self.shape):
             slices_large, slices_small = self._overlap_slices(data.shape)
@@ -189,6 +202,7 @@ class Mask(object):
             if slices_small is None:
                 return None    # no overlap
 
+            # cutout is a copy
             cutout = np.zeros(self.shape, dtype=data.dtype)
             cutout[:] = fill_value
             cutout[slices_small] = data[slices_large]

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -159,9 +159,17 @@ class Mask(object):
         """
 
         data = np.asanyarray(data)
-        cutout = data[self.bbox.slices]
 
-        if cutout.shape != self.shape:
+        partial_overlap = False
+        if self.bbox.ixmin < 0 or self.bbox.iymin < 0:
+            partial_overlap = True
+
+        if not partial_overlap:
+            # try this for speed -- the result may still be a partial
+            # overlap, in which case the next block will be triggered
+            cutout = data[self.bbox.slices]
+
+        if partial_overlap or (cutout.shape != self.shape):
             slices_large, slices_small = self._overlap_slices(data.shape)
 
             if slices_small is None:

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -239,4 +239,8 @@ class Mask(object):
             input ``data``.
         """
 
-        return self.cutout(data, fill_value=fill_value) * self.data
+        cutout = self.cutout(data, fill_value=fill_value)
+        if cutout is None:
+            return None
+        else:
+            return cutout * self.data

--- a/regions/core/tests/test_mask.py
+++ b/regions/core/tests/test_mask.py
@@ -1,0 +1,92 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+from ..bounding_box import BoundingBox
+from ..mask import Mask
+from ..pixcoord import PixCoord
+from ...shapes import CirclePixelRegion
+
+try:
+    import matplotlib    # noqa
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
+
+
+POSITIONS = [(-20, -20), (-20, 20), (20, -20), (60, 60)]
+
+
+def test_mask_input_shapes():
+    with pytest.raises(ValueError):
+        mask_data = np.ones((10, 10))
+        bbox = BoundingBox(5, 10, 5, 10)
+        Mask(mask_data, bbox)
+
+
+def test_mask_array():
+    mask_data = np.ones((10, 10))
+    bbox = BoundingBox(5, 15, 5, 15)
+    mask = Mask(mask_data, bbox)
+    data = np.array(mask)
+    assert_allclose(data, mask.data)
+
+
+def test_mask_cutout_shape():
+    mask_data = np.ones((10, 10))
+    bbox = BoundingBox(5, 15, 5, 15)
+    mask = Mask(mask_data, bbox)
+
+    with pytest.raises(ValueError):
+        mask.cutout(np.arange(10))
+
+    with pytest.raises(ValueError):
+        mask._overlap_slices((10,))
+
+    with pytest.raises(ValueError):
+        mask.to_image((10,))
+
+
+def test_mask_cutout_copy():
+    data = np.ones((50, 50))
+    aper = CirclePixelRegion(PixCoord(25, 25), radius=10.)
+    mask = aper.to_mask()
+    cutout = mask.cutout(data, copy=True)
+    data[25, 25] = 100.
+    assert cutout[10, 10] == 1.
+
+
+@pytest.mark.parametrize('position', POSITIONS)
+def test_mask_cutout_no_overlap(position):
+    data = np.ones((50, 50))
+    aper = CirclePixelRegion(PixCoord(position[0], position[1]), radius=10.)
+    mask = aper.to_mask()
+
+    cutout = mask.cutout(data)
+    assert cutout is None
+
+    weighted_data = mask.multiply(data)
+    assert weighted_data is None
+
+    image = mask.to_image(data.shape)
+    assert image is None
+
+
+@pytest.mark.parametrize('position', POSITIONS)
+def test_mask_cutout_partial_overlap(position):
+    data = np.ones((50, 50))
+    aper = CirclePixelRegion(PixCoord(position[0], position[1]), radius=30.)
+    mask = aper.to_mask()
+
+    cutout = mask.cutout(data)
+    assert cutout.shape == mask.shape
+
+    weighted_data = mask.multiply(data)
+    assert weighted_data.shape == mask.shape
+
+    image = mask.to_image(data.shape)
+    assert image.shape == data.shape


### PR DESCRIPTION
This PR fixes a bug in region mask cutouts that is triggered when the region `x` and `y` positions are both negative *and* the region has no overlap with the data.  Simple example:

```python
from regions import CirclePixelRegion, PixCoord
reg = CirclePixelRegion(PixCoord(-20, -20), radius=10.)
mask  = reg.to_mask()
data = np.ones((50, 50))
cutout = mask.cutout(data)
```

The `cutout` result should be `None`, since the region has no overlap with the data.  This PR fixes that.

This PR also add a `copy` keyword to the `cutout()` method and adds unit tests for `Mask` (there were none before), including a regression test for this issue.

This issue was fixed in `photutils` in https://github.com/astropy/photutils/pull/646.