### PR TITLE
Remove support for ASTROPY_LT_13 in tests

### DIFF
--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -10,7 +10,6 @@ from ...core import PixCoord
 from ...tests.helpers import make_simple_wcs
 from ..annulus import *
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
-from .utils import ASTROPY_LT_13
 
 
 class TestCircleAnnulusPixelRegion(BaseTestPixelRegion):
@@ -42,18 +41,11 @@ class TestCircleAnnulusSkyRegion(BaseTestSkyRegion):
     skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='icrs')
     wcs = make_simple_wcs(skycoord, 5 * u.arcsec, 20)
 
-    if ASTROPY_LT_13:
-        expected_repr = ('<CircleAnnulusSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
-                         'deg\n    (3.0, 4.0)>, inner radius=20.0 arcsec, outer radius=30.0 arcsec)>')
-        expected_str = ('Region: CircleAnnulusSkyRegion\ncenter: <SkyCoord (ICRS): '
-                        '(ra, dec) in deg\n    (3.0, 4.0)>\ninner radius: 20.0 '
-                        'arcsec\nouter radius: 30.0 arcsec')
-    else:
-        expected_repr = ('<CircleAnnulusSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
-                         'deg\n    ( 3.,  4.)>, inner radius=20.0 arcsec, outer radius=30.0 arcsec)>')
-        expected_str = ('Region: CircleAnnulusSkyRegion\ncenter: <SkyCoord (ICRS): '
-                        '(ra, dec) in deg\n    ( 3.,  4.)>\ninner radius: 20.0 '
-                        'arcsec\nouter radius: 30.0 arcsec')
+    expected_repr = ('<CircleAnnulusSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+                     'deg\n    ( 3.,  4.)>, inner radius=20.0 arcsec, outer radius=30.0 arcsec)>')
+    expected_str = ('Region: CircleAnnulusSkyRegion\ncenter: <SkyCoord (ICRS): '
+                    '(ra, dec) in deg\n    ( 3.,  4.)>\ninner radius: 20.0 '
+                    'arcsec\nouter radius: 30.0 arcsec')
 
     def test_init(self):
         assert_quantity_allclose(self.reg.center.ra, self.skycoord.ra)
@@ -106,24 +98,14 @@ class TestEllipseAnnulusSkyRegion(BaseTestSkyRegion):
                                   50 * u.arcsec, 80 * u.arcsec)
     wcs = make_simple_wcs(skycoord, 5 * u.arcsec, 20)
 
-    if ASTROPY_LT_13:
-        expected_repr = ('<EllipseAnnulusSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
-                         'deg\n    (3.0, 4.0)>, inner width=20.0 arcsec, '
-                         'inner height=50.0 arcsec, outer width=50.0 arcsec, '
-                         'outer height=80.0 arcsec, angle=0.0 deg)>')
-        expected_str = ('Region: EllipseAnnulusSkyRegion\ncenter: <SkyCoord (ICRS): '
-                        '(ra, dec) in deg\n    (3.0, 4.0)>\ninner width: 20.0 arcsec\n'
-                        'inner height: 50.0 arcsec\nouter width: 50.0 arcsec\n'
-                        'outer height: 80.0 arcsec\nangle: 0.0 deg')
-    else:
-        expected_repr = ('<EllipseAnnulusSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
-                         'deg\n    (3., 4.)>, inner width=20.0 arcsec, '
-                         'inner height=50.0 arcsec, outer width=50.0 arcsec, '
-                         'outer height=80.0 arcsec, angle=0.0 deg)>')
-        expected_str = ('Region: EllipseAnnulusSkyRegion\ncenter: <SkyCoord (ICRS): '
-                        '(ra, dec) in deg\n    (3., 4.)>\ninner width: 20.0 arcsec\n'
-                        'inner height: 50.0 arcsec\nouter width: 50.0 arcsec\n'
-                        'outer height: 80.0 arcsec\nangle: 0.0 deg')
+    expected_repr = ('<EllipseAnnulusSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+                     'deg\n    (3., 4.)>, inner width=20.0 arcsec, '
+                     'inner height=50.0 arcsec, outer width=50.0 arcsec, '
+                     'outer height=80.0 arcsec, angle=0.0 deg)>')
+    expected_str = ('Region: EllipseAnnulusSkyRegion\ncenter: <SkyCoord (ICRS): '
+                    '(ra, dec) in deg\n    (3., 4.)>\ninner width: 20.0 arcsec\n'
+                    'inner height: 50.0 arcsec\nouter width: 50.0 arcsec\n'
+                    'outer height: 80.0 arcsec\nangle: 0.0 deg')
 
     def test_init(self):
         assert_quantity_allclose(self.reg.center.ra, self.skycoord.ra)
