### PR TITLE
Do not check for end of line after CRTF version number

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,9 @@ Bug Fixes
 - Fixed an issue in the DS9 parser where uppercase coordinate frames
   would fail. [#237]
 
+- Fixed an issue where the CRTF file parser would fail if the CRTF
+  version number was included on the first line. [#240]
+
 API Changes
 -----------
 

--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -14,7 +14,7 @@ from ..core import Shape, ShapeList, reg_mapping
 __all__ = ['read_crtf', 'CRTFParser', 'CRTFRegionParser']
 
 # All CASA files start with '#CRTF' . It may also include the version number like '#CRTFv0' .
-regex_begin = re.compile(r'^#CRTFv?[\d]?$')
+regex_begin = re.compile(r'^#CRTFv?[\d]?')
 
 # Comment Format :
 regex_comment = re.compile(r'^#.*$')

--- a/regions/io/crtf/tests/test_crtf_language.py
+++ b/regions/io/crtf/tests/test_crtf_language.py
@@ -11,6 +11,7 @@ from ..read import CRTFParser, read_crtf
 from ..write import crtf_objects_to_string
 from ..core import CRTFRegionParserError
 
+from ....shapes.circle import CircleSkyRegion
 from ....shapes.ellipse import EllipseSkyRegion
 
 _ASTROPY_MINVERSION = vers.LooseVersion('1.1')
@@ -158,3 +159,20 @@ def test_file_crtf(filename):
 
     for split_line in desired_lines:
         assert split_line in actual_lines
+
+
+def test_crtf_header():
+    """
+    Regression test for issue #239.
+    """
+    crtf_str = ('#CRTFv0 CASA Region Text Format version 0\n'
+                'circle[[42deg, 43deg], 3deg], coord=J2000, color=green')
+    parser = CRTFParser(crtf_str)
+    reg = parser.shapes.to_regions()[0]
+    assert isinstance(reg, CircleSkyRegion)
+    assert reg.center.ra.value == 42.0
+    assert reg.center.ra.unit == 'deg'
+    assert reg.center.dec.value == 43.0
+    assert reg.center.dec.unit == 'deg'
+    assert reg.radius.value == 3.0
+    assert reg.radius.unit == 'deg'


### PR DESCRIPTION
Issue #239 reported a CRTF file with text after the CRTF version number on the first line, which our parser failed to read because it searched for and end-of-line after the version.  I don't believe the end-of-line is a necessary part of the CRTF spec.