### PR TITLE
Rename Mask class and add origin arg to plot methods

### DIFF
--- a/docs/plot_compound.py
+++ b/docs/plot_compound.py
@@ -56,8 +56,8 @@ ax.scatter(skycoords_xor.l.value, skycoords_xor.b.value, color='orange',
 ax.scatter(skycoords_and.l.value, skycoords_and.b.value, color='magenta',
            label='and', transform=ax.get_transform('galactic'))
 
-circle1.to_pixel(wcs=wcs).plot(ax, edgecolor='green', facecolor='none', alpha=0.8, lw=3)
-circle2.to_pixel(wcs=wcs).plot(ax, edgecolor='red', facecolor='none', alpha=0.8, lw=3)
+circle1.to_pixel(wcs=wcs).plot(ax=ax, edgecolor='green', facecolor='none', alpha=0.8, lw=3)
+circle2.to_pixel(wcs=wcs).plot(ax=ax, edgecolor='red', facecolor='none', alpha=0.8, lw=3)
 
 ax.legend(loc='lower right')
 

--- a/docs/plot_example.py
+++ b/docs/plot_example.py
@@ -27,6 +27,6 @@ for source in dataset.source_table:
     region = CircleSkyRegion(center=center, radius=radius)
     pix_region = region.to_pixel(wcs=wcs)
 
-    pix_region.plot(ax, edgecolor='yellow', facecolor='yellow', alpha=0.5, lw=3)
+    pix_region.plot(ax=ax, edgecolor='yellow', facecolor='yellow', alpha=0.5, lw=3)
 
 plt.show()

--- a/docs/plot_example_pix.py
+++ b/docs/plot_example_pix.py
@@ -9,5 +9,5 @@ region = CirclePixelRegion(center=PixCoord(x=3, y=5), radius=3)
 
 data = np.arange(10 * 15).reshape((10, 15))
 ax.imshow(data, cmap='gray', interpolation='nearest', origin='lower')
-region.plot(ax, color='red')
+region.plot(ax=ax, color='red')
 plt.show()

--- a/docs/plot_reg.py
+++ b/docs/plot_reg.py
@@ -19,6 +19,6 @@ ax.set_ylim([-0.5, 892.5])
 regs = read_ds9('plot_image.reg')
 
 for i, reg in enumerate(regs):
-    reg.plot(ax)
+    reg.plot(ax=ax)
 
 plt.show()

--- a/docs/plotting.rst
+++ b/docs/plotting.rst
@@ -21,6 +21,8 @@ To draw a matplotlib patch object, add it to an `matplotlib.axes.Axes` object.
     axes = plt.gca()
     axes.set_aspect('equal')
     axes.add_patch(patch)
+    axes.set_xlim([-0.5, 1])
+    axes.set_ylim([-0.5, 1])
 
     plt.show()
 
@@ -29,10 +31,28 @@ The :meth:`~regions.PixelRegion.plot`, a convenience method just does these two
 steps at once (creating a matplotlib patch and adding it to an axis),
 and calls ``plt.gca()`` if no axis is passed in.
 
+You can shift the origin of the region very conveniently while plotting by simply
+supplying the ``origin`` pixel coordinates to :meth:`~regions.PixelRegion.plot`,
+:meth:`~regions.PixelRegion.as_patch`. The ``**kwargs`` argument takes any
+keyword argument that the `~matplotlib.patches.Patch` object accepts. For Ex:
+
+.. plot::
+   :include-source:
+
+    from regions import PixCoord, BoundingBox
+    import matplotlib.pyplot as plt
+
+    bbox = BoundingBox(ixmin=-1, ixmax=1, iymin=-2, iymax=2)
+    region = bbox.to_region()
+    # shifting the origin to (1, 1) pixel position
+    ax = region.plot(origin=(1, 1), edgecolor='yellow', facecolor='red', fill=True)
+    ax.set_xlim([-4, 2])
+    ax.set_ylim([-4, 2])
+    plt.show()
+
 Note that not all pixel regions have ``as_patch()`` methods, e.g.
-the `~regions.CircleAnnulusRegion`, `~regions.PointPixelRegion` and
-`~regions.CompundPixelRegion` don't have because there are no equivalent classes
-in `matplotlib.patches`.
+the `~regions.TextPixelRegion` and `~regions.CompoundPixelRegion`
+don't have because there are no equivalent classes in `matplotlib.patches`.
 
 Here's a full example how to plot a `~regions.CirclePixelRegion` on an image.
 

--- a/docs/plotting.rst
+++ b/docs/plotting.rst
@@ -32,8 +32,8 @@ steps at once (creating a matplotlib patch and adding it to an axis),
 and calls ``plt.gca()`` if no axis is passed in.
 
 You can shift the origin of the region very conveniently while plotting by simply
-supplying the ``origin`` pixel coordinates to :meth:`~regions.PixelRegion.plot`,
-:meth:`~regions.PixelRegion.as_patch`. The ``**kwargs`` argument takes any
+supplying the ``origin`` pixel coordinates to :meth:`~regions.PixelRegion.plot`
+and :meth:`~regions.PixelRegion.as_patch`. The ``**kwargs`` argument takes any
 keyword argument that the `~matplotlib.patches.Patch` object accepts. For Ex:
 
 .. plot::
@@ -43,9 +43,8 @@ keyword argument that the `~matplotlib.patches.Patch` object accepts. For Ex:
     import matplotlib.pyplot as plt
 
     bbox = BoundingBox(ixmin=-1, ixmax=1, iymin=-2, iymax=2)
-    region = bbox.to_region()
     # shifting the origin to (1, 1) pixel position
-    ax = region.plot(origin=(1, 1), edgecolor='yellow', facecolor='red', fill=True)
+    ax = bbox.plot(origin=(1, 1), edgecolor='yellow', facecolor='red', fill=True)
     ax.set_xlim([-4, 2])
     ax.set_ylim([-4, 2])
     plt.show()

--- a/docs/plotting.rst
+++ b/docs/plotting.rst
@@ -34,7 +34,7 @@ and calls ``plt.gca()`` if no axis is passed in.
 You can shift the origin of the region very conveniently while plotting by simply
 supplying the ``origin`` pixel coordinates to :meth:`~regions.PixelRegion.plot`
 and :meth:`~regions.PixelRegion.as_patch`. The ``**kwargs`` argument takes any
-keyword argument that the `~matplotlib.patches.Patch` object accepts. For Ex:
+keyword argument that the `~matplotlib.patches.Patch` object accepts. For e.g.:
 
 .. plot::
    :include-source:
@@ -49,9 +49,9 @@ keyword argument that the `~matplotlib.patches.Patch` object accepts. For Ex:
     ax.set_ylim([-4, 2])
     plt.show()
 
-Note that not all pixel regions have ``as_patch()`` methods, e.g.
-the `~regions.TextPixelRegion` and `~regions.CompoundPixelRegion`
-don't have because there are no equivalent classes in `matplotlib.patches`.
+Pixel regions such as `~regions.TextPixelRegion` and
+`~regions.CompoundPixelRegion` don't have ``as_patch()`` method as
+there are no equivalent classes in `matplotlib.patches`.
 
 Here's a full example how to plot a `~regions.CirclePixelRegion` on an image.
 

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -231,7 +231,7 @@ class BoundingBox(object):
         xypos = PixCoord(xpos, ypos)
         h, w = self.shape
 
-        return RectanglePixelRegion(xypos, width=w, height=h, angle=0.)
+        return RectanglePixelRegion(center=xypos, width=w, height=h)
 
     def plot(self, origin=(0, 0), ax=None, **kwargs):
         """

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -248,7 +248,12 @@ class BoundingBox(object):
             is used.
         kwargs
             Any keyword arguments accepted by `matplotlib.patches.Patch`.
+
+        Returns
+        -------
+        ax: `~matplotlib.axes`
+            Axes on which the patch is added.
         """
 
         reg = self.to_region()
-        reg.plot(origin=origin, ax=ax, **kwargs)
+        return reg.plot(origin=origin, ax=ax, **kwargs)

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -188,7 +188,7 @@ class BoundingBox(object):
 
         Parameters
         ----------
-        kwargs
+        kwargs : `dict`
             Any keyword arguments accepted by
             `matplotlib.patches.Patch`.
 
@@ -246,12 +246,12 @@ class BoundingBox(object):
         ax : `matplotlib.axes.Axes` instance, optional
             If `None`, then the current `~matplotlib.axes.Axes` instance
             is used.
-        kwargs
+        kwargs : `dict`
             Any keyword arguments accepted by `matplotlib.patches.Patch`.
 
         Returns
         -------
-        ax: `~matplotlib.axes`
+        ax : `~matplotlib.axes.Axes`
             Axes on which the patch is added.
         """
 

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -216,3 +216,39 @@ class BoundingBox(object):
 
         return Rectangle(xy=(self.extent[0], self.extent[2]),
                          width=self.shape[1], height=self.shape[0], **kwargs)
+
+    def to_region(self):
+        """
+        Return a `~regions.RectanglePixelRegion` that
+        represents the bounding box.
+        """
+
+        from ..shapes import RectanglePixelRegion
+        from .pixcoord import PixCoord
+
+        xpos = (self.extent[1] + self.extent[0]) / 2.
+        ypos = (self.extent[3] + self.extent[2]) / 2.
+        xypos = PixCoord(xpos, ypos)
+        h, w = self.shape
+
+        return RectanglePixelRegion(xypos, width=w, height=h, angle=0.)
+
+    def plot(self, origin=(0, 0), ax=None, **kwargs):
+        """
+        Plot the `BoundingBox` on a matplotlib `~matplotlib.axes.Axes`
+        instance.
+
+        Parameters
+        ----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed
+            image.
+        ax : `matplotlib.axes.Axes` instance, optional
+            If `None`, then the current `~matplotlib.axes.Axes` instance
+            is used.
+        kwargs
+            Any keyword arguments accepted by `matplotlib.patches.Patch`.
+        """
+
+        reg = self.to_region()
+        reg.plot(origin=origin, ax=ax, **kwargs)

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -129,13 +129,29 @@ class CompoundPixelRegion(PixelRegion):
 
         return mpath.Path(verts, codes)
 
-    def as_patch(self, **kwargs):
+    def as_patch(self, origin=(0, 0), **kwargs):
+        """
+        Matplotlib patch object for annulus region (`matplotlib.patches.PathPatch`).
+
+        Parameters:
+        -----------
+        origin : array_like, optional
+            The ``(x, y)`` pixel position of the origin of the displayed image.
+            Default is (0, 0).
+        kwargs: dict
+            All keywords that a `~matplotlib.patches.PathPatch` object accepts
+
+        Returns
+        -------
+        patch : `~matplotlib.patches.PathPatch`
+            Matplotlib patch object
+        """
 
         if self.region1.center == self.region2.center and self.operator == op.xor:
             import matplotlib.patches as mpatches
 
-            patch_inner = self.region1.as_patch()
-            patch_outer = self.region2.as_patch()
+            patch_inner = self.region1.as_patch(origin=origin)
+            patch_outer = self.region2.as_patch(origin=origin)
             path = self._make_annulus_path(patch_inner, patch_outer)
             patch = mpatches.PathPatch(path, **kwargs)
             return patch

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -133,12 +133,12 @@ class CompoundPixelRegion(PixelRegion):
         """
         Matplotlib patch object for annulus region (`matplotlib.patches.PathPatch`).
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         origin : array_like, optional
             The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
-        kwargs: dict
+        kwargs : `dict`
             All keywords that a `~matplotlib.patches.PathPatch` object accepts
 
         Returns

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -5,9 +5,9 @@ import operator as op
 
 import numpy as np
 
-from . import PixelRegion, SkyRegion, BoundingBox, Mask
+from . import PixelRegion, SkyRegion, BoundingBox, RegionMask
 from ..core.attributes import (CompoundRegionPix, CompoundRegionSky,
-                               RegionVisual, RegionMeta)
+                               RegionMeta, RegionVisual)
 
 __all__ = ['CompoundPixelRegion', 'CompoundSkyRegion']
 
