### PR TITLE
add PixCoord.xy

### DIFF
--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -162,3 +162,10 @@ class PixCoord(object):
         dx = other.x - self.x
         dy = other.y - self.y
         return np.hypot(dx, dy)
+
+    @property
+    def xy(self):
+        """
+        A 2-tuple ``(x, y)`` for this coordinate.
+        """
+        return (self.x, self.y)

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -203,3 +203,11 @@ def test_equality():
 
     assert a == b
     assert a == a
+
+
+def test_pixcoord_xy():
+    a = np.array([1, 2])
+    pc = PixCoord(a[0], a[1])
+
+    assert pc.xy[0] == pc.x
+    assert pc.xy[1] == pc.y


### PR DESCRIPTION
This does a pretty trivial thing of adding a convenience accessor to PixCoord called `xy`, which just does `(self.x, self.y)`.

The basic motivation for this is to make interfacing regions and photutils slightly easier - photutils apertures are (x,y) tuples, so it's a light cleaner to be able to do ``photutils.CircularAperture([skyregion.to_pixel(wcs).xy, ...], ...)`` than the alternative.  More broadly, I suspect there are various other situations where such an accessor is more convenient than having to individually index x and y.