@@ -176,24 +158,14 @@ class TestRectangleAnnulusSkyRegion(BaseTestSkyRegion):
                                   50 * u.arcsec, 80 * u.arcsec)
     wcs = make_simple_wcs(skycoord, 5 * u.arcsec, 20)
 
-    if ASTROPY_LT_13:
-        expected_repr = ('<RectangleAnnulusSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
-                         'deg\n    (3.0, 4.0)>, inner width=20.0 arcsec, '
-                         'inner height=50.0 arcsec, outer width=50.0 arcsec, '
-                         'outer height=80.0 arcsec, angle=0.0 deg)>')
-        expected_str = ('Region: RectangleAnnulusSkyRegion\ncenter: <SkyCoord (ICRS): '
-                        '(ra, dec) in deg\n    (3.0, 4.0)>\ninner width: 20.0 arcsec\n'
-                        'inner height: 50.0 arcsec\nouter width: 50.0 arcsec\n'
-                        'outer height: 80.0 arcsec\nangle: 0.0 deg')
-    else:
-        expected_repr = ('<RectangleAnnulusSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
-                         'deg\n    (3., 4.)>, inner width=20.0 arcsec, '
-                         'inner height=50.0 arcsec, outer width=50.0 arcsec, '
-                         'outer height=80.0 arcsec, angle=0.0 deg)>')
-        expected_str = ('Region: RectangleAnnulusSkyRegion\ncenter: <SkyCoord (ICRS): '
-                        '(ra, dec) in deg\n    (3., 4.)>\ninner width: 20.0 arcsec\n'
-                        'inner height: 50.0 arcsec\nouter width: 50.0 arcsec\n'
-                        'outer height: 80.0 arcsec\nangle: 0.0 deg')
+    expected_repr = ('<RectangleAnnulusSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+                     'deg\n    (3., 4.)>, inner width=20.0 arcsec, '
+                     'inner height=50.0 arcsec, outer width=50.0 arcsec, '
+                     'outer height=80.0 arcsec, angle=0.0 deg)>')
+    expected_str = ('Region: RectangleAnnulusSkyRegion\ncenter: <SkyCoord (ICRS): '
+                    '(ra, dec) in deg\n    (3., 4.)>\ninner width: 20.0 arcsec\n'
+                    'inner height: 50.0 arcsec\nouter width: 50.0 arcsec\n'
+                    'outer height: 80.0 arcsec\nangle: 0.0 deg')
 
     def test_init(self):
         assert_quantity_allclose(self.reg.center.ra, self.skycoord.ra)

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -16,7 +16,7 @@ from astropy.wcs import WCS
 from ...core import PixCoord
 from ...tests.helpers import make_simple_wcs
 from ..circle import CirclePixelRegion, CircleSkyRegion
-from .utils import ASTROPY_LT_13, HAS_MATPLOTLIB  # noqa
+from .utils import HAS_MATPLOTLIB  # noqa
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 
 
@@ -55,18 +55,11 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
 
     reg = CircleSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg), 2 * u.arcsec)
 
-    if ASTROPY_LT_13:
-        expected_repr = ('<CircleSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
-                         'deg\n    (3.0, 4.0)>, radius=2.0 arcsec)>')
-        expected_str = ('Region: CircleSkyRegion\ncenter: <SkyCoord (ICRS): '
-                        '(ra, dec) in deg\n    (3.0, 4.0)>\nradius: 2.0 '
-                        'arcsec')
-    else:
-        expected_repr = ('<CircleSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
-                         'deg\n    ( 3.,  4.)>, radius=2.0 arcsec)>')
-        expected_str = ('Region: CircleSkyRegion\ncenter: <SkyCoord (ICRS): '
-                        '(ra, dec) in deg\n    ( 3.,  4.)>\nradius: 2.0 '
-                        'arcsec')
+    expected_repr = ('<CircleSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+                     'deg\n    ( 3.,  4.)>, radius=2.0 arcsec)>')
+    expected_str = ('Region: CircleSkyRegion\ncenter: <SkyCoord (ICRS): '
+                    '(ra, dec) in deg\n    ( 3.,  4.)>\nradius: 2.0 '
+                    'arcsec')
 
     def test_transformation(self, wcs):
         skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='galactic')

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -16,7 +16,7 @@ from astropy.wcs import WCS
 from ...core import PixCoord
 from ...tests.helpers import make_simple_wcs
 from ..ellipse import EllipsePixelRegion, EllipseSkyRegion
