### PR TITLE
origin offset in `plot` and `as_patch` of PointPixelRegion

### DIFF
--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -246,7 +246,7 @@ class PixelRegion(Region):
             The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
 
-        kwargs: `dict`
+        kwargs : `dict`
             keywords that a `~matplotlib.patches.Patch` accepts
 
         Returns
@@ -299,14 +299,14 @@ class PixelRegion(Region):
         origin : array_like, optional
             The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
-        ax : `~matplotlib.axes`, optional
+        ax : `~matplotlib.axes.Axes`, optional
             Axis
-        kwargs: `dict`
+        kwargs : `dict`
             keywords that a `~matplotlib.patches.Patch` accepts
 
         Returns
         -------
-        ax: `~matplotlib.axes`
+        ax : `~matplotlib.axes.Axes`
             Axes on which the patch is added.
         """
         import matplotlib.pyplot as plt

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -256,7 +256,6 @@ class PixelRegion(Region):
         """
         raise NotImplementedError
 
-
     def mpl_properties_default(self, shape='patch'):
         """
         This sets the default values of the visual attributes as specified

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -127,12 +127,12 @@ class CirclePixelRegion(PixelRegion):
         """
         Matplotlib patch object for this region (`matplotlib.patches.Circle`)
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         origin : array_like, optional
             The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
-        kwargs: dict
+        kwargs : `dict`
             All keywords that a `~matplotlib.patches.Circle` object accepts
 
         Returns

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -191,7 +191,7 @@ class EllipsePixelRegion(PixelRegion):
         origin : array_like, optional
             The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
-        kwargs: dict
+        kwargs : `dict`
             All keywords that a `~matplotlib.patches.Ellipse` object accepts
 
         Returns

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -108,7 +108,7 @@ class LinePixelRegion(PixelRegion):
         origin : array_like, optional
             The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
-        kwargs: dict
+        kwargs : `dict`
             All keywords that a `~matplotlib.patches.Arrow` object accepts
 
         Returns

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -90,31 +90,56 @@ class PointPixelRegion(PixelRegion):
 
     def as_artist(self, origin=(0, 0), **kwargs):
         """
-        Matplotlib patch object for this region (`matplotlib.patches.Circle`).
+        Matplotlib Line2D object for this region (`matplotlib.lines.Line2D`).
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         origin : array_like, optional
             The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
-        kwargs: dict
-            All keywords that a `~matplotlib.patches.Circle` object accepts
+        kwargs : `dict`
+            All keywords that a `~matplotlib.lines.Line2D` object accepts
 
         Returns
         -------
-        patch : `~matplotlib.patches.Circle`
-            Matplotlib circle patch
+        patch : `~matplotlib.lines.Line2D`
+            Matplotlib Line2D object.
         """
+
         from matplotlib.lines import Line2D
 
-        # We can move this to a method like `as_artist`
-        mpl_params = self.mpl_properties_default('Line2D')
+        mpl_params = self.mpl_properties_default('LINE2D')
         mpl_params.update(kwargs)