@@ -91,7 +91,7 @@ class CompoundPixelRegion(PixelRegion):
                                       'constant'))
 
         data = self.operator(*np.array(padded_data, dtype=np.int))
-        return Mask(data=data, bbox=bbox)
+        return RegionMask(data=data, bbox=bbox)
 
     def to_sky(self, wcs):
         skyreg1 = self.region1.to_sky(wcs=wcs)

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -306,7 +306,7 @@ class PixelRegion(Region):
         Returns
         -------
         ax: `~matplotlib.axes`
-            Axis on which the patch is added.
+            Axes on which the patch is added.
         """
         import matplotlib.pyplot as plt
 

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -240,6 +240,15 @@ class PixelRegion(Region):
         """
         Convert to mpl patch
 
+        Parameters
+        ----------
+        origin : array_like, optional
+            The ``(x, y)`` pixel position of the origin of the displayed image.
+            Default is (0, 0).
+
+        kwargs: `dict`
+            keywords that a `~matplotlib.patches.Patch` accepts
+
         Returns
         -------
         patch : `~matplotlib.patches.Patch`
@@ -287,7 +296,7 @@ class PixelRegion(Region):
         Parameters
         ----------
         origin : array_like, optional
-            The ``(x, y)`` position of the origin of the displayed image.
+            The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
         ax : `~matplotlib.axes`, optional
             Axis

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -301,7 +301,7 @@ class PixelRegion(Region):
         ax : `~matplotlib.axes`, optional
             Axis
         kwargs: `dict`
