### PR TITLE
Remove Python 3.4 build from travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,9 +65,6 @@ matrix:
           env: NUMPY_VERSION=1.11
         - python: 3.5
           env: NUMPY_VERSION=1.10
-        - python: 3.4
-          env: NUMPY_VERSION=1.9
-               PIP_DEPENDENCIES='pytest>=3.1,<3.7'
 
         # Try numpy pre-release
         - python: 3.6


### PR DESCRIPTION
The Python 3.4 build is broken:
https://travis-ci.org/astropy/regions/jobs/418635993

This PR removes it.

No-one is using Python 3.4, let's support Python 3.5+

@astrofrog @keflavich @sushobhana @larrybradley - OK?
(not sure why is active on astropy-regions or has an interest in this)