### PR TITLE
Change CRTF writer to match CASA implementation

### DIFF
--- a/regions/io/core.py
+++ b/regions/io/core.py
@@ -154,9 +154,11 @@ class ShapeList(list):
 
         for key, val in crtf_strings.items():
             crtf_strings[key] = val.replace("FMT", fmt).replace("RAD",
-                                                               radunitstr)
+                                                                radunitstr)
 
-        output += 'global coord={}\n'.format(coordsys)
+        # CASA does not support global coordinate specification, even though the
+        # documentation for the specification explicitly states that it does.
+        # output += 'global coord={}\n'.format(coordsys)
 
         for shape in self:
 
@@ -164,7 +166,10 @@ class ShapeList(list):
             shape.meta = to_crtf_meta(shape.meta)
 
             # if unspecified, include is True.
-            include = "-" if shape.include in (False, '-') else "+"
+            # Despite the specification, CASA does *not* support a preceding
+            # "+".  If you want a region included, leave the opening character
+            # blank.
+            include = "-" if shape.include in (False, '-') else ""
             include += "ann " if shape.meta.get('type', 'reg') == 'ann' else ""
 
             if shape.meta.get('label', "") != "":
@@ -174,6 +179,11 @@ class ShapeList(list):
                                 key not in ('include', 'comment', 'symbol',
                                             'coord', 'text', 'range', 'corr',
                                             'type', 'text'))
+
+            # the first item should be the coordinates, since CASA cannot
+            # recognize a region without an inline coordinate specification
+            # It can be, but does not need to be, comma-separated at the start
+            meta_str = "coord={0}, ".format(coordsys.upper()) + meta_str
 
             if 'comment' in shape.meta:
                 meta_str += ", " + shape.meta['comment']

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -26,7 +26,7 @@ __all__ = [
 regex_global = re.compile("^#? *(-?)([a-zA-Z0-9]+)")
 
 # Regular expression to extract meta attributes
-regex_meta = re.compile("([a-zA-Z]+)(=)({.*?}|\'.*?\'|\".*?\"|[0-9\s]+\s?|[^=\s]+\s?[0-9]*)\s?")
+regex_meta = re.compile(r"([a-zA-Z]+)(=)({.*?}|\'.*?\'|\".*?\"|[0-9\s]+\s?|[^=\s]+\s?[0-9]*)\s?")
 
 # Regular expression to strip parenthesis
 regex_paren = re.compile("[()]")


### PR DESCRIPTION
CASA is incompatible with its own specification.  It cannot read CRTF files with 'global' coordinate specifications, even though the documented spec explicitly shows that example.  I've made a few fixes that empirically solve _some_ of the issues with the CASA parser, but frankly, CASA effectively does not have any capability of handling its own region files.  AFAICT, if a region file contains a region outside the image it's being "applied" to, it simply crashes and ignores the rest of the file.