-            keywords that a `~matplotlib.text.Text` accepts
+            keywords that a `~matplotlib.patches.Patch` accepts
 
         Returns
         -------
@@ -313,9 +313,7 @@ class PixelRegion(Region):
         if ax is None:
             ax = plt.gca()
 
-        mpl_params = self.mpl_properties_default('patch')
-        mpl_params.update(kwargs)
-        patch = self.as_patch(**mpl_params)
+        patch = self.as_patch(origin=origin, **kwargs)
         ax.add_patch(patch)
 
         return ax

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -236,7 +236,7 @@ class PixelRegion(Region):
                                  " a strictly positive integer)".format(subpixels))
 
     @abc.abstractmethod
-    def as_patch(self, **kwargs):
+    def as_patch(self, origin=(0, 0), **kwargs):
         """
         Convert to mpl patch
 
@@ -279,13 +279,16 @@ class PixelRegion(Region):
 
         return kwargs
 
-    def plot(self, ax=None, **kwargs):
+    def plot(self, origin=(0, 0), ax=None, **kwargs):
         """
         Calls ``as_patch`` method forwarding all kwargs and adds patch
         to given axis.
 
         Parameters
         ----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed image.
+            Default is (0, 0).
         ax : `~matplotlib.axes`, optional
             Axis
         kwargs: `dict`

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -6,10 +6,10 @@ import numpy as np
 import astropy.units as u
 
 
