### PR TITLE
Allow for mixed-case data in ds9 strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ Bug Fixes
 - A ``ValueError`` is now raised when calling ``BoundingBox.slices``
   when ``ixmin`` or ``iymin`` is negative. [#347]
 
+- Fixed an issue in the DS9 parser where uppercase coordinate frames
+  would fail. [#237]
+
 API Changes
 -----------
 

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -170,15 +170,16 @@ class DS9Parser:
     radius: 40.0
     """
 
-    # List of valid coordinate system
-    coordinate_systems = ['fk5', 'fk4', 'icrs', 'galactic', 'wcs', 'physical', 'image', 'ecliptic', 'J2000']
+    # List of valid coordinate system (all lowercase)
+    coordinate_systems = ['fk5', 'fk4', 'icrs', 'galactic', 'wcs',
+                          'physical', 'image', 'ecliptic', 'j2000']
     coordinate_systems += [f'wcs{letter}' for letter in string.ascii_lowercase]
 
     # Map to convert coordinate system names
     coordsys_mapping = dict(zip(coordinates.frame_transform_graph.get_names(),
                                 coordinates.frame_transform_graph.get_names()))
     coordsys_mapping['ecliptic'] = 'geocentrictrueecliptic'
-    coordsys_mapping['J2000'] = 'fk5'
+    coordsys_mapping['j2000'] = 'fk5'
 
     def __init__(self, region_string, errors='strict'):
         if errors not in ('strict', 'ignore', 'warn'):

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -239,8 +239,8 @@ class DS9Parser:
             return
 
         # Special case / header: parse global parameters into metadata
-        if line.lstrip()[:6] == 'global':
-            self.global_meta = self.parse_meta(line)
+        if line.lstrip()[:6].lower() == 'global':
+            self.global_meta = self.parse_meta(line.lower())
             # global_meta can specify "include=1"; never seen other options
             # used but presumably =0 means false
             self.global_meta['include'] = (False if
@@ -249,7 +249,7 @@ class DS9Parser:
             return
 
         # Try to parse the line
-        region_type_search = regex_global.search(line)
+        region_type_search = regex_global.search(line.lower())
         if region_type_search:
             include = region_type_search.groups()[0]
             region_type = region_type_search.groups()[1]
@@ -295,7 +295,8 @@ class DS9Parser:
         meta : dict
             A dictionary containing the metadata.
         """
-        keys_vals = [(x, y) for x, _, y in regex_meta.findall(meta_str.strip())]
+        # keys must be lower-casae, but data can be any case
+        keys_vals = [(x.lower(), y) for x, _, y in regex_meta.findall(meta_str.strip())]
         extra_text = regex_meta.split(meta_str.strip())[-1]
         result = {}
         for key, val in keys_vals:
@@ -453,7 +454,8 @@ class DS9RegionParser:
         # coordinate of the # symbol or end of the line (-1) if not found
         hash_or_end = self.line.find("#")
         temp = self.line[self.region_end:hash_or_end].strip(" |")
-        self.coord_str = regex_paren.sub("", temp)
+        # force all coordinate names (circle, etc) to be lower-case
+        self.coord_str = regex_paren.sub("", temp).lower()
 
         # don't want any meta_str if there is no metadata found
         if hash_or_end >= 0:

--- a/regions/io/ds9/tests/test_ds9_language.py
+++ b/regions/io/ds9/tests/test_ds9_language.py
@@ -215,6 +215,20 @@ def test_issue65_regression():
     assert reg.radius.value == 1.0
 
 
+def test_frame_uppercase():
+    """
+    Regression test for issue #236 (PR #237)
+    """
+    regstr = ('GALACTIC\ncircle(188.5557102,12.0314056,7.1245) # '
+              'text={This message has both ' 'a " and : in it} textangle=30')
+    parser = DS9Parser(regstr)
+    regions = parser.shapes
+    reg = regions[0].to_region()
+    assert reg.center.l.value == 188.5557102
+    assert reg.center.b.value == 12.0314056
+    assert reg.radius.value == 7.1245
+
+
 def test_pixel_angle():
     """
     Checks whether angle in PixelRegions is a u.Quantity object.


### PR DESCRIPTION
WIP: This is a fix for #236.  Wherever we're handling global metadata (keywords) or region shape names, we force them lowercase.  For the metadata, e.g., `text={blah}`, we lowercase the key but not the value.