### PR TITLE
Add region copy methods

### DIFF
--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import numbers
+import copy
 import numpy as np
 from astropy.coordinates import SkyCoord
 from .core import _DEFAULT_WCS_ORIGIN, _DEFAULT_WCS_MODE
@@ -40,6 +40,9 @@ class PixCoord(object):
             self.x, self.y = x.item(), y.item()
         else:
             self.x, self.y = x, y
+
+    def copy(self):
+        return self.__class__(copy.copy(self.x), copy.copy(self.y))
 
     @staticmethod
     def _validate(val, name, expected='any'):

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -42,7 +42,10 @@ class PixCoord(object):
             self.x, self.y = x, y
 
     def copy(self):
-        return self.__class__(copy.copy(self.x), copy.copy(self.y))
+        return self.__class__(
+            copy.deepcopy(self.x),
+            copy.deepcopy(self.y),
+        )
 
     @staticmethod
     def _validate(val, name, expected='any'):

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -14,10 +14,21 @@ def wcs():
     return dataset.wcs
 
 
-def test_pixcoord_copy():
+def test_pixcoord_copy_scalar():
     p = PixCoord(x=1, y=2)
     p2 = p.copy()
+    p.x = 99
+    p.y = 99
     assert p2.xy == (1, 2)
+
+
+def test_pixcoord_copy_array():
+    p = PixCoord(x=[1, 2], y=[3, 4])
+    p2 = p.copy()
+    p.x[0] = 99
+    p.y[0] = 99
+    assert_equal(p2.x, [1, 2])
+    assert_equal(p2.y, [3, 4])
 
 
 def test_pixcoord_basic_dimension():
@@ -137,7 +148,7 @@ def test_pixcoord_to_sky_array_1d(wcs):
 
     p2 = PixCoord.from_sky(skycoord=s, wcs=wcs)
     assert isinstance(p2.x, np.ndarray)
-    assert p2.x.shape == (2, )
+    assert p2.x.shape == (2,)
     assert not p2.isscalar
 
     assert p == p2
@@ -191,7 +202,7 @@ def test_pixcoord_separation_array_2d():
 def test_equality():
     a = np.array([1, 2])
     b = PixCoord(a[0], a[1])
-    c = PixCoord(a[0]+0.0000001, a[1])
+    c = PixCoord(a[0] + 0.0000001, a[1])
 
     assert not b == a
     assert b == b

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -14,6 +14,12 @@ def wcs():
     return dataset.wcs
 
 
+def test_pixcoord_copy():
+    p = PixCoord(x=1, y=2)
+    p2 = p.copy()
+    assert p2.xy == (1, 2)
+
+
 def test_pixcoord_basic_dimension():
     with pytest.raises(ValueError):
         PixCoord(np.array([1, 2]), [3, 4, 5, 6])

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-
+import copy
 import numpy as np
 import math
 
@@ -65,6 +65,15 @@ class CirclePixelRegion(PixelRegion):
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
         self._repr_params = ('radius',)
+
+    def copy(self):
+        """Make an independent (deep) copy."""
+        return self.__class__(
+            self.center.copy(),
+            copy.copy(self.radius),
+            copy.deepcopy(self.meta),
+            copy.deepcopy(self.visual),
+        )
 
     @property
     def area(self):

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -70,7 +70,7 @@ class CirclePixelRegion(PixelRegion):
         """Make an independent (deep) copy."""
         return self.__class__(
             self.center.copy(),
-            copy.copy(self.radius),
+            copy.deepcopy(self.radius),
             copy.deepcopy(self.meta),
             copy.deepcopy(self.visual),
         )
@@ -179,12 +179,20 @@ class CircleSkyRegion(SkyRegion):
     radius = QuantityLength("radius")
 
     def __init__(self, center, radius, meta=None, visual=None):
-
         self.center = center
         self.radius = radius
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
         self._repr_params = ('radius',)
+
+    def copy(self):
+        """Make an independent (deep) copy."""
+        return self.__class__(
+            self.center.copy(),
+            copy.deepcopy(self.radius),
+            copy.deepcopy(self.meta),
+            copy.deepcopy(self.visual),
+        )
 
     def to_pixel(self, wcs):
         center, scale, _ = skycoord_to_pixel_scale_angle(self.center, wcs)

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import math
+import copy
 
 import numpy as np
 from astropy import units as u