-__all__ = ['Mask']
+__all__ = ['RegionMask']
 
 
-class Mask(object):
+class RegionMask(object):
     """
     Class for a region mask.
 

--- a/regions/core/tests/test_mask.py
+++ b/regions/core/tests/test_mask.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from ..bounding_box import BoundingBox
-from ..mask import Mask
+from ..mask import RegionMask
 from ..pixcoord import PixCoord
 from ...shapes import CirclePixelRegion
 
@@ -25,13 +25,13 @@ def test_mask_input_shapes():
     with pytest.raises(ValueError):
         mask_data = np.ones((10, 10))
         bbox = BoundingBox(5, 10, 5, 10)
-        Mask(mask_data, bbox)
+        RegionMask(mask_data, bbox)
 
 
 def test_mask_array():
     mask_data = np.ones((10, 10))
     bbox = BoundingBox(5, 15, 5, 15)
-    mask = Mask(mask_data, bbox)
+    mask = RegionMask(mask_data, bbox)
     data = np.array(mask)
     assert_allclose(data, mask.data)
 
@@ -39,7 +39,7 @@ def test_mask_array():
 def test_mask_cutout_shape():
     mask_data = np.ones((10, 10))
     bbox = BoundingBox(5, 15, 5, 15)
-    mask = Mask(mask_data, bbox)
+    mask = RegionMask(mask_data, bbox)
 
     with pytest.raises(ValueError):
         mask.cutout(np.arange(10))

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -123,10 +123,25 @@ class CirclePixelRegion(PixelRegion):
 
         return Mask(fraction, bbox=bbox)
 
-    def as_patch(self, **kwargs):
-        """Matplotlib patch object for this region (`matplotlib.patches.Circle`)"""
+    def as_patch(self, origin=(0, 0), **kwargs):
+        """
+        Matplotlib patch object for this region (`matplotlib.patches.Circle`)
+
+        Parameters:
+        -----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed image.
+            Default is (0, 0).
+        kwargs: dict
+            All keywords that a `~matplotlib.patches.Circle` object accepts
+
+        Returns
+        -------
+        patch : `~matplotlib.patches.Circle`
+            Matplotlib circle patch
+        """
         from matplotlib.patches import Circle
-        xy = self.center.x, self.center.y
+        xy = self.center.x - origin[0], self.center.y - origin[1]
         radius = self.radius
         return Circle(xy=xy, radius=radius, **kwargs)
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -130,7 +130,7 @@ class CirclePixelRegion(PixelRegion):
         Parameters:
         -----------
         origin : array_like, optional
-            The ``(x, y)`` position of the origin of the displayed image.
+            The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
         kwargs: dict
             All keywords that a `~matplotlib.patches.Circle` object accepts

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -143,7 +143,11 @@ class CirclePixelRegion(PixelRegion):
         from matplotlib.patches import Circle
         xy = self.center.x - origin[0], self.center.y - origin[1]
         radius = self.radius
-        return Circle(xy=xy, radius=radius, **kwargs)
+
+        mpl_params = self.mpl_properties_default('patch')
+        mpl_params.update(kwargs)
+
+        return Circle(xy=xy, radius=radius, **mpl_params)
 
 
 class CircleSkyRegion(SkyRegion):

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -7,7 +7,7 @@ import math
 from astropy.coordinates import Angle, SkyCoord
 from astropy.wcs.utils import pixel_to_skycoord
 
-from ..core import PixCoord, PixelRegion, SkyRegion, Mask, BoundingBox
+from ..core import PixCoord, PixelRegion, SkyRegion, RegionMask, BoundingBox
 from .._utils.wcs_helpers import skycoord_to_pixel_scale_angle
 from .._geometry import circular_overlap_grid
 from ..core.attributes import (ScalarSky, ScalarPix, QuantityLength,
@@ -121,7 +121,7 @@ class CirclePixelRegion(PixelRegion):
         fraction = circular_overlap_grid(xmin, xmax, ymin, ymax, nx, ny,
                                          self.radius, use_exact, subpixels)
 
-        return Mask(fraction, bbox=bbox)
+        return RegionMask(fraction, bbox=bbox)
 
     def as_patch(self, origin=(0, 0), **kwargs):
         """

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -8,7 +8,7 @@ from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.wcs.utils import pixel_to_skycoord
 
