### PR TITLE
Minor improvements to mask docs

### DIFF
--- a/docs/masks.rst
+++ b/docs/masks.rst
@@ -163,8 +163,11 @@ as well as a cutout with the data multiplied by the mask::
     >>> weighted_data = mask.multiply(hdu.data)
     >>> pf.close()
 
+Note that ``weighted_data`` will have zeros where the mask is zero; it therefore
+should not be used to compute statistics.  See `Masked Statistics` below.
+
 We can take a look at the results to make sure the source overlaps
-with the aperture::
+with the aperture
 
 .. doctest-skip::
 
@@ -240,6 +243,9 @@ at the extent of the mask in the image:
    :nofigs:
 
     pf.close()
+
+Masked Statistics
+`````````````````
 
 Finally, we can use the mask and data values to compute weighted
 statistics::

--- a/docs/masks.rst
+++ b/docs/masks.rst
@@ -167,7 +167,7 @@ Note that ``weighted_data`` will have zeros where the mask is zero; it therefore
 should not be used to compute statistics.  See `Masked Statistics` below.
 
 We can take a look at the results to make sure the source overlaps
-with the aperture
+with the aperture:
 
 .. doctest-skip::
 


### PR DESCRIPTION
The mask docs are somewhat unclear at present; `mask.multiply` is not
appropriate for most statistics.  Also, I think we need a `mask.get_pixels`
method to enable use of other types of statistics, like the median.  Do we have
that somewhere already and I'm just forgetting?  Seems likely.