### PR TITLE
Set cython: language_level=3

### DIFF
--- a/regions/_geometry/circular_overlap.pyx
+++ b/regions/_geometry/circular_overlap.pyx
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# cython: language_level=3
 """
 The functions defined here allow one to determine the exact area of
 overlap of a rectangle and a circle (written by Thomas Robitaille).

--- a/regions/_geometry/core.pyx
+++ b/regions/_geometry/core.pyx
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# cython: language_level=3
 """The functions here are the core geometry functions."""
 
 from __future__ import (absolute_import, division, print_function,

--- a/regions/_geometry/elliptical_overlap.pyx
+++ b/regions/_geometry/elliptical_overlap.pyx
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# cython: language_level=3
 """
 The functions defined here allow one to determine the exact area of
 overlap of an ellipse and a triangle (written by Thomas Robitaille).

--- a/regions/_geometry/pnpoly.pyx
+++ b/regions/_geometry/pnpoly.pyx
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# cython: language_level=3
 #
 # The code in this file was adapted from code written by Greg von Winckel:
 #

--- a/regions/_geometry/polygonal_overlap.pyx
+++ b/regions/_geometry/polygonal_overlap.pyx
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
+# cython: language_level=3
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 

--- a/regions/_geometry/rectangular_overlap.pyx
+++ b/regions/_geometry/rectangular_overlap.pyx
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# cython: language_level=3
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 


### PR DESCRIPTION
Set  cython: language_level=3 to avoid cython compiler warnings like this:
```
cythoning regions/_geometry/rectangular_overlap.pyx to regions/_geometry/rectangular_overlap.c
/Users/deil/software/anaconda3/envs/regions/lib/python3.7/site-packages/Cython/Compiler/Main.py:367: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /Users/deil/work/code/regions/regions/_geometry/rectangular_overlap.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
```
All tests pass for me locally, expect the same for CI.