-from ..core import PixCoord, PixelRegion, SkyRegion, Mask, BoundingBox
+from ..core import PixCoord, PixelRegion, SkyRegion, RegionMask, BoundingBox
 from .._geometry import elliptical_overlap_grid
 from .._utils.wcs_helpers import skycoord_to_pixel_scale_angle
 from ..core.attributes import (ScalarPix, ScalarLength, QuantityLength,
@@ -180,7 +180,7 @@ class EllipsePixelRegion(PixelRegion):
             use_exact, subpixels,
         )
 
-        return Mask(fraction, bbox=bbox)
+        return RegionMask(fraction, bbox=bbox)
 
     def as_patch(self, origin=(0, 0), **kwargs):
         """

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -189,7 +189,7 @@ class EllipsePixelRegion(PixelRegion):
         Parameters:
         -----------
         origin : array_like, optional
-            The ``(x, y)`` position of the origin of the displayed image.
+            The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
         kwargs: dict
             All keywords that a `~matplotlib.patches.Ellipse` object accepts

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -182,10 +182,26 @@ class EllipsePixelRegion(PixelRegion):
 
         return Mask(fraction, bbox=bbox)
 
-    def as_patch(self, **kwargs):
-        """Matplotlib patch object for this region (`matplotlib.patches.Ellipse`)."""
+    def as_patch(self, origin=(0, 0), **kwargs):
+        """
+        Matplotlib patch object for this region (`matplotlib.patches.Ellipse`).
+
+        Parameters:
+        -----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed image.
+            Default is (0, 0).
+        kwargs: dict
+            All keywords that a `~matplotlib.patches.Ellipse` object accepts
+
+        Returns
+        -------
+        patch : `~matplotlib.patches.Ellipse`
+            Matplotlib ellipse patch
+
+        """
         from matplotlib.patches import Ellipse
-        xy = self.center.x, self.center.y
+        xy = self.center.x - origin[0], self.center.y - origin[1]
         width = self.width
         height = self.height
         # From the docstring: MPL expects "rotation in degrees (anti-clockwise)"

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -206,7 +206,12 @@ class EllipsePixelRegion(PixelRegion):
         height = self.height
         # From the docstring: MPL expects "rotation in degrees (anti-clockwise)"
         angle = self.angle.to('deg').value
-        return Ellipse(xy=xy, width=width, height=height, angle=angle, **kwargs)
+
+        mpl_params = self.mpl_properties_default('patch')
+        mpl_params.update(kwargs)
+
+        return Ellipse(xy=xy, width=width, height=height, angle=angle,
+                       **mpl_params)
 
 
 class EllipseSkyRegion(SkyRegion):

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -129,7 +129,10 @@ class LinePixelRegion(PixelRegion):
         if not 'width' in kwargs:
             kwargs['width'] = .1  # Let the default width be .1 instead of 1.
 
-        return Arrow(x, y, dx, dy, **kwargs)
+        mpl_params = self.mpl_properties_default('patch')
+        mpl_params.update(kwargs)
+
+        return Arrow(x, y, dx, dy, **mpl_params)
 
 
 class LineSkyRegion(SkyRegion):

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -99,16 +99,31 @@ class LinePixelRegion(PixelRegion):
         # TODO: needs to be implemented
         raise NotImplementedError
 
-    def as_patch(self, **kwargs):
-        """Matplotlib patch object for this region (`matplotlib.patches.Line`)."""
+    def as_patch(self, origin=(0, 0), **kwargs):
+        """
+        Matplotlib patch object for this region (`matplotlib.patches.Arrow`).
+
+        Parameters:
+        -----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed image.
+            Default is (0, 0).
+        kwargs: dict
+            All keywords that a `~matplotlib.patches.Arrow` object accepts
+
+        Returns
+        -------
+        patch : `~matplotlib.patches.Arrow`
+            Matplotlib line patch
+        """
         # Long term we want to support DS9 lines with arrow heads
 
         # We may want to use Line2D instead of arrow for lines because the width
         # of the arrow is non-scalable in patches
 
         from matplotlib.patches import Arrow
-        x = self.start.x
-        y = self.start.y
+        x = self.start.x - origin[0]
+        y = self.start.y - origin[1]
         dx = self.end.x - self.start.x
         dy = self.end.y - self.start.y
         if not 'width' in kwargs:

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -106,7 +106,7 @@ class LinePixelRegion(PixelRegion):
         Parameters:
         -----------
         origin : array_like, optional
-            The ``(x, y)`` position of the origin of the displayed image.
+            The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
         kwargs: dict
             All keywords that a `~matplotlib.patches.Arrow` object accepts

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -93,13 +93,16 @@ class PointPixelRegion(PixelRegion):
         from matplotlib.patches import Circle
         return Circle((self.center.x, self.center.y), radius=2, **kwargs)
 
-    def plot(self, ax=None, **kwargs):
+    def plot(self, origin=(0, 0), ax=None, **kwargs):
         """
         Forwards all kwargs to `Line2D` object and adds the line
         to given axis.
 
         Parameters
         ----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed image.
