### PR TITLE
Replace calls to deprecated np.asscalar() by .item()

### DIFF
--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -37,7 +37,7 @@ class PixCoord(object):
         x, y = np.broadcast_arrays(x, y)
 
         if x.shape == ():
-            self.x, self.y = np.asscalar(x), np.asscalar(y)
+            self.x, self.y = x.item(), y.item()
         else:
             self.x, self.y = x, y
 


### PR DESCRIPTION
Since numpy 1.16 the `np.asscalar` is deprecated. This PR replaces the two calls in `pixcoord.py` by the equivalent `.item()`.