-from .utils import ASTROPY_LT_13, HAS_MATPLOTLIB  # noqa
+from .utils import HAS_MATPLOTLIB  # noqa
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 
 
@@ -80,20 +80,12 @@ class TestEllipseSkyRegion(BaseTestSkyRegion):
         angle=5 * u.deg,
     )
 
-    if ASTROPY_LT_13:
-        expected_repr = ('<EllipseSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
-                    'deg\n    (3.0, 4.0)>, width=4.0 deg, height=3.0 deg,'
-                    ' angle=5.0 deg)>')
-        expected_str = ('Region: EllipseSkyRegion\ncenter: <SkyCoord (ICRS): '
-                   '(ra, dec) in deg\n    (3.0, 4.0)>\nwidth: 4.0 deg\n'
-                   'height: 3.0 deg\nangle: 5.0 deg')
-    else:
-        expected_repr = ('<EllipseSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
-                    'deg\n    ( 3.,  4.)>, width=4.0 deg, height=3.0 deg,'
-                    ' angle=5.0 deg)>')
-        expected_str = ('Region: EllipseSkyRegion\ncenter: <SkyCoord (ICRS): '
-                   '(ra, dec) in deg\n    ( 3.,  4.)>\nwidth: 4.0 deg\n'
-                   'height: 3.0 deg\nangle: 5.0 deg')
+    expected_repr = ('<EllipseSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+                     'deg\n    ( 3.,  4.)>, width=4.0 deg, height=3.0 deg,'
+                     ' angle=5.0 deg)>')
+    expected_str = ('Region: EllipseSkyRegion\ncenter: <SkyCoord (ICRS): '
+                    '(ra, dec) in deg\n    ( 3.,  4.)>\nwidth: 4.0 deg\n'
+                    'height: 3.0 deg\nangle: 5.0 deg')
 
     def test_dimension_center(self):
         center = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)

--- a/regions/shapes/tests/test_line.py
+++ b/regions/shapes/tests/test_line.py
@@ -16,7 +16,7 @@ from astropy.wcs import WCS
 from ...tests.helpers import make_simple_wcs
 from ...core import PixCoord
 from ..line import LinePixelRegion, LineSkyRegion
-from .utils import ASTROPY_LT_13, HAS_MATPLOTLIB  # noqa
+from .utils import HAS_MATPLOTLIB  # noqa
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 
 
@@ -57,20 +57,12 @@ class TestLineSkyRegion(BaseTestSkyRegion):
     end = SkyCoord(3 * u.deg, 5 * u.deg, frame='galactic')
     reg = LineSkyRegion(start, end)
 
-    if ASTROPY_LT_13:
-        expected_repr = ('<LineSkyRegion(start=<SkyCoord (Galactic): (l, b) in deg\n'
-                         '    (3.0, 4.0)>, end=<SkyCoord (Galactic): (l, b) in deg\n'
-                         '    (3.0, 5.0)>)>')
-        expected_str = ('Region: LineSkyRegion\nstart: <SkyCoord (Galactic): (l, b) in deg\n'
-                         '    (3.0, 4.0)>\nend: <SkyCoord (Galactic): (l, b) in deg\n'
-                         '    (3.0, 5.0)>')
-    else:
-        expected_repr = ('<LineSkyRegion(start=<SkyCoord (Galactic): (l, b) in deg\n'
-                         '    ( 3.,  4.)>, end=<SkyCoord (Galactic): (l, b) in deg\n'
-                         '    ( 3.,  5.)>)>')
-        expected_str = ('Region: LineSkyRegion\nstart: <SkyCoord (Galactic): (l, b) in deg\n'
-                         '    ( 3.,  4.)>\nend: <SkyCoord (Galactic): (l, b) in deg\n'
-                         '    ( 3.,  5.)>')
+    expected_repr = ('<LineSkyRegion(start=<SkyCoord (Galactic): (l, b) in deg\n'
+                     '    ( 3.,  4.)>, end=<SkyCoord (Galactic): (l, b) in deg\n'
+                     '    ( 3.,  5.)>)>')
+    expected_str = ('Region: LineSkyRegion\nstart: <SkyCoord (Galactic): (l, b) in deg\n'
+                    '    ( 3.,  4.)>\nend: <SkyCoord (Galactic): (l, b) in deg\n'
+                    '    ( 3.,  5.)>')
 
     def test_transformation(self, wcs):
         pixline = self.reg.to_pixel(wcs)

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -15,7 +15,7 @@ from astropy.wcs import WCS
 from ...core import PixCoord
 from ...tests.helpers import make_simple_wcs
 from ..point import PointPixelRegion, PointSkyRegion
