### PR TITLE
Update package infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ distribute-*.tar.gz
 
 # Mac OSX
 .DS_Store
+
+# Pytest
+.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ matrix:
           env: NUMPY_VERSION=1.10
         - python: 3.4
           env: NUMPY_VERSION=1.9
+               PIP_DEPENDENCIES='pytest>=3.1'
 
         # Try numpy pre-release
         - python: 3.6

--- a/regions/_astropy_init.py
+++ b/regions/_astropy_init.py
@@ -22,11 +22,13 @@ try:
 except ImportError:
     __githash__ = ''
 
+
 # set up the test command
 def _get_test_runner():
     import os
     from astropy.tests.helper import TestRunner
     return TestRunner(os.path.dirname(__file__))
+
 
 def test(package=None, test_path=None, args=None, plugins=None,
          verbose=False, pastebin=None, remote_data=False, pep8=False,
@@ -87,7 +89,7 @@ def test(package=None, test_path=None, args=None, plugins=None,
     open_files : bool, optional
         Fail when any tests leave files open.  Off by default, because
         this adds extra run time to the test suite.  Requires the
-        `psutil` package.
+        `psutil <https://pypi.python.org/pypi/psutil>`_ package.
 
     parallel : int, optional
         When provided, run the tests in parallel on the specified
@@ -110,10 +112,13 @@ def test(package=None, test_path=None, args=None, plugins=None,
         remote_data=remote_data, pep8=pep8, pdb=pdb,
         coverage=coverage, open_files=open_files, **kwargs)
 
-if not _ASTROPY_SETUP_:
+if not _ASTROPY_SETUP_:  # noqa
     import os
     from warnings import warn
-    from astropy import config
+    from astropy.config.configuration import (
+        update_default_config,
+        ConfigurationDefaultMissingError,
+        ConfigurationDefaultMissingWarning)
 
     # add these here so we only need to cleanup the namespace at the end
     config_dir = None
@@ -123,16 +128,16 @@ if not _ASTROPY_SETUP_:
         config_template = os.path.join(config_dir, __package__ + ".cfg")
         if os.path.isfile(config_template):
             try:
-                config.configuration.update_default_config(
+                update_default_config(
                     __package__, config_dir, version=__version__)
             except TypeError as orig_error:
                 try:
-                    config.configuration.update_default_config(
-                        __package__, config_dir)
-                except config.configuration.ConfigurationDefaultMissingError as e:
-                    wmsg = (e.args[0] + " Cannot install default profile. If you are "
+                    update_default_config(__package__, config_dir)
+                except ConfigurationDefaultMissingError as e:
+                    wmsg = (e.args[0] +
+                            " Cannot install default profile. If you are "
                             "importing from source, this is expected.")
-                    warn(config.configuration.ConfigurationDefaultMissingWarning(wmsg))
+                    warn(ConfigurationDefaultMissingWarning(wmsg))
                     del e
-                except:
+                except Exception:
                     raise orig_error

--- a/regions/conftest.py
+++ b/regions/conftest.py
@@ -13,32 +13,38 @@ else:
     # function name.
     del pytest_arraydiff
 
-from astropy.tests.pytest_plugins import *
+from astropy.tests.pytest_plugins import *    # noqa
 
-## Uncomment the following line to treat all DeprecationWarnings as
-## exceptions
-enable_deprecations_as_exceptions()
+# Uncomment the following line to treat all DeprecationWarnings as
+# exceptions
+# enable_deprecations_as_exceptions()    # noqa
 
-# The KeyError below is essential in some cases when the package uses other
-# astropy affiliated packages.
+# Uncomment and customize the following lines to add/remove entries from
+# the list of packages for which version numbers are displayed when running
+# the tests. Making it pass for KeyError is essential in some cases when
+# the package uses other astropy affiliated packages.
 try:
-    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
-    del PYTEST_HEADER_MODULES['h5py']
-    del PYTEST_HEADER_MODULES['Pandas']
-except KeyError:
+    PYTEST_HEADER_MODULES['Cython'] = 'Cython'    # noqa
+    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'    # noqa
+    del PYTEST_HEADER_MODULES['h5py']    # noqa
+    del PYTEST_HEADER_MODULES['Pandas']    # noqa
+except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
     pass
 
-## Uncomment the following lines to display the version number of the
-## package rather than the version number of Astropy in the top line when
-## running the tests.
+# Uncomment the following lines to display the version number of the
+# package rather than the version number of Astropy in the top line when
+# running the tests.
 import os
 
-## This is to figure out the affiliated package version, rather than
-## using Astropy's
+# This is to figure out the affiliated package version, rather than
+# using Astropy's
 try:
     from .version import version
 except ImportError:
     version = 'dev'
 
-packagename = os.path.basename(os.path.dirname(__file__))
-TESTED_VERSIONS[packagename] = version
+try:
+    packagename = os.path.basename(os.path.dirname(__file__))
+    TESTED_VERSIONS[packagename] = version    # noqa
+except NameError:   # Needed to support Astropy <= 1.0.0
+    pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[build_docs]
+[build_sphinx]
 source-dir = docs
 build-dir = docs/_build
 all_files = 1
@@ -7,8 +7,8 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
-minversion = 2.2
+[tool:pytest]
+minversion = 3.1
 norecursedirs = build docs/_build
 addopts = --arraydiff -p no:warnings
 # TODO: re-activate doctests.


### PR DESCRIPTION
This PR updates some of the package infrastructure.  It's motivated by the fact that I couldn't run `pytest` directly within the package.  That's fixed now.