+            Default is (0, 0).
         ax: `~matplotlib.axes`, optional
                     Axis
         kwargs: dict

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -88,7 +88,23 @@ class PointPixelRegion(PixelRegion):
         # TODO: needs to be implemented
         raise NotImplementedError
 
-    def as_patch(self, **kwargs):
+    def as_patch(self, origin=(0, 0), **kwargs):
+        """
+        Matplotlib patch object for this region (`matplotlib.patches.Circle`).
+
+        Parameters:
+        -----------
+        origin : array_like, optional
+            The ``(x, y)`` pixel position of the origin of the displayed image.
+            Default is (0, 0).
+        kwargs: dict
+            All keywords that a `~matplotlib.patches.Circle` object accepts
+
+        Returns
+        -------
+        patch : `~matplotlib.patches.Circle`
+            Matplotlib circle patch
+        """
         # FIXME: need to make radius constant
         from matplotlib.patches import Circle
         return Circle((self.center.x, self.center.y), radius=2, **kwargs)
@@ -101,7 +117,7 @@ class PointPixelRegion(PixelRegion):
         Parameters
         ----------
         origin : array_like, optional
-            The ``(x, y)`` position of the origin of the displayed image.
+            The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
         ax: `~matplotlib.axes`, optional
                     Axis

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -124,7 +124,7 @@ class PointPixelRegion(PixelRegion):
             The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
         ax: `~matplotlib.axes`, optional
-                    Axis
+            Axes on which the point is added
         kwargs: dict
             All keywords that a ``Line2D`` object accepts
         """

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -107,7 +107,11 @@ class PointPixelRegion(PixelRegion):
         """
         # FIXME: need to make radius constant
         from matplotlib.patches import Circle