-from .utils import ASTROPY_LT_13, HAS_MATPLOTLIB  # noqa
+from .utils import HAS_MATPLOTLIB  # noqa
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 
 
@@ -57,16 +57,10 @@ class TestPointSkyRegion(BaseTestSkyRegion):
 
     reg = PointSkyRegion(SkyCoord(3, 4, unit='deg'))
 
-    if ASTROPY_LT_13:
-        expected_repr = ('<PointSkyRegion(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                         '    (3.0, 4.0)>)>')
-        expected_str = ('Region: PointSkyRegion\ncenter: <SkyCoord (ICRS): '
-                        '(ra, dec) in deg\n    (3.0, 4.0)>')
-    else:
-        expected_repr = ('<PointSkyRegion(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                         '    ( 3.,  4.)>)>')
-        expected_str = ('Region: PointSkyRegion\ncenter: <SkyCoord (ICRS): '
-                        '(ra, dec) in deg\n    ( 3.,  4.)>')
+    expected_repr = ('<PointSkyRegion(<SkyCoord (ICRS): (ra, dec) in deg\n'
+                     '    ( 3.,  4.)>)>')
+    expected_str = ('Region: PointSkyRegion\ncenter: <SkyCoord (ICRS): '
+                    '(ra, dec) in deg\n    ( 3.,  4.)>')
 
     def test_contains(self, wcs):
         position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -13,7 +13,7 @@ from ..._utils.examples import make_example_dataset
 from ...core import PixCoord, BoundingBox
 from ...tests.helpers import make_simple_wcs
 from ..polygon import PolygonPixelRegion, PolygonSkyRegion
-from .utils import ASTROPY_LT_13, HAS_MATPLOTLIB  # noqa
+from .utils import HAS_MATPLOTLIB  # noqa
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 
 
@@ -97,20 +97,12 @@ class TestPolygonSkyRegion(BaseTestSkyRegion):
 
     reg = PolygonSkyRegion(SkyCoord([3, 4, 3] * u.deg, [3, 4, 4] * u.deg))
 
-    if ASTROPY_LT_13:
-        expected_repr = ('<PolygonSkyRegion(vertices=<SkyCoord (ICRS): (ra, '
-                    'dec) in deg\n    [(3.0, 3.0), (4.0, 4.0), (3.0, '
-                    '4.0)]>)>')
-        expected_str = ('Region: PolygonSkyRegion\nvertices: <SkyCoord (ICRS):'
-                   ' (ra, dec) in deg\n    [(3.0, 3.0), (4.0, 4.0), (3.0,'
-                   ' 4.0)]>')
-    else:
-        expected_repr = ('<PolygonSkyRegion(vertices=<SkyCoord (ICRS): (ra, '
-                    'dec) in deg\n    [( 3.,  3.), ( 4.,  4.), ( 3.,  '
-                    '4.)]>)>')
-        expected_str = ('Region: PolygonSkyRegion\nvertices: <SkyCoord (ICRS):'
-                   ' (ra, dec) in deg\n    [( 3.,  3.), ( 4.,  4.), ( 3.,'
-                   '  4.)]>')
+    expected_repr = ('<PolygonSkyRegion(vertices=<SkyCoord (ICRS): (ra, '
+                'dec) in deg\n    [( 3.,  3.), ( 4.,  4.), ( 3.,  '
+                '4.)]>)>')
+    expected_str = ('Region: PolygonSkyRegion\nvertices: <SkyCoord (ICRS):'
+               ' (ra, dec) in deg\n    [( 3.,  3.), ( 4.,  4.), ( 3.,'
+               '  4.)]>')
 
     def test_transformation(self, wcs):
 

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -15,7 +15,7 @@ from astropy.wcs import WCS
 from ...core import PixCoord
 from ..rectangle import RectanglePixelRegion, RectangleSkyRegion
 from ...tests.helpers import make_simple_wcs