-        point = Line2D([self.center.x + origin[0]],
-                       [self.center.y + origin[1]],
+
+        point = Line2D([self.center.x - origin[0]], [self.center.y - origin[1]],
                        **mpl_params)
 
         return point
+
+    def plot(self, origin=(0, 0), ax=None, **kwargs):
+        """
+        Forwards all kwargs to `~matplotlib.lines.Line2D` object and adds the
+        line to the given axes.
+
+        Parameters
+        ----------
+        origin : array_like, optional
+            The ``(x, y)`` pixel position of the origin of the displayed image.
+            Default is (0, 0).
+        ax : `~matplotlib.axes.Axes`, optional
+            Axes on which the point is added
+        kwargs : dict
+            All keywords that a `~matplotlib.lines.Line2D` object accepts
+        """
+        from matplotlib import pyplot as plt
+
+        if ax is None:
+            ax = plt.gca()
+
+        point = self.as_artist(origin=origin, kwargs=kwargs)
+        ax.add_line(point)
+
+        return ax
 
 
 class PointSkyRegion(SkyRegion):

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -102,7 +102,7 @@ class PointPixelRegion(PixelRegion):
 
         Returns
         -------
-        patch : `~matplotlib.lines.Line2D`
+        point : `~matplotlib.lines.Line2D`
             Matplotlib Line2D object.
         """
 
@@ -115,31 +115,6 @@ class PointPixelRegion(PixelRegion):
                        **mpl_params)
 
         return point
-
-    def plot(self, origin=(0, 0), ax=None, **kwargs):
-        """
-        Forwards all kwargs to `~matplotlib.lines.Line2D` object and adds the
-        line to the given axes.
-
-        Parameters
-        ----------
-        origin : array_like, optional
-            The ``(x, y)`` pixel position of the origin of the displayed image.
-            Default is (0, 0).
-        ax : `~matplotlib.axes.Axes`, optional
-            Axes on which the point is added
-        kwargs : dict
-            All keywords that a `~matplotlib.lines.Line2D` object accepts
-        """
-        from matplotlib import pyplot as plt
-
-        if ax is None:
-            ax = plt.gca()
-
-        point = self.as_artist(origin=origin, kwargs=kwargs)
-        ax.add_line(point)
-
-        return ax
 
 
 class PointSkyRegion(SkyRegion):

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -133,7 +133,7 @@ class PolygonPixelRegion(PixelRegion):
         origin : array_like, optional
             The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
-        kwargs: dict
+        kwargs : `dict`
             All keywords that a `~matplotlib.patches.Polygon` object accepts
 
         Returns

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -176,7 +176,7 @@ class RectanglePixelRegion(PixelRegion):
         origin : array_like, optional
             The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
-        kwargs: dict
+        kwargs : `dict`
             All keywords that a `~matplotlib.patches.Rectangle` object accepts
 
         Returns

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -73,7 +73,7 @@ class TextPixelRegion(PointPixelRegion):
             Default is (0, 0).
         ax : `~matplotlib.axes`, optional
             Axes
-        kwargs: `dict`
+        kwargs : `dict`
             keywords that a `~matplotlib.text.Text` accepts
 
         Returns

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -58,43 +58,31 @@ class TextPixelRegion(PointPixelRegion):
         center = pixel_to_skycoord(self.center.x, self.center.y, wcs=wcs)
         return TextSkyRegion(center, self.text)
 
-    def as_artist(self, **kwargs):
-        raise NotImplementedError
-
-    def plot(self, origin=(0, 0), ax=None, **kwargs):
+    def as_artist(self, origin=(0, 0), **kwargs):
         """
-        Forwarding all kwargs to `~matplotlib.text.Text` object and add it
-        to given axis.
+        Matplotlib Text object for this region (`matplotlib.text.Text`).
 
         Parameters
         ----------
         origin : array_like, optional
             The ``(x, y)`` pixel position of the origin of the displayed image.
             Default is (0, 0).
-        ax : `~matplotlib.axes`, optional
-            Axes
         kwargs : `dict`
-            keywords that a `~matplotlib.text.Text` accepts
+            All keywords that a `~matplotlib.text.Text` object accepts
 
         Returns
         -------
-        ax : `~matplotlib.axes`
-            The axes with the text.
+        text : `~matplotlib.text.Text`
+            Matplotlib Text object.
         """
-        import matplotlib.pyplot as plt
         from matplotlib.text import Text
-
-        if ax is None:
-            ax = plt.gca()
 
         mpl_params = self.mpl_properties_default('text')
         mpl_params.update(kwargs)
         text = Text(self.center.x - origin[0], self.center.y - origin[1],
                     self.text, **mpl_params)
 
-        ax.add_artist(text)
-
-        return ax
+        return text
 
 
 class TextSkyRegion(PointSkyRegion):


### PR DESCRIPTION
It is implicit that the `as_patch` of the point region gives a circle patch 
which I think should be deprecated to avoid confusion.

The `plot` draws a `Line2D` which actually represents a point.
#215 
@keflavich 