### PR TITLE
fix bad escapes

### DIFF
--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -26,7 +26,7 @@ __all__ = [
 regex_global = re.compile("^#? *(-?)([a-zA-Z0-9]+)")
 
 # Regular expression to extract meta attributes
-regex_meta = re.compile("([a-zA-Z]+)(=)({.*?}|\'.*?\'|\".*?\"|[0-9\s]+\s?|[^=\s]+\s?[0-9]*)\s?")
+regex_meta = re.compile(r"([a-zA-Z]+)(=)({.*?}|\'.*?\'|\".*?\"|[0-9\s]+\s?|[^=\s]+\s?[0-9]*)\s?")
 
 # Regular expression to strip parenthesis
 regex_paren = re.compile("[()]")


### PR DESCRIPTION
Apparently we have some bad escapes in this regex; I was getting deprecation warnings when importing regions in another project.  However, I'm not convinced our tests cover this, which is a problem; this PR should be accompanied with a test...