@@ -79,6 +80,17 @@ class EllipsePixelRegion(PixelRegion):
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
         self._repr_params = ('width', 'height', 'angle')
+
+    def copy(self):
+        """Make an independent (deep) copy."""
+        return self.__class__(
+            self.center.copy(),
+            copy.deepcopy(self.width),
+            copy.deepcopy(self.height),
+            copy.deepcopy(self.angle),
+            copy.deepcopy(self.meta),
+            copy.deepcopy(self.visual),
+        )
 
     @property
     def area(self):
@@ -249,6 +261,17 @@ class EllipseSkyRegion(SkyRegion):
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
         self._repr_params = ('width', 'height', 'angle')
+
+    def copy(self):
+        """Make an independent (deep) copy."""
+        return self.__class__(
+            self.center.copy(),
+            copy.deepcopy(self.width),
+            copy.deepcopy(self.height),
+            copy.deepcopy(self.angle),
+            copy.deepcopy(self.meta),
+            copy.deepcopy(self.visual),
+        )
 
     def to_pixel(self, wcs):
         center, scale, north_angle = skycoord_to_pixel_scale_angle(self.center, wcs)

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-
+import copy
 import numpy as np
 
 from astropy.wcs.utils import skycoord_to_pixel, pixel_to_skycoord
@@ -58,6 +58,14 @@ class PolygonPixelRegion(PixelRegion):
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
         self._repr_params = ('vertices',)
+
+    def copy(self):
+        """Make an independent (deep) copy."""
+        return self.__class__(
+            self.vertices.copy(),
+            copy.deepcopy(self.meta),
+            copy.deepcopy(self.visual),
+        )
 
     @property
     def area(self):
@@ -172,6 +180,14 @@ class PolygonSkyRegion(SkyRegion):
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
         self._repr_params = ('vertices',)
+
+    def copy(self):
+        """Make an independent (deep) copy."""
+        return self.__class__(
+            self.vertices.copy(),
+            copy.deepcopy(self.meta),
+            copy.deepcopy(self.visual),
+        )
 
     def to_pixel(self, wcs):
         x, y = skycoord_to_pixel(self.vertices, wcs)

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-
+import copy
 import numpy as np
 from astropy import units as u
 
@@ -12,7 +12,6 @@ from .._geometry import rectangular_overlap_grid
 from .._utils.wcs_helpers import skycoord_to_pixel_scale_angle
 from ..core.attributes import ScalarPix, ScalarLength, QuantityLength, ScalarSky
 from .polygon import PolygonPixelRegion
-
 
 __all__ = ['RectanglePixelRegion', 'RectangleSkyRegion']
 
@@ -80,6 +79,17 @@ class RectanglePixelRegion(PixelRegion):
         self.visual = visual or {}
         self._repr_params = ('width', 'height', 'angle')
 
+    def copy(self):
+        """Make an independent (deep) copy."""
+        return self.__class__(
+            self.center.copy(),
+            copy.deepcopy(self.width),
+            copy.deepcopy(self.height),
+            copy.deepcopy(self.angle),
+            copy.deepcopy(self.meta),
+            copy.deepcopy(self.visual),
+        )
+
     @property
     def area(self):
         """Region area (float)"""
@@ -117,8 +127,8 @@ class RectanglePixelRegion(PixelRegion):
 
         w2 = self.width / 2.
         h2 = self.height / 2.
-        cos_angle = np.cos(self.angle)    # self.angle is a Quantity
-        sin_angle = np.sin(self.angle)    # self.angle is a Quantity
+        cos_angle = np.cos(self.angle)  # self.angle is a Quantity
+        sin_angle = np.sin(self.angle)  # self.angle is a Quantity
         dx1 = abs(w2 * cos_angle - h2 * sin_angle)
         dy1 = abs(w2 * sin_angle + h2 * cos_angle)
         dx2 = abs(w2 * cos_angle + h2 * sin_angle)
