### PR TITLE
Remove shapely converter functions, keep docs page

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,7 +15,6 @@ The regions package requires the following packages:
 In addition, the following packages are needed for optional functionality:
 
 * `Matplotlib <https://matplotlib.org>`__ 1.5 or later
-* `Shapely <http://toblerity.org/shapely/manual.html>`__
 
 Stable version
 ==============

--- a/docs/shapely.rst
+++ b/docs/shapely.rst
@@ -1,45 +1,43 @@
 .. _gs-shapely:
 
-Exporting regions to shapely objects
-====================================
+Converting regions to shapely objects
+=====================================
 
 The `Shapely <http://toblerity.org/shapely/manual.html>`__ Python package is a
 generic package for the manipulation and analysis of geometric objects in the
 Cartesian plane. Concerning regions in the cartesian plane, it is more
-feature-complete, powerful and optimized than this ``regions`` package. It
-doesn't do everything astronomers need though, e.g. no sky regions, no use of
-Astropy classes like `~astropy.coordinates.SkyCoord` or
-`~astropy.coordinates.Angle`, and no region serialisation with the formats
-astronomers use (such as e.g. ds9 regions).
+feature-complete, powerful and optimized than this ``regions`` package.
 
-`~regions.PixelRegion` classes provide a method :meth:`~regions.PixelRegion.to_shapely` that allows creation
-of Shapely shape objects. At the moment there is no ``from_shapely`` method to convert Shapely objects
-back to ``regions`` objects. The future of the use of Shapely in ``regions`` is currently unclear, some options are:
+The use of Shapely or other Python regions packages that come from the geospatial domain
+in Astronomy is rare. However, if you have a complex pixel region analysis task,
+you can consider using Shapely. Either use it directly, by defining Shapely regions
+via Python code or one of the serialisation formats they support, or by writing
+some Python code to convert ``astropy-regions`` objects to Shapely objects.
 
-1. Add ``from_shapely`` and use it to implement e.g. `~regions.PolygonPixelRegion` operations
-   can "discretization" of other shapes to polygons.
-   This would make Shapely a required dependency to work with polygons.
-2. Keep ``to_shapely`` for the (small?) fraction of users that want to do this,
-   but don't expand or use it inside the ``regions`` package  to avoid the extra heavy dependency.
-3. Remove the use of Shapely completely from the API unless good use cases demonstrating a need come up.
-
-Here's an example how to create a Shapely object and do something that's not implemented in ``regions``,
-namely to buffer a rectangle, resulting in a polygon.
+Here we give one example how to do this: convert a circle to a Shapely object
+and polygonise it. That's one nice feature of Shapely, it can polygonise all shapes
+and do fast polygon-based computations like intersection and union. If you need to
+do this, that's a good reason to use Shapely.
 
 .. plot::
-   :include-source:
+    :include-source:
 
-    from regions import PixCoord, RectanglePixelRegion
+    import matplotlib.pyplot as plt
+    from regions import PixCoord, CirclePixelRegion
 
-    region = RectanglePixelRegion(center=PixCoord(3, 2), width=2, height=1)
+    # Make an example region
+    region = CirclePixelRegion(center=PixCoord(3, 2), radius=2)
 
-    # Get a `shapely.geometry.polygon.Polygon` object
-    shape = region.to_shapely()
+    # Convert to Shapely
+    from shapely.geometry import Point
+    point = Point(region.center.x, region.center.y)
+    circle = point.buffer(region.radius)
 
-    # Get a polygon that is buffered by 3 pixels compared to 'shape'
-    shape_poly = shape.buffer(distance=3)
+    # Actually, this is a polygon approximation of the circle!
+    print(circle)
 
     # Plot the result
-    x, y = shape_poly.exterior.xy
+    x, y = circle.exterior.xy
     ax = plt.subplot(1, 1, 1)
     ax.plot(x, y, 'g-')
+    plt.show()

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -142,9 +142,6 @@ class CompoundPixelRegion(PixelRegion):
         else:
             raise NotImplementedError
 
-    def to_shapely(self, **kwargs):
-        raise NotImplementedError
-
     def bounding_box(self, **kwargs):
         raise NotImplementedError
 

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -236,13 +236,6 @@ class PixelRegion(Region):
                                  " a strictly positive integer)".format(subpixels))
 
     @abc.abstractmethod
