### PR TITLE
The 'contains' method is supposed to work on arrays

### DIFF
--- a/dev/regions_pyregion_comparison.py
+++ b/dev/regions_pyregion_comparison.py
@@ -9,7 +9,7 @@ pyregion in two regards.
   in the file) that survives the parsing process
 
 The test files are the ones used since PyAstro16, see
-https://zenodo.org/record/5679://zenodo.org/record/56793 
+https://zenodo.org/record/5679://zenodo.org/record/56793
 
 """
 from pathlib import Path

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -59,7 +59,7 @@ class CompoundPixelRegion(PixelRegion):
         in_reg = self.operator(self.region1.contains(pixcoord),
                                self.region2.contains(pixcoord))
         if self.meta.get('include', False):
-            return not in_reg
+            return np.logical_not(in_reg)
         else:
             return in_reg
 

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -59,9 +59,9 @@ class CompoundPixelRegion(PixelRegion):
         in_reg = self.operator(self.region1.contains(pixcoord),
                                self.region2.contains(pixcoord))
         if self.meta.get('include', False):
-            return np.logical_not(in_reg)
-        else:
             return in_reg
+        else:
+            return np.logical_not(in_reg)
 
     def to_mask(self, mode='center', subpixels=1):
 

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -58,7 +58,7 @@ class CompoundPixelRegion(PixelRegion):
     def contains(self, pixcoord):
         in_reg = self.operator(self.region1.contains(pixcoord),
                                self.region2.contains(pixcoord))
-        if self.meta.get('include', False):
+        if self.meta.get('include', True):
             return in_reg
         else:
             return np.logical_not(in_reg)
@@ -198,10 +198,10 @@ class CompoundSkyRegion(SkyRegion):
     def contains(self, skycoord, wcs):
         in_reg = self.operator(self.region1.contains(skycoord, wcs),
                                self.region2.contains(skycoord, wcs))
-        if self.meta.get('include', False):
-            return not in_reg
-        else:
+        if self.meta.get('include', True):
             return in_reg
+        else:
+            return np.logical_not(in_reg)
 
     def to_pixel(self, wcs):
         pixreg1 = self.region1.to_pixel(wcs=wcs)

--- a/regions/io/core.py
+++ b/regions/io/core.py
@@ -717,7 +717,7 @@ def to_shape_list(region_list, coordinate_system='fk5'):
             meta['text'] = meta.get('text', meta.pop('label', ''))
 
         shape_list.append(Shape(coordsys, reg_type, new_coord, meta, False,
-                                region.meta.get('include', False)))
+                                region.meta.get('include', True)))
 
     return shape_list
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -74,7 +74,7 @@ class CirclePixelRegion(PixelRegion):
     def contains(self, pixcoord):
         pixcoord = PixCoord._validate(pixcoord, name='pixcoord')
         in_circle = self.center.separation(pixcoord) < self.radius
-        if self.meta.get('include', False):
+        if self.meta.get('include', True):
             return in_circle
         else:
             return np.logical_not(in_circle)

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import numpy as np
 import math
 
 from astropy.coordinates import Angle, SkyCoord
@@ -74,7 +75,7 @@ class CirclePixelRegion(PixelRegion):
         pixcoord = PixCoord._validate(pixcoord, name='pixcoord')
         in_circle = self.center.separation(pixcoord) < self.radius
         if self.meta.get('include', False):
-            return not in_circle
+            return np.logical_not(in_circle)
         else:
             return in_circle
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -75,9 +75,9 @@ class CirclePixelRegion(PixelRegion):
         pixcoord = PixCoord._validate(pixcoord, name='pixcoord')
         in_circle = self.center.separation(pixcoord) < self.radius
         if self.meta.get('include', False):
-            return np.logical_not(in_circle)
-        else:
             return in_circle
+        else:
+            return np.logical_not(in_circle)
 
     def to_shapely(self):
         return self.center.to_shapely().buffer(self.radius)

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -93,7 +93,7 @@ class EllipsePixelRegion(PixelRegion):
         dy = pixcoord.y - self.center.y
         in_ell = ((2 * (cos_angle * dx + sin_angle * dy) / self.width) ** 2 +
                   (2 * (sin_angle * dx - cos_angle * dy) / self.height) ** 2 <= 1.)
-        if self.meta.get('include', False):
+        if self.meta.get('include', True):
             return in_ell
         else:
             return np.logical_not(in_ell)

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -94,9 +94,9 @@ class EllipsePixelRegion(PixelRegion):
         in_ell = ((2 * (cos_angle * dx + sin_angle * dy) / self.width) ** 2 +
                   (2 * (sin_angle * dx - cos_angle * dy) / self.height) ** 2 <= 1.)
         if self.meta.get('include', False):
-            return np.logical_not(in_ell)
-        else:
             return in_ell
+        else:
+            return np.logical_not(in_ell)
 
     def to_shapely(self):
         from shapely import affinity

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -91,8 +91,12 @@ class EllipsePixelRegion(PixelRegion):
         sin_angle = np.sin(self.angle)
         dx = pixcoord.x - self.center.x
         dy = pixcoord.y - self.center.y
-        return ((2 * (cos_angle * dx + sin_angle * dy) / self.width) ** 2 +
-                (2 * (sin_angle * dx - cos_angle * dy) / self.height) ** 2 <= 1.)
+        in_ell = ((2 * (cos_angle * dx + sin_angle * dy) / self.width) ** 2 +
+                  (2 * (sin_angle * dx - cos_angle * dy) / self.height) ** 2 <= 1.)
+        if self.meta.get('include', False):
+            return np.logical_not(in_ell)
+        else:
+            return in_ell
 
     def to_shapely(self):
         from shapely import affinity

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -76,7 +76,7 @@ class LinePixelRegion(PixelRegion):
             in_reg = np.zeros(pixcoord.x.shape, dtype=bool)
 
         if self.meta.get('include', False):
-            return not in_reg
+            return np.logical_not(in_reg)
         else:
             return in_reg
 

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -149,9 +149,10 @@ class LineSkyRegion(SkyRegion):
 
     def contains(self, skycoord, wcs):
         if self.meta.get('include', False):
-            return True
-        else:
+            # lines never contain anything 
             return False
+        else:
+            return True
 
     def to_pixel(self, wcs):
         start_x, start_y = skycoord_to_pixel(self.start, wcs=wcs)

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -148,7 +148,7 @@ class LineSkyRegion(SkyRegion):
         self._repr_params = ('start', 'end')
 
     def contains(self, skycoord, wcs):
-        if self.meta.get('include', False):
+        if self.meta.get('include', True):
             # lines never contain anything 
             return False
         else:

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -76,9 +76,9 @@ class LinePixelRegion(PixelRegion):
             in_reg = np.zeros(pixcoord.x.shape, dtype=bool)
 
         if self.meta.get('include', True):
-            return np.logical_not(in_reg)
-        else:
             return in_reg
+        else:
+            return np.logical_not(in_reg)
 
     def to_shapely(self):
         from shapely.geometry import LineString

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -149,7 +149,7 @@ class LineSkyRegion(SkyRegion):
 
     def contains(self, skycoord, wcs):
         if self.meta.get('include', True):
-            # lines never contain anything 
+            # lines never contain anything
             return False
         else:
             return True

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -75,7 +75,7 @@ class LinePixelRegion(PixelRegion):
         else:
             in_reg = np.zeros(pixcoord.x.shape, dtype=bool)
 
-        if self.meta.get('include', False):
+        if self.meta.get('include', True):
             return np.logical_not(in_reg)
         else:
             return in_reg

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -70,9 +70,10 @@ class PointPixelRegion(PixelRegion):
             in_reg = np.zeros(pixcoord.x.shape, dtype=bool)
 
         if self.meta.get('include', False):
-            return np.logical_not(in_reg)
-        else:
+            # in_reg = False, always.  Points do not include anything
             return in_reg
+        else:
+            return np.logical_not(in_reg)
 
     def to_shapely(self):
         return self.center.to_shapely()

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -147,9 +147,10 @@ class PointSkyRegion(SkyRegion):
 
     def contains(self, skycoord, wcs):
         if self.meta.get('include', True):
-            return True
-        else:
+            # points never include anything
             return False
+        else:
+            return True
 
     def to_pixel(self, wcs):
         center_x, center_y = skycoord_to_pixel(self.center, wcs=wcs)

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -70,7 +70,7 @@ class PointPixelRegion(PixelRegion):
             in_reg = np.zeros(pixcoord.x.shape, dtype=bool)
 
         if self.meta.get('include', False):
-            return not in_reg
+            return np.logical_not(in_reg)
         else:
             return in_reg
 

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -69,7 +69,7 @@ class PointPixelRegion(PixelRegion):
         else:
             in_reg = np.zeros(pixcoord.x.shape, dtype=bool)
 
-        if self.meta.get('include', False):
+        if self.meta.get('include', True):
             # in_reg = False, always.  Points do not include anything
             return in_reg
         else:

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -146,7 +146,7 @@ class PointSkyRegion(SkyRegion):
         self._repr_params = None
 
     def contains(self, skycoord, wcs):
-        if self.meta.get('include', False):
+        if self.meta.get('include', True):
             return True
         else:
             return False

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -74,7 +74,11 @@ class PolygonPixelRegion(PixelRegion):
 
         shape = x.shape
         mask = points_in_polygon(x.flatten(), y.flatten(), vx, vy).astype(bool)
-        return mask.reshape(shape)
+        in_poly = mask.reshape(shape)
+        if self.meta.get('include', False):
+            return in_poly
+        else:
+            return np.logical_not(in_poly)
 
     def to_shapely(self):
         from shapely.geometry import Polygon

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -75,7 +75,7 @@ class PolygonPixelRegion(PixelRegion):
         shape = x.shape
         mask = points_in_polygon(x.flatten(), y.flatten(), vx, vy).astype(bool)
         in_poly = mask.reshape(shape)
-        if self.meta.get('include', False):
+        if self.meta.get('include', True):
             return in_poly
         else:
             return np.logical_not(in_poly)

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -91,7 +91,11 @@ class RectanglePixelRegion(PixelRegion):
         dy = pixcoord.y - self.center.y
         dx_rot = cos_angle * dx + sin_angle * dy
         dy_rot = sin_angle * dx - cos_angle * dy
-        return (np.abs(dx_rot) < self.width * 0.5) & (np.abs(dy_rot) < self.height * 0.5)
+        in_rect = (np.abs(dx_rot) < self.width * 0.5) & (np.abs(dy_rot) < self.height * 0.5)
+        if self.meta.get('include', False):
+            return np.logical_not(in_rect)
+        else:
+            return in_rect
 
     def to_shapely(self):
 

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -93,9 +93,9 @@ class RectanglePixelRegion(PixelRegion):
         dy_rot = sin_angle * dx - cos_angle * dy
         in_rect = (np.abs(dx_rot) < self.width * 0.5) & (np.abs(dy_rot) < self.height * 0.5)
         if self.meta.get('include', False):
-            return np.logical_not(in_rect)
-        else:
             return in_rect
+        else:
+            return np.logical_not(in_rect)
 
     def to_shapely(self):
 

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -92,7 +92,7 @@ class RectanglePixelRegion(PixelRegion):
         dx_rot = cos_angle * dx + sin_angle * dy
         dy_rot = sin_angle * dx - cos_angle * dy
         in_rect = (np.abs(dx_rot) < self.width * 0.5) & (np.abs(dy_rot) < self.height * 0.5)
-        if self.meta.get('include', False):
+        if self.meta.get('include', True):
             return in_rect
         else:
             return np.logical_not(in_rect)

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -110,6 +110,10 @@ def test_pix_to_mask(region, mode):
 def test_sky_in(region):
     region.contains(SkyCoord(1 * u.deg, 1 * u.deg, frame='icrs'), COMMON_WCS)
 
+@pytest.mark.parametrize('region', SKY_REGIONS, ids=ids_func)
+def test_sky_in_array(region):
+    region.contains(SkyCoord([1,2,3] * u.deg, [3,2,1] * u.deg, frame='icrs'), COMMON_WCS)
+
 
 @pytest.mark.parametrize('region', SKY_REGIONS, ids=ids_func)
 def test_sky_to_pix(region):

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -94,4 +94,4 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
     def test_contains(self):
         position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
         # 1,2 is outside, 3,4 is the center and is inside
-        assert reg.contains(position) == np.array([False,True], dtype='bool')
+        assert self.reg.contains(position) == np.array([False, True], dtype='bool')

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -90,3 +90,8 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
         with pytest.raises(ValueError) as err:
             CircleSkyRegion(center, radius)
         assert 'The center must be a 0D SkyCoord object' in str(err)
+
+    def test_contains(self):
+        position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+        # 1,2 is outside, 3,4 is the center and is inside
+        assert reg.contains(position) == np.array([False,True], dtype='bool')

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -91,7 +91,7 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
             CircleSkyRegion(center, radius)
         assert 'The center must be a 0D SkyCoord object' in str(err)
 
-    def test_contains(self):
-        position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+    def test_contains(self, wcs):
+        position = SkyCoord([1, 3] * u.deg, [2, 4] * u.deg)
         # 1,2 is outside, 3,4 is the center and is inside
-        assert self.reg.contains(position) == np.array([False, True], dtype='bool')
+        assert all(self.reg.contains(position, wcs) == np.array([False, True], dtype='bool'))

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -92,3 +92,8 @@ class TestEllipseSkyRegion(BaseTestSkyRegion):
         with pytest.raises(ValueError) as err:
             EllipseSkyRegion(center, width, height)
         assert 'The center must be a 0D SkyCoord object' in str(err)
+
+    def test_contains(self):
+        position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+        # 1,2 is outside, 3,4 is the center and is inside
+        assert reg.contains(position) == np.array([False,True], dtype='bool')

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -96,4 +96,4 @@ class TestEllipseSkyRegion(BaseTestSkyRegion):
     def test_contains(self):
         position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
         # 1,2 is outside, 3,4 is the center and is inside
-        assert reg.contains(position) == np.array([False,True], dtype='bool')
+        assert self.reg.contains(position) == np.array([False, True], dtype='bool')

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -9,12 +9,22 @@ import pytest
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import SkyCoord
+from astropy.utils.data import get_pkg_data_filename
+from astropy.io import fits
+from astropy.wcs import WCS
 
 from ...core import PixCoord
 from ...tests.helpers import make_simple_wcs
 from ..ellipse import EllipsePixelRegion, EllipseSkyRegion
 from .utils import ASTROPY_LT_13, HAS_MATPLOTLIB  # noqa
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
+
+
+@pytest.fixture(scope='session')
+def wcs():
+    filename = get_pkg_data_filename('data/example_header.fits')
+    header = fits.getheader(filename)
+    return WCS(header)
 
 
 class TestEllipsePixelRegion(BaseTestPixelRegion):
@@ -93,7 +103,7 @@ class TestEllipseSkyRegion(BaseTestSkyRegion):
             EllipseSkyRegion(center, width, height)
         assert 'The center must be a 0D SkyCoord object' in str(err)
 
-    def test_contains(self):
-        position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+    def test_contains(self, wcs):
+        position = SkyCoord([1, 3] * u.deg, [2, 4] * u.deg)
         # 1,2 is outside, 3,4 is the center and is inside
-        assert self.reg.contains(position) == np.array([False, True], dtype='bool')
+        assert all(self.reg.contains(position, wcs) == np.array([False, True], dtype='bool'))

--- a/regions/shapes/tests/test_line.py
+++ b/regions/shapes/tests/test_line.py
@@ -86,7 +86,7 @@ class TestLineSkyRegion(BaseTestSkyRegion):
         assert_quantity_allclose(skyline.end.data.lon, self.reg.end.data.lon)
         assert_quantity_allclose(skyline.end.data.lat, self.reg.end.data.lat)
 
-    def test_contains(self):
+    def test_contains(self, wcs):
         position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
         # lines do not contain things
-        assert self.reg.contains(position) == np.array([False, False], dtype='bool')
+        assert all(self.reg.contains(position, wcs) == np.array([False, False], dtype='bool'))

--- a/regions/shapes/tests/test_line.py
+++ b/regions/shapes/tests/test_line.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from numpy.testing import assert_allclose
+import numpy as np
 import pytest
 
 from astropy import units as u

--- a/regions/shapes/tests/test_line.py
+++ b/regions/shapes/tests/test_line.py
@@ -85,3 +85,8 @@ class TestLineSkyRegion(BaseTestSkyRegion):
         assert_quantity_allclose(skyline.start.data.lat, self.reg.start.data.lat)
         assert_quantity_allclose(skyline.end.data.lon, self.reg.end.data.lon)
         assert_quantity_allclose(skyline.end.data.lat, self.reg.end.data.lat)
+
+    def test_contains(self):
+        position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+        # lines do not contain things
+        assert reg.contains(position) == np.array([False,False], dtype='bool')

--- a/regions/shapes/tests/test_line.py
+++ b/regions/shapes/tests/test_line.py
@@ -89,4 +89,4 @@ class TestLineSkyRegion(BaseTestSkyRegion):
     def test_contains(self):
         position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
         # lines do not contain things
-        assert reg.contains(position) == np.array([False,False], dtype='bool')
+        assert self.reg.contains(position) == np.array([False, False], dtype='bool')

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -2,16 +2,28 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import numpy as np
 from numpy.testing import assert_allclose
+import pytest
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+from astropy.utils.data import get_pkg_data_filename
+from astropy.io import fits
+from astropy.wcs import WCS
 
 from ...core import PixCoord
 from ...tests.helpers import make_simple_wcs
 from ..point import PointPixelRegion, PointSkyRegion
 from .utils import ASTROPY_LT_13
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
+
+
+@pytest.fixture(scope='session')
+def wcs():
+    filename = get_pkg_data_filename('data/example_header.fits')
+    header = fits.getheader(filename)
+    return WCS(header)
 
 
 class TestPointPixelRegion(BaseTestPixelRegion):
@@ -46,7 +58,7 @@ class TestPointSkyRegion(BaseTestSkyRegion):
         expected_str = ('Region: PointSkyRegion\ncenter: <SkyCoord (ICRS): '
                    '(ra, dec) in deg\n    ( 3.,  4.)>')
 
-    def test_contains(self):
+    def test_contains(self, wcs):
         position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
         # points do not contain things
-        assert reg.contains(position) == np.array([False,False], dtype='bool')
+        assert all(self.reg.contains(position, wcs) == np.array([False,False], dtype='bool'))

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -45,3 +45,8 @@ class TestPointSkyRegion(BaseTestSkyRegion):
                     '    ( 3.,  4.)>)>')
         expected_str = ('Region: PointSkyRegion\ncenter: <SkyCoord (ICRS): '
                    '(ra, dec) in deg\n    ( 3.,  4.)>')
+
+    def test_contains(self):
+        position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+        # points do not contain things
+        assert reg.contains(position) == np.array([False,False], dtype='bool')

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -127,3 +127,8 @@ class TestPolygonSkyRegion(BaseTestSkyRegion):
         poly = PolygonSkyRegion(vertices=poly.vertices.transform_to(self.reg.vertices))
         assert_quantity_allclose(poly.vertices.data.lon, self.reg.vertices.data.lon, atol=1e-3 * u.deg)
         assert_quantity_allclose(poly.vertices.data.lat, self.reg.vertices.data.lat, atol=1e-3 * u.deg)
+
+    def test_contains(self):
+        position = SkyCoord([1, 2] * u.deg, [3.25, 3.75] * u.deg)
+        # 1,2 is outside, 3.25,3.75 should be inside the triangle...
+        assert reg.contains(position) == np.array([False,True], dtype='bool')

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -131,4 +131,4 @@ class TestPolygonSkyRegion(BaseTestSkyRegion):
     def test_contains(self):
         position = SkyCoord([1, 2] * u.deg, [3.25, 3.75] * u.deg)
         # 1,2 is outside, 3.25,3.75 should be inside the triangle...
-        assert reg.contains(position) == np.array([False,True], dtype='bool')
+        assert self.reg.contains(position) == np.array([False, True], dtype='bool')

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -128,7 +128,7 @@ class TestPolygonSkyRegion(BaseTestSkyRegion):
         assert_quantity_allclose(poly.vertices.data.lon, self.reg.vertices.data.lon, atol=1e-3 * u.deg)
         assert_quantity_allclose(poly.vertices.data.lat, self.reg.vertices.data.lat, atol=1e-3 * u.deg)
 
-    def test_contains(self):
-        position = SkyCoord([1, 2] * u.deg, [3.25, 3.75] * u.deg)
+    def test_contains(self, wcs):
+        position = SkyCoord([1, 3.25] * u.deg, [2, 3.75] * u.deg)
         # 1,2 is outside, 3.25,3.75 should be inside the triangle...
-        assert self.reg.contains(position) == np.array([False, True], dtype='bool')
+        assert all(self.reg.contains(position, wcs) == np.array([False, True], dtype='bool'))

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -109,7 +109,7 @@ class TestRectangleSkyRegion(BaseTestSkyRegion):
                    '(ICRS): (ra, dec) in deg\n    ( 3.,  4.)>\nwidth: '
                    '4.0 deg\nheight: 3.0 deg\nangle: 5.0 deg')
 
-    def test_contains(self):
-        position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+    def test_contains(self, wcs):
+        position = SkyCoord([1, 3] * u.deg, [2, 4] * u.deg)
         # 1,2 is outside, 3,4 is the center and is inside
-        assert self.reg.contains(position) == np.array([False, True], dtype='bool')
+        assert all(self.reg.contains(position, wcs) == np.array([False, True], dtype='bool'))

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -108,3 +108,8 @@ class TestRectangleSkyRegion(BaseTestSkyRegion):
         expected_str = ('Region: RectangleSkyRegion\ncenter: <SkyCoord '
                    '(ICRS): (ra, dec) in deg\n    ( 3.,  4.)>\nwidth: '
                    '4.0 deg\nheight: 3.0 deg\nangle: 5.0 deg')
+
+    def test_contains(self):
+        position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+        # 1,2 is outside, 3,4 is the center and is inside
+        assert reg.contains(position) == np.array([False,True], dtype='bool')

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -112,4 +112,4 @@ class TestRectangleSkyRegion(BaseTestSkyRegion):
     def test_contains(self):
         position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
         # 1,2 is outside, 3,4 is the center and is inside
-        assert reg.contains(position) == np.array([False,True], dtype='bool')
+        assert self.reg.contains(position) == np.array([False, True], dtype='bool')

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -1,18 +1,29 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.data import get_pkg_data_filename
+from astropy.io import fits
+from astropy.wcs import WCS
 
 from ...core import PixCoord
 from ..rectangle import RectanglePixelRegion, RectangleSkyRegion
 from ...tests.helpers import make_simple_wcs
 from .utils import ASTROPY_LT_13, HAS_MATPLOTLIB  # noqa
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
+
+
+@pytest.fixture(scope='session')
+def wcs():
+    filename = get_pkg_data_filename('data/example_header.fits')
+    header = fits.getheader(filename)
+    return WCS(header)
 
 
 class TestRectanglePixelRegion(BaseTestPixelRegion):

--- a/regions/shapes/tests/test_text.py
+++ b/regions/shapes/tests/test_text.py
@@ -2,16 +2,28 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import numpy as np
 from numpy.testing import assert_allclose
+import pytest
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+from astropy.utils.data import get_pkg_data_filename
+from astropy.io import fits
+from astropy.wcs import WCS
 
 from ...core import PixCoord
 from ...tests.helpers import make_simple_wcs
 from ..text import TextPixelRegion, TextSkyRegion
 from .utils import ASTROPY_LT_13
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
+
+
+@pytest.fixture(scope='session')
+def wcs():
+    filename = get_pkg_data_filename('data/example_header.fits')
+    header = fits.getheader(filename)
+    return WCS(header)
 
 
 class TestTextPixelRegion(BaseTestPixelRegion):

--- a/regions/shapes/tests/test_text.py
+++ b/regions/shapes/tests/test_text.py
@@ -45,3 +45,8 @@ class TestTextSkyRegion(BaseTestSkyRegion):
                              '    ( 3.,  4.)>, text=Sample Text)>')
         expected_str = ('Region: TextSkyRegion\ncenter: <SkyCoord (ICRS): '
                         '(ra, dec) in deg\n    ( 3.,  4.)>\ntext: Sample Text')
+
+    def test_contains(self, wcs):
+        position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+        # Nothing is in a text region
+        assert all(self.reg.contains(position, wcs) == np.array([False, False], dtype='bool'))


### PR DESCRIPTION
This PR fixes the broken functionality because a non-array-compatible logical not was being used.  The not operator (`~`) only works on arrays, the `not` operator only works on scalars, but `np.logical_not` appears to work on both.

@sushobhana, could you review this?  It would be helpful to have more explicit tests of both the include and not-include versions of the contains methods