### PR TITLE
Add support for python 3.7 in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - 2.7
     - 3.5
     - 3.6
+    - 3.7
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -39,39 +40,39 @@ matrix:
     include:
 
         # Do a coverage test in Python 3.
-        - python: 3.6
+        - python: 3.7
           env: SETUP_CMD='test --coverage'
                CONDA_CHANNELS='conda-forge astropy'
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - python: 2.7
           env: SETUP_CMD='build_docs -w'
-        - python: 3.6
+        - python: 3.7
           env: SETUP_CMD='build_docs -w'
                CONDA_CHANNELS='conda-forge astropy'
         # Do a test without the optional dependencies
-        - python: 3.6
+        - python: 3.7
           env: SETUP_CMD='test'
                CONDA_DEPENDENCIES='Cython pytest-arraydiff'
 
 
         # Try Astropy development version
-        - python: 3.6
+        - python: 3.7
           env: ASTROPY_VERSION=development
                CONDA_CHANNELS='conda-forge astropy'
 
         # Try older numpy versions
-        - python: 3.5
+        - python: 3.6
           env: NUMPY_VERSION=1.11
         - python: 3.5
           env: NUMPY_VERSION=1.10
 
         # Try numpy pre-release
-        - python: 3.6
+        - python: 3.7
           env: NUMPY_VERSION=prerelease
 
         # Do a PEP8 test with pycodestyle
-        - python: 3.6
+        - python: 3.7
           env: MAIN_CMD='pycodestyle regions --count' SETUP_CMD=''
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
-language: python
+# We set the language to c because python isn't supported on the MacOS X nodes
+# on Travis. However, the language ends up being irrelevant anyway, since we
+# install Python ourselves using conda.
+language: c
 
-python:
-    - 2.7
-    - 3.5
-    - 3.6
+compiler: gcc
 
-# Setting sudo to false opts in to Travis-CI container-based builds.
-sudo: false
+# Cache can be cleared from the travis settings menu, see docs currently at
+# https://docs.travis-ci.com/user/caching#Clearing-Caches
+cache:
+  - ccache
+
+os:
+    - linux
+
+dist: xenial
+
+sudo: true
 
 addons:
     apt:
@@ -21,6 +30,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
+        - PYTHON_VERSION=3.7
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
@@ -38,51 +48,42 @@ env:
 matrix:
     include:
 
-        # Do a coverage test in Python 3.
-        - python: 3.7
-          dist: xenial
-          sudo: true
-          env: SETUP_CMD='test --coverage'
+        # Do a coverage test in Python 3.7
+        - env: SETUP_CMD='test --coverage'
                CONDA_CHANNELS='conda-forge astropy'
+
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        - python: 2.7
-          env: SETUP_CMD='build_docs -w'
-        - python: 3.6
-          env: SETUP_CMD='build_docs -w'
+        - env: PYTHON_VERSION=2.7
+               SETUP_CMD='build_docs -w'
+        - env: PYTHON_VERSION=3.6
+               SETUP_CMD='build_docs -w'
                CONDA_CHANNELS='conda-forge astropy'
+
         # Do a test without the optional dependencies
-        - python: 3.7
-          dist: xenial
-          sudo: true
-          env: SETUP_CMD='test'
+        - env: SETUP_CMD='test'
                CONDA_DEPENDENCIES='Cython pytest-arraydiff'
 
 
         # Try Astropy development version
-        - python: 3.7
-          dist: xenial
-          sudo: true
-          env: ASTROPY_VERSION=development
+        - env: ASTROPY_VERSION=development
                CONDA_CHANNELS='conda-forge astropy'
 
         # Try older numpy versions
-        - python: 3.6
-          env: NUMPY_VERSION=1.11
-        - python: 3.5
-          env: NUMPY_VERSION=1.10
+        - env: PYTHON_VERSION=3.6
+               NUMPY_VERSION=1.11
+        - env: PYTHON_VERSION=3.5
+               NUMPY_VERSION=1.10
 
         # Try numpy pre-release
-        - python: 3.7
-          dist: xenial
-          sudo: true
-          env: NUMPY_VERSION=prerelease
+        - env: NUMPY_VERSION=prerelease
 
         # Do a PEP8 test with pycodestyle
-        - python: 3.7
-          dist: xenial
-          sudo: true
-          env: MAIN_CMD='pycodestyle regions --count' SETUP_CMD=''
+        - env: MAIN_CMD='pycodestyle regions --count' SETUP_CMD=''
+
+        # Try MacOS X
+        - os: osx
+          env: SETUP_CMD='test'
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
     - 2.7
     - 3.5
     - 3.6
-    - 3.7
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -41,6 +40,8 @@ matrix:
 
         # Do a coverage test in Python 3.
         - python: 3.7
+          dist: xenial
+          sudo: true
           env: SETUP_CMD='test --coverage'
                CONDA_CHANNELS='conda-forge astropy'
         # Check for sphinx doc build warnings - we do this first because it
@@ -48,16 +49,22 @@ matrix:
         - python: 2.7
           env: SETUP_CMD='build_docs -w'
         - python: 3.7
+          dist: xenial
+          sudo: true
           env: SETUP_CMD='build_docs -w'
                CONDA_CHANNELS='conda-forge astropy'
         # Do a test without the optional dependencies
         - python: 3.7
+          dist: xenial
+          sudo: true
           env: SETUP_CMD='test'
                CONDA_DEPENDENCIES='Cython pytest-arraydiff'
 
 
         # Try Astropy development version
         - python: 3.7
+          dist: xenial
+          sudo: true
           env: ASTROPY_VERSION=development
                CONDA_CHANNELS='conda-forge astropy'
 
@@ -69,10 +76,14 @@ matrix:
 
         # Try numpy pre-release
         - python: 3.7
+          dist: xenial
+          sudo: true
           env: NUMPY_VERSION=prerelease
 
         # Do a PEP8 test with pycodestyle
         - python: 3.7
+          dist: xenial
+          sudo: true
           env: MAIN_CMD='pycodestyle regions --count' SETUP_CMD=''
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,7 @@ matrix:
         # may run for a long time
         - python: 2.7
           env: SETUP_CMD='build_docs -w'
-        - python: 3.7
-          dist: xenial
-          sudo: true
+        - python: 3.6
           env: SETUP_CMD='build_docs -w'
                CONDA_CHANNELS='conda-forge astropy'
         # Do a test without the optional dependencies

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,14 +19,14 @@ environment:
 
   matrix:
 
-      # We test Python 2.7 and 3.6 because 2.7 is the supported Python 2
-      # release of Astropy and Python 3.6 is the latest Python 3 release.
+      # We test Python 2.7 and 3.7 because 2.7 is the supported Python 2
+      # release of Astropy and Python 3.7 is the latest Python 3 release.
 
       - PYTHON_VERSION: "2.7"
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 
-      - PYTHON_VERSION: "3.6"
+      - PYTHON_VERSION: "3.7"
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 


### PR DESCRIPTION
#206 
The sudo and dist must be `true` and `xenial` explicitely for python3.7 (see https://github.com/travis-ci/travis-ci/issues/9815) 