-from .utils import ASTROPY_LT_13, HAS_MATPLOTLIB  # noqa
+from .utils import HAS_MATPLOTLIB  # noqa
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 
 
@@ -135,20 +135,12 @@ class TestRectangleSkyRegion(BaseTestSkyRegion):
         angle=5 * u.deg,
     )
 
-    if ASTROPY_LT_13:
-        expected_repr = ('<RectangleSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
-                    'deg\n    (3.0, 4.0)>, width=4.0 deg, height=3.0 '
-                    'deg, angle=5.0 deg)>')
-        expected_str = ('Region: RectangleSkyRegion\ncenter: <SkyCoord '
-                   '(ICRS): (ra, dec) in deg\n    (3.0, 4.0)>\nwidth: '
-                   '4.0 deg\nheight: 3.0 deg\nangle: 5.0 deg')
-    else:
-        expected_repr = ('<RectangleSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
-                    'deg\n    ( 3.,  4.)>, width=4.0 deg, height=3.0 '
-                    'deg, angle=5.0 deg)>')
-        expected_str = ('Region: RectangleSkyRegion\ncenter: <SkyCoord '
-                   '(ICRS): (ra, dec) in deg\n    ( 3.,  4.)>\nwidth: '
-                   '4.0 deg\nheight: 3.0 deg\nangle: 5.0 deg')
+    expected_repr = ('<RectangleSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+                'deg\n    ( 3.,  4.)>, width=4.0 deg, height=3.0 '
+                'deg, angle=5.0 deg)>')
+    expected_str = ('Region: RectangleSkyRegion\ncenter: <SkyCoord '
+               '(ICRS): (ra, dec) in deg\n    ( 3.,  4.)>\nwidth: '
+               '4.0 deg\nheight: 3.0 deg\nangle: 5.0 deg')
 
     def test_contains(self, wcs):
         position = SkyCoord([1, 3] * u.deg, [2, 4] * u.deg)

--- a/regions/shapes/tests/test_text.py
+++ b/regions/shapes/tests/test_text.py
@@ -15,7 +15,6 @@ from astropy.wcs import WCS
 from ...core import PixCoord
 from ...tests.helpers import make_simple_wcs
 from ..text import TextPixelRegion, TextSkyRegion
-from .utils import ASTROPY_LT_13
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 
 
@@ -47,16 +46,10 @@ class TestTextSkyRegion(BaseTestSkyRegion):
 
     reg = TextSkyRegion(SkyCoord(3, 4, unit='deg'), "Sample Text")
 
-    if ASTROPY_LT_13:
-        expected_repr = ('<TextSkyRegion(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                            '    (3.0, 4.0)>, text=Sample Text)>')
-        expected_str = ('Region: TextSkyRegion\ncenter: <SkyCoord (ICRS): '
-                          '(ra, dec) in deg\n    (3.0, 4.0)>\ntext: Sample Text')
-    else:
-        expected_repr = ('<TextSkyRegion(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                             '    ( 3.,  4.)>, text=Sample Text)>')
-        expected_str = ('Region: TextSkyRegion\ncenter: <SkyCoord (ICRS): '
-                        '(ra, dec) in deg\n    ( 3.,  4.)>\ntext: Sample Text')
+    expected_repr = ('<TextSkyRegion(<SkyCoord (ICRS): (ra, dec) in deg\n'
+                         '    ( 3.,  4.)>, text=Sample Text)>')
+    expected_str = ('Region: TextSkyRegion\ncenter: <SkyCoord (ICRS): '
+                    '(ra, dec) in deg\n    ( 3.,  4.)>\ntext: Sample Text')
 
     def test_contains(self, wcs):
         position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)

--- a/regions/shapes/tests/utils.py
+++ b/regions/shapes/tests/utils.py
@@ -1,8 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from distutils.version import LooseVersion
-import astropy
-
-ASTROPY_LT_13 = LooseVersion(astropy.__version__) < LooseVersion('1.3')
 
 try:
     import matplotlib  # noqa


### PR DESCRIPTION
This PR removes support for  ASTROPY_LT_13 from some tests.

I don't know what Astropy version we support here, but I think it's clear that Astropy < 1.3 is not our target.

@astrofrog @keflavich - OK?