### PR TITLE
Support boolean array mask creation

### DIFF
--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import abc
 import operator
 import inspect
+import numpy as np
 
 from astropy.extern import six
 
@@ -378,3 +379,24 @@ class SkyRegion(Region):
         pixel_region : `~regions.PixelRegion` object.
         """
         raise NotImplementedError
+
+
+class PixelRegionList(list):
+    """
+    A list of regions defined in some common pixel space
+    """
+
+    def to_boolean_mask(self, shape):
+        """
+        Create a boolean array mask from all of the contained regions given a
+        shape
+        """
+
+        mask_array = np.zeros(shape, dtype='bool')
+
+        for reg in self:
+            mask = reg.to_mask()
+
+            mask.to_image_partial_overlap(mask_array)
+
+        return mask_array

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -99,10 +99,17 @@ class RegionMask(object):
 
         return slices_large, slices_small
 
-    def _to_image_partial_overlap(self, image):
+    def to_image_partial_overlap(self, image):
         """
-        Return an image of the mask in a 2D array, where the mask
-        is not fully within the image (i.e. partial or no overlap).
+        Return an image of the mask in a 2D array, where the mask is not fully
+        within the image (i.e. partial or no overlap).  This can be used, for
+        example, to convert a region to a boolean array mask of an image.
+
+        Parameters
+        ----------
+        image : np.array
+            An ndarray image whose values will be modified inplace to be the
+            values of the mask.
         """
 
         # find the overlap of the mask on the output image shape
@@ -138,12 +145,12 @@ class RegionMask(object):
         image = np.zeros(shape)
 
         if self.bbox.ixmin < 0 or self.bbox.iymin < 0:
-            return self._to_image_partial_overlap(image)
+            return self.to_image_partial_overlap(image)
 
         try:
             image[self.bbox.slices] = self.data
         except ValueError:    # partial or no overlap
-            image = self._to_image_partial_overlap(image)
+            image = self.to_image_partial_overlap(image)
 
         return image
 


### PR DESCRIPTION
This is a WIP, with only one commit so far.

A critical tool for regions is converting a region or list of regions into a boolean array mask for a given image.  AFAICT, we don't support that right now, but I might be missing something.

Note that https://astropy-regions.readthedocs.io/en/latest/masks.html does not include this use case.  It only shows how to make cutouts and cutout masks.  It does not show how to make complete boolean array masks for an image.

The first step in this process is making `to_image_partial_overlap` a public function, because that's effectively all that is needed.  You just create a blank mask array with the same shape as the target image, then use this function to fill in the blanks.

The goal of this PR is to produce something with functionality identical to pyregion.get_mask.