@@ -204,11 +214,11 @@ class RectanglePixelRegion(PixelRegion):
         Return the x, y coordinate pairs that define the corners
         """
 
-        corners = [(-self.width/2, -self.height/2),
-                   ( self.width/2, -self.height/2),
-                   ( self.width/2,  self.height/2),
-                   (-self.width/2,  self.height/2),
-                  ]
+        corners = [(-self.width / 2, -self.height / 2),
+                   (self.width / 2, -self.height / 2),
+                   (self.width / 2, self.height / 2),
+                   (-self.width / 2, self.height / 2),
+                   ]
         rotmat = [[np.cos(self.angle), np.sin(self.angle)],
                   [-np.sin(self.angle), np.cos(self.angle)]]
 
@@ -219,11 +229,10 @@ class RectanglePixelRegion(PixelRegion):
         """
         Return a 4-cornered polygon equivalent to this rectangle
         """
-        x,y = self.corners.T
+        x, y = self.corners.T
         vertices = PixCoord(x=x, y=y)
         return PolygonPixelRegion(vertices=vertices, meta=self.meta,
                                   visual=self.visual)
-
 
     def _lower_left_xy(self):
         """
@@ -279,6 +288,17 @@ class RectangleSkyRegion(SkyRegion):
         self.meta = meta or {}
         self.visual = visual or {}
         self._repr_params = ('width', 'height', 'angle')
+
+    def copy(self):
+        """Make an independent (deep) copy."""
+        return self.__class__(
+            self.center.copy(),
+            copy.deepcopy(self.width),
+            copy.deepcopy(self.height),
+            copy.deepcopy(self.angle),
+            copy.deepcopy(self.meta),
+            copy.deepcopy(self.visual),
+        )
 
     def to_pixel(self, wcs):
         center, scale, north_angle = skycoord_to_pixel_scale_angle(self.center, wcs)

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -37,6 +37,13 @@ class TestCirclePixelRegion(BaseTestPixelRegion):
     expected_repr = '<CirclePixelRegion(PixCoord(x=3, y=4), radius=2)>'
     expected_str = 'Region: CirclePixelRegion\ncenter: PixCoord(x=3, y=4)\nradius: 2'
 
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert reg.center.xy == (3, 4)
+        assert reg.radius == 2
+        assert reg.visual == {}
+        assert reg.meta == {}
+
     def test_pix_sky_roundtrip(self):
         wcs = make_simple_wcs(SkyCoord(2 * u.deg, 3 * u.deg), 0.1 * u.deg, 20)
         reg_new = self.reg.to_sky(wcs).to_pixel(wcs)

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -28,7 +28,6 @@ def wcs():
 
 
 class TestCirclePixelRegion(BaseTestPixelRegion):
-
     reg = CirclePixelRegion(PixCoord(3, 4), radius=2)
     sample_box = [0, 6, 1, 7]
     inside = [(3, 4)]
@@ -59,7 +58,6 @@ class TestCirclePixelRegion(BaseTestPixelRegion):
 
 
 class TestCircleSkyRegion(BaseTestSkyRegion):
-
     reg = CircleSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg), 2 * u.arcsec)
 
     expected_repr = ('<CircleSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
@@ -67,6 +65,13 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
     expected_str = ('Region: CircleSkyRegion\ncenter: <SkyCoord (ICRS): '
                     '(ra, dec) in deg\n    ( 3.,  4.)>\nradius: 2.0 '
                     'arcsec')
+
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert_allclose(reg.center.ra.deg, 3)
+        assert_allclose(reg.radius.to_value("arcsec"), 2)
+        assert reg.visual == {}
+        assert reg.meta == {}
 
     def test_transformation(self, wcs):
         skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='galactic')

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -38,6 +38,15 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
     expected_str = ('Region: EllipsePixelRegion\ncenter: PixCoord(x=3, y=4)\n'
                     'width: 4\nheight: 3\nangle: 5.0 deg')
 
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert reg.center.xy == (3, 4)
+        assert reg.width == 4
+        assert reg.height == 3
+        assert_allclose(reg.angle.to_value("deg"), 5)
+        assert reg.visual == {}
+        assert reg.meta == {}
+
     def test_pix_sky_roundtrip(self):
         wcs = make_simple_wcs(SkyCoord(2 * u.deg, 3 * u.deg), 0.1 * u.deg, 20)
         reg_new = self.reg.to_sky(wcs).to_pixel(wcs)