-    def to_shapely(self):
-        """
-        Convert this region to a Shapely object.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
     def as_patch(self, **kwargs):
         """
         Convert to mpl patch

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -141,21 +141,6 @@ class PixCoord(object):
         x, y = skycoord.to_pixel(wcs=wcs, origin=origin, mode=mode)
         return cls(x=x, y=y)
 
-    def to_shapely(self):
-        """Convert this coord object to a `shapely.geometry.Point` object.
-        """
-        if not self.isscalar:
-            raise TypeError('Non-scalar PixCoord cannot be converted to Shapely.')
-
-        from shapely.geometry import Point
-        return Point(self.x, self.y)
-
-    @classmethod
-    def from_shapely(cls, point):
-        """Create `PixCoord` from `shapely.geometry.Point` object.
-        """
-        return cls(x=point.x, y=point.y)
-
     def separation(self, other):
         r"""Separation to another pixel coordinate.
 

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -6,13 +6,6 @@ import pytest
 from ..._utils.examples import make_example_dataset
 from ..pixcoord import PixCoord
 
-try:
-    import shapely
-
-    HAS_SHAPELY = True
-except:
-    HAS_SHAPELY = False
-
 
 @pytest.fixture(scope='session')
 def wcs():
@@ -187,27 +180,6 @@ def test_pixcoord_separation_array_2d():
     assert isinstance(sep, np.ndarray)
     assert sep.shape == (1, 2)
     assert_allclose(sep, [[5, 5]])
-
-
-@pytest.mark.skipif('not HAS_SHAPELY')
-def test_pixcoord_shapely_scalar():
-    from shapely.geometry.point import Point
-    p = PixCoord(x=1, y=2)
-    s = p.to_shapely()
-    assert isinstance(s, Point)
-    assert s.x == 1
-    assert s.y == 2
-
-    p2 = PixCoord.from_shapely(point=s)
-    assert p2.x == 1
-    assert p2.y == 2
-
-
-@pytest.mark.skipif('not HAS_SHAPELY')
-def test_pixcoord_shapely_array():
-    p = PixCoord(x=[1, 2, 3], y=[11, 22, 33])
-    with pytest.raises(TypeError):
-        p.to_shapely()
 
 
 def test_equality():

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -79,9 +79,6 @@ class CirclePixelRegion(PixelRegion):
         else:
             return np.logical_not(in_circle)
 
-    def to_shapely(self):
-        return self.center.to_shapely().buffer(self.radius)
-
     def to_sky(self, wcs):
         # TODO: write a pixel_to_skycoord_scale_angle
         center = pixel_to_skycoord(self.center.x, self.center.y, wcs)

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -98,12 +98,6 @@ class EllipsePixelRegion(PixelRegion):
         else:
             return np.logical_not(in_ell)
 
-    def to_shapely(self):
-        from shapely import affinity
-        ellipse = self.center.to_shapely().buffer(0.5 * self.height)
-        ellipse = affinity.scale(ellipse, xfact=self.width / self.height, yfact=1)
-        return affinity.rotate(ellipse, self.angle.to(u.deg).value)
-
     def to_sky(self, wcs):
         # TODO: write a pixel_to_skycoord_scale_angle
         center = pixel_to_skycoord(self.center.x, self.center.y, wcs)

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -80,10 +80,6 @@ class LinePixelRegion(PixelRegion):
         else:
             return np.logical_not(in_reg)
 
-    def to_shapely(self):
-        from shapely.geometry import LineString
-        return LineString([(self.start.x, self.start.y), (self.end.x, self.end.y)])
-
     def to_sky(self, wcs, mode='local', tolerance=None):
         start = pixel_to_skycoord(self.start.x, self.start.y, wcs)
         end = pixel_to_skycoord(self.end.x, self.end.y, wcs)

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -75,9 +75,6 @@ class PointPixelRegion(PixelRegion):
         else:
             return np.logical_not(in_reg)
 
-    def to_shapely(self):
-        return self.center.to_shapely()
-
     def to_sky(self, wcs):
         center = pixel_to_skycoord(self.center.x, self.center.y, wcs=wcs)
         return PointSkyRegion(center)

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -62,8 +62,7 @@ class PolygonPixelRegion(PixelRegion):
     @property
     def area(self):
         """Region area (float)."""
-        # FIXME: for now we use shapely, but could try and avoid the dependency in future
-        return self.to_shapely().area
+        raise NotImplementedError
 
     def contains(self, pixcoord):
         pixcoord = PixCoord._validate(pixcoord, 'pixcoord')
@@ -79,10 +78,6 @@ class PolygonPixelRegion(PixelRegion):
             return in_poly
         else:
             return np.logical_not(in_poly)
-
-    def to_shapely(self):
-        from shapely.geometry import Polygon
-        return Polygon(list(zip(self.vertices.x, self.vertices.y)))
 
     def to_sky(self, wcs):
         vertices_sky = pixel_to_skycoord(self.vertices.x, self.vertices.y, wcs)

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -97,24 +97,6 @@ class RectanglePixelRegion(PixelRegion):
         else:
             return np.logical_not(in_rect)
 
-    def to_shapely(self):
-
-        from shapely import affinity
-        from shapely.geometry import Polygon
-
-        x1 = self.center.x - self.width * 0.5
-        y1 = self.center.y - self.height * 0.5
-        x2 = self.center.x + self.width * 0.5
-        y2 = self.center.y - self.height * 0.5
-        x3 = self.center.x + self.width * 0.5
-        y3 = self.center.y + self.height * 0.5
-        x4 = self.center.x - self.width * 0.5
-        y4 = self.center.y + self.height * 0.5
-
-        rectangle = Polygon([(x1, y1), (x2, y2), (x3, y3), (x4, y4)])
-
-        return affinity.rotate(rectangle, self.angle.to(u.deg).value)
-
     def to_sky(self, wcs):
         # TODO: write a pixel_to_skycoord_scale_angle
         center = pixel_to_skycoord(self.center.x, self.center.y, wcs)

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -24,7 +24,6 @@ from ..point import PointPixelRegion, PointSkyRegion
 from ..annulus import (CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
                        RectangleAnnulusPixelRegion, RectangleAnnulusSkyRegion,
                        EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion)
-from .utils import HAS_SHAPELY  # noqa
 
 PIXEL_REGIONS = [
     CirclePixelRegion(PixCoord(3, 4), radius=5),
@@ -69,11 +68,12 @@ def test_pix_in(region):
 
 @pytest.mark.parametrize('region', PIXEL_REGIONS, ids=ids_func)
 def test_pix_area(region):
-    try:
-        area = region.area
-        assert not isinstance(area, u.Quantity)
-    except ImportError:  # for shapely
+    # TODO: remove the pytest.skip once polygon area is implemented
+    if isinstance(region, PolygonPixelRegion):
         pytest.skip()
+
+    area = region.area
+    assert not isinstance(area, u.Quantity)
 
 
 @pytest.mark.parametrize(('region'), PIXEL_REGIONS, ids=ids_func)
@@ -84,16 +84,6 @@ def test_pix_to_sky(region):
     except NotImplementedError:
         pytest.xfail()
 
-
-@pytest.mark.skipif('not HAS_SHAPELY')
-@pytest.mark.parametrize('region', PIXEL_REGIONS, ids=ids_func)
-def test_pix_to_shapely(region):
-    from shapely.geometry.base import BaseGeometry
-    try:
-        shape = region.to_shapely()
-        assert isinstance(shape, BaseGeometry)
-    except NotImplementedError:
-        pytest.xfail()
 
 @pytest.mark.parametrize(('region', 'mode'),
                          itertools.product(PIXEL_REGIONS, MASK_MODES),

--- a/regions/shapes/tests/test_common.py
+++ b/regions/shapes/tests/test_common.py
@@ -7,9 +7,8 @@ import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 import pytest
 
+from ..polygon import PolygonPixelRegion
 from ...core import PixCoord, BoundingBox
-from .utils import ASTROPY_LT_13, HAS_SHAPELY # noqa
-
 
 class BaseTestRegion(object):
 
@@ -23,10 +22,11 @@ class BaseTestRegion(object):
 class BaseTestPixelRegion(BaseTestRegion):
 
     def test_area(self):
-        try:
-            assert_allclose(self.reg.area, self.expected_area)
-        except ImportError:
+        # TODO: remove the pytest.skip once polygon area is implemented
+        if isinstance(self.reg, PolygonPixelRegion):
             pytest.skip()
+
+        assert_allclose(self.reg.area, self.expected_area)
 
     def test_mask_area(self):
         try:
@@ -38,30 +38,6 @@ class BaseTestPixelRegion(BaseTestRegion):
                 assert_allclose(np.sum(mask.data), self.expected_area, rtol=0.005)
             except NotImplementedError:
                 pytest.skip()
-
-    @pytest.mark.skipif('not HAS_SHAPELY')
-    def test_contains_compared_to_shapely(self):
-        from shapely.geometry import Point
-        np.random.seed(12345)
-        x = np.random.uniform(self.sample_box[0], self.sample_box[1], 1000)
-        y = np.random.uniform(self.sample_box[2], self.sample_box[3], 1000)
-        try:  # handles when `to_shapely` is not implemented for the subclass.
-            inside = self.reg.contains(PixCoord(x, y))
-            reg_shapely = self.reg.to_shapely()
-            inside_shapely = [reg_shapely.contains(Point(x[i], y[i])) for i in range(len(x))]
-            assert_equal(inside, inside_shapely)
-        except NotImplementedError:
-            pytest.skip()
-
-    @pytest.mark.skipif('not HAS_SHAPELY')
-    def test_bbox_compared_to_shapely(self):
-        try:  # handles when `to_shapely` is not implemented for the subclass.
-            reg_shapely = self.reg.to_shapely()
-            xmin, ymin, xmax, ymax = reg_shapely.bounds
-            bbox_shapely = BoundingBox.from_float(xmin, xmax, ymin, ymax)
-            assert self.reg.bounding_box == bbox_shapely
-        except NotImplementedError:
-            pytest.skip()
 
     def test_contains_scalar(self):
 

--- a/regions/shapes/tests/utils.py
+++ b/regions/shapes/tests/utils.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from distutils.version import LooseVersion
-
 import astropy
-import numpy
 
 ASTROPY_LT_13 = LooseVersion(astropy.__version__) < LooseVersion('1.3')
 
@@ -11,9 +9,3 @@ try:
     HAS_MATPLOTLIB = True
 except:
     HAS_MATPLOTLIB = False
-
-try:
-    import shapely  # noqa
-    HAS_SHAPELY = True
-except:
-    HAS_SHAPELY = False


### PR DESCRIPTION
This PR removes the `to_shapely` and `from_shapely` converter methods we had on some pixel region classes (point, circle, rectangle, polygon).

I did keep and update the example on the docs page explaining that Shapely exists and that astronomers might want to use it for complex planar shape analysis tasks, especially polygon-related things like buffer, union and intersect. I think the number of users that want to do that is close to zero, if someone has such analysis tasks they would likely not create Astropy region objects and convert them to Shapely objects directly, but use the direct methods to create Shapely objects via Python API or one of the serialisation formats they support. I'm actually +1 to remove that docs page also, but I gather that keeping it might increase the chance to get this change / PR accepted.

I made this suggestion in  https://github.com/astropy/regions/pull/165#issuecomment-412837404, but to have discussion in one place I'll paste my arguments here:

- `astropy-regions` should become `astropy.regions` in the core package soon.
- from the user perspective: very few astronomers need or have ever heard of Shapely, support for it doesn't belong in Astropy core IMO, it's a feature for 1% of users and a distraction for the rest
- from the developer perspective: supporting it is significant effort in terms of implementing, testing and documenting. Half-ass support for some regions is not nice. Note that even after years, there's still quite a lot to do for regions, IMO if anyone has time to hack on it , it should be on core functionality, not shapely.
- If shapely becomes popular among astronomers in the future, adding support like that is easy. But we should never take things away, so if we add it now, we should support it forever.

#46 from two years ago is on the same topic, when we started this package we weren't sure if we should use / support Shapely.

@astrofrog @keflavich @larrybradley @sushobhana - Thoughts?