### PR TITLE
Fix for issue 233: 'text' renamed to 'label'

### DIFF
--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -397,7 +397,8 @@ class RegionMeta(Meta):
     valid_keys = ['label', 'include', 'frame', 'range', 'veltype',
                   'restfreq', 'tag', 'comment', 'line', 'name',
                   'select', 'highlite', 'fixed', 'edit', 'move', 'rotate',
-                  'delete', 'source', 'background', 'corr', 'type'
+                  'delete', 'source', 'background', 'corr', 'type',
+                  'text'
                   ]
 
     key_mapping = {}

--- a/regions/io/core.py
+++ b/regions/io/core.py
@@ -178,7 +178,7 @@ class ShapeList(list):
                                 shape.meta.items() if
                                 key not in ('include', 'comment', 'symbol',
                                             'coord', 'text', 'range', 'corr',
-                                            'type', 'text'))
+                                            'type'))
 
             # the first item should be the coordinates, since CASA cannot
             # recognize a region without an inline coordinate specification

--- a/regions/io/core.py
+++ b/regions/io/core.py
@@ -613,7 +613,10 @@ class Shape(object):
         reg.visual = RegionVisual()
         reg.meta = RegionMeta()
 
-        label = self.meta.pop('text', self.meta.get('label', ""))
+        # both 'text' and 'label' should be set to the same value, where we
+        # default to the 'text' value since that is the one used by ds9 regions
+        label = self.meta.get('text',
+                              self.meta.get('label', ""))
         if label != '':
             reg.meta['label'] = label
         for key in self.meta:

--- a/regions/io/ds9/tests/test_ds9_language.py
+++ b/regions/io/ds9/tests/test_ds9_language.py
@@ -263,3 +263,20 @@ def test_expicit_formatting_directives():
     reg_str_explicit = 'fk5\ncircle(1h20m30s, 2d3m7s, 2d)'
     coord = DS9Parser(reg_str_explicit).shapes[0].coord
     assert_quantity_allclose(u.Quantity(coord), u.Quantity(valid_coord))
+
+def test_text_metadata():
+    """
+    Regression test for issue #233: make sure that text metadata is parsed and
+    stored appropriately.
+    """
+
+    reg_str = 'image\ncircle(1.5, 2, 2) # text={this_is_text}'
+    parsed_reg = DS9Parser(reg_str)
+
+    assert len(parsed_reg.shapes) == 1
+    assert parsed_reg.shapes[0].meta['text'] == 'this_is_text'
+
+    regs = parsed_reg.shapes.to_regions()
+
+    assert regs[0].meta['label'] == 'this_is_text'
+    assert regs[0].meta['text'] == 'this_is_text'


### PR DESCRIPTION
WIP: do not merge.

In a previous commit, the metadata 'text' was renamed to 'label'.  This breaks the one-to-one mapping between ds9 metadata keywords and astropy.regions metadata keywords, and therefore is a questionable decision.  We need to determine, going forward, whether to:

 * [ ] revert to using 'text' as the text metadata label
 * [ ] stick with using 'label' as the text metadata label
 * [x] keep both, so that reg.meta['text'] = reg.meta['label']

Any feedback?