@@ -86,6 +95,15 @@ class TestEllipseSkyRegion(BaseTestSkyRegion):
     expected_str = ('Region: EllipseSkyRegion\ncenter: <SkyCoord (ICRS): '
                     '(ra, dec) in deg\n    ( 3.,  4.)>\nwidth: 4.0 deg\n'
                     'height: 3.0 deg\nangle: 5.0 deg')
+
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert_allclose(reg.center.ra.deg, 3)
+        assert_allclose(reg.width.to_value("deg"),  4)
+        assert_allclose(reg.height.to_value("deg"), 3)
+        assert_allclose(reg.angle.to_value("deg"), 5)
+        assert reg.visual == {}
+        assert reg.meta == {}
 
     def test_dimension_center(self):
         center = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -44,6 +44,13 @@ class TestPolygonPixelRegion(BaseTestPixelRegion):
     # (0,0) *---* (2, 0)
     #
 
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert_allclose(reg.vertices.x, [1, 3, 1])
+        assert_allclose(reg.vertices.y, [1, 1, 4])
+        assert reg.visual == {}
+        assert reg.meta == {}
+
     def test_pix_sky_roundtrip(self):
         wcs = make_simple_wcs(SkyCoord(2 * u.deg, 3 * u.deg), 0.1 * u.deg, 20)
         reg_new = self.reg.to_sky(wcs).to_pixel(wcs)
@@ -103,6 +110,12 @@ class TestPolygonSkyRegion(BaseTestSkyRegion):
     expected_str = ('Region: PolygonSkyRegion\nvertices: <SkyCoord (ICRS):'
                ' (ra, dec) in deg\n    [( 3.,  3.), ( 4.,  4.), ( 3.,'
                '  4.)]>')
+
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert_allclose(reg.vertices.ra.deg, [3, 4, 3])
+        assert reg.visual == {}
+        assert reg.meta == {}
 
     def test_transformation(self, wcs):
 

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -67,6 +67,15 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
     expected_str = ('Region: RectanglePixelRegion\ncenter: PixCoord(x=3, y=4)\n'
                     'width: 4\nheight: 3\nangle: 5.0 deg')
 
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert reg.center.xy == (3, 4)
+        assert reg.width == 4
+        assert reg.height == 3
+        assert_allclose(reg.angle.to_value("deg"), 5)
+        assert reg.visual == {}
+        assert reg.meta == {}
+
     def test_pix_sky_roundtrip(self):
         wcs = make_simple_wcs(SkyCoord(2 * u.deg, 3 * u.deg), 0.1 * u.deg, 20)
         reg_new = self.reg.to_sky(wcs).to_pixel(wcs)
@@ -141,6 +150,15 @@ class TestRectangleSkyRegion(BaseTestSkyRegion):
     expected_str = ('Region: RectangleSkyRegion\ncenter: <SkyCoord '
                '(ICRS): (ra, dec) in deg\n    ( 3.,  4.)>\nwidth: '
                '4.0 deg\nheight: 3.0 deg\nangle: 5.0 deg')
+
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert_allclose(reg.center.ra.deg, 3)
+        assert_allclose(reg.width.to_value("deg"),  4)
+        assert_allclose(reg.height.to_value("deg"), 3)
+        assert_allclose(reg.angle.to_value("deg"), 5)
+        assert reg.visual == {}
+        assert reg.meta == {}
 
     def test_contains(self, wcs):
         position = SkyCoord([1, 3] * u.deg, [2, 4] * u.deg)


### PR DESCRIPTION
As mentioned in #266 I'd like to add copy methods for regions.

I looked around a bit, e.g. [here](https://docs.python.org/3/library/copy.html) and [here](https://pymotw.com/3/copy/index.html), and there's `__copy__` and `__deepcopy__` that we could implement.

However, looking at `SkyCoord`, that doesn't seem to be implemented there. So I'd suggest to follow that class, and add a `copy` method for regions.

@astrofrog @keflavich @larrybradley  @sushobhana or anyone interested - could you please have a look at the one example method and test fr `CirclePixelRegion.copy` here? Is it OK, or would you suggest some different implementation or test pattern?

I'll wait a day here for suggestions before going ahead and adding `copy` methods for many region classes.