-        return Circle((self.center.x, self.center.y), radius=2, **kwargs)
+
+        mpl_params = self.mpl_properties_default('patch')
+        mpl_params.update(kwargs)
+
+        return Circle((self.center.x, self.center.y), radius=2, **mpl_params)
 
     def plot(self, origin=(0, 0), ax=None, **kwargs):
         """

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -144,7 +144,11 @@ class PolygonPixelRegion(PixelRegion):
         from matplotlib.patches import Polygon
         xy = np.vstack([self.vertices.x - origin[0],
                         self.vertices.y - origin[1]]).transpose()
-        return Polygon(xy=xy, **kwargs)
+
+        mpl_params = self.mpl_properties_default('patch')
+        mpl_params.update(kwargs)
+
+        return Polygon(xy=xy, **mpl_params)
 
 
 class PolygonSkyRegion(SkyRegion):

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -131,7 +131,7 @@ class PolygonPixelRegion(PixelRegion):
         Parameters:
         -----------
         origin : array_like, optional
-            The ``(x, y)`` position of the origin of the displayed image.
+            The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
         kwargs: dict
             All keywords that a `~matplotlib.patches.Polygon` object accepts

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -124,10 +124,26 @@ class PolygonPixelRegion(PixelRegion):
 
         return Mask(fraction, bbox=bbox)
 
-    def as_patch(self, **kwargs):
-        """Matplotlib patch object for this region (`matplotlib.patches.Polygon`)."""
+    def as_patch(self, origin=(0, 0), **kwargs):
+        """
+        Matplotlib patch object for this region (`matplotlib.patches.Polygon`).
+
+        Parameters:
+        -----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed image.
+            Default is (0, 0).
+        kwargs: dict
+            All keywords that a `~matplotlib.patches.Polygon` object accepts
+
+        Returns
+        -------
+        patch : `~matplotlib.patches.Polygon`
+            Matplotlib polygon patch
+        """
         from matplotlib.patches import Polygon
-        xy = np.vstack([self.vertices.x, self.vertices.y]).transpose()
+        xy = np.vstack([self.vertices.x - origin[0],
+                        self.vertices.y - origin[1]]).transpose()
         return Polygon(xy=xy, **kwargs)
 
 

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from astropy.wcs.utils import skycoord_to_pixel, pixel_to_skycoord
 
-from ..core import PixelRegion, SkyRegion, Mask, BoundingBox, PixCoord
+from ..core import PixelRegion, SkyRegion, RegionMask, BoundingBox, PixCoord
 from .._geometry import polygonal_overlap_grid
 from .._geometry.pnpoly import points_in_polygon
 from ..core.attributes import OneDPix, OneDSky, RegionMeta, RegionVisual
@@ -122,7 +122,7 @@ class PolygonPixelRegion(PixelRegion):
             nx, ny, vx, vy, use_exact, subpixels,
         )
 
-        return Mask(fraction, bbox=bbox)
+        return RegionMask(fraction, bbox=bbox)
 
     def as_patch(self, origin=(0, 0), **kwargs):
         """

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -7,7 +7,7 @@ from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.wcs.utils import pixel_to_skycoord
 
-from ..core import PixCoord, PixelRegion, SkyRegion, Mask, BoundingBox
+from ..core import PixCoord, PixelRegion, SkyRegion, RegionMask, BoundingBox
 from .._geometry import rectangular_overlap_grid
 from .._utils.wcs_helpers import skycoord_to_pixel_scale_angle
 from ..core.attributes import ScalarPix, ScalarLength, QuantityLength, ScalarSky
@@ -164,7 +164,7 @@ class RectanglePixelRegion(PixelRegion):
             use_exact, subpixels,
         )
 
-        return Mask(fraction, bbox=bbox)
+        return RegionMask(fraction, bbox=bbox)
 
     def as_patch(self, origin=(0, 0), **kwargs):
         """

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -173,7 +173,7 @@ class RectanglePixelRegion(PixelRegion):
         Parameters:
         -----------
         origin : array_like, optional
-            The ``(x, y)`` position of the origin of the displayed image.
+            The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
         kwargs: dict
             All keywords that a `~matplotlib.patches.Rectangle` object accepts

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -166,17 +166,32 @@ class RectanglePixelRegion(PixelRegion):
 
         return Mask(fraction, bbox=bbox)
 
-    def as_patch(self, **kwargs):
+    def as_patch(self, origin=(0, 0), **kwargs):
         """
         Matplotlib patch object for this region (`matplotlib.patches.Rectangle`).
+
+        Parameters:
+        -----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed image.
+            Default is (0, 0).
+        kwargs: dict
+            All keywords that a `~matplotlib.patches.Rectangle` object accepts
+
+        Returns
+        -------
+        patch : `~matplotlib.patches.Rectangle`
+            Matplotlib circle patch
         """
         from matplotlib.patches import Rectangle
         xy = self._lower_left_xy()
+        xy = xy[0] - origin[0], xy[1] - origin[1]
         width = self.width
         height = self.height
         # From the docstring: MPL expects "rotation in degrees (anti-clockwise)"
         angle = self.angle.to('deg').value
-        return Rectangle(xy=xy, width=width, height=height, angle=angle, **kwargs)
+        return Rectangle(xy=xy, width=width, height=height,
+                         angle=angle, **kwargs)
 
     def _lower_left_xy(self):
         """

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -190,8 +190,12 @@ class RectanglePixelRegion(PixelRegion):
         height = self.height
         # From the docstring: MPL expects "rotation in degrees (anti-clockwise)"
         angle = self.angle.to('deg').value
+
+        mpl_params = self.mpl_properties_default('patch')
+        mpl_params.update(kwargs)
+
         return Rectangle(xy=xy, width=width, height=height,
-                         angle=angle, **kwargs)
+                         angle=angle, **mpl_params)
 
     def _lower_left_xy(self):
         """

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -13,7 +13,7 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.wcs import WCS
 
-from ...core.mask import Mask
+from ...core.mask import RegionMask
 from ...core.core import Region, SkyRegion, PixelRegion
 from ...core.pixcoord import PixCoord
 from ..circle import CirclePixelRegion, CircleSkyRegion
@@ -91,7 +91,7 @@ def test_pix_to_sky(region):
 def test_pix_to_mask(region, mode):
     try:
         mask = region.to_mask(mode=mode)
-        assert isinstance(mask, Mask)
+        assert isinstance(mask, RegionMask)
     except NotImplementedError:
         pytest.xfail()
 

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -40,7 +40,7 @@ class TextPixelRegion(PointPixelRegion):
         center = PixCoord(x=x, y=y)
         reg = TextPixelRegion(center=center, text="Hello World!",
                               visual=RegionVisual(textangle=textangle))
-        reg.plot(ax)
+        reg.plot(ax=ax)
 
         plt.xlim(10, 30)
         plt.ylim(2.5, 20)

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -61,13 +61,16 @@ class TextPixelRegion(PointPixelRegion):
     def as_patch(self, **kwargs):
         raise NotImplementedError
 
-    def plot(self, ax=None, **kwargs):
+    def plot(self, origin=(0, 0), ax=None, **kwargs):
         """
         Forwarding all kwargs to `~matplotlib.text.Text` object and add it
         to given axis.
 
         Parameters
         ----------
+        origin : array_like, optional
+            The ``(x, y)`` position of the origin of the displayed image.
+            Default is (0, 0).
         ax : `~matplotlib.axes`, optional
             Axes
         kwargs: `dict`
@@ -86,7 +89,8 @@ class TextPixelRegion(PointPixelRegion):
 
         mpl_params = self.mpl_properties_default('text')
         mpl_params.update(kwargs)
-        text = Text(self.center.x, self.center.y, self.text, **mpl_params)
+        text = Text(self.center.x - origin[0], self.center.y - origin[1],
+                    self.text, **mpl_params)
 
         ax.add_artist(text)
 

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -69,7 +69,7 @@ class TextPixelRegion(PointPixelRegion):
         Parameters
         ----------
         origin : array_like, optional
-            The ``(x, y)`` position of the origin of the displayed image.
+            The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
         ax : `~matplotlib.axes`, optional
             Axes

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -79,7 +79,7 @@ class TextPixelRegion(PointPixelRegion):
         Returns
         -------
         ax : `~matplotlib.axes`
-            The axis with the patch.
+            The axes with the text.
         """
         import matplotlib.pyplot as plt
         from matplotlib.text import Text


### PR DESCRIPTION
According to discussion in https://github.com/astropy/photutils/issues/684
1. Added origin arg to plot methods (which is present in photutils)
2. Added `to_region` and `plot` methods to `BoundingBox`
3. Rename `Mask` to `RegionMask`. 

Now, `RegionMask` are `ApertureMask` are same both API and code wise.
Geometry functions and `BoundingBox` are also same in both packages.