### PR TITLE
Remove duplicated region file write examples

### DIFF
--- a/regions/io/crtf/write.py
+++ b/regions/io/crtf/write.py
@@ -42,7 +42,6 @@ def crtf_objects_to_string(regions, coordsys='fk5', fmt='.6f', radunit='deg'):
     circle[[1.000007deg, 2.000002deg], 5.000000deg], coord=FK5,
 
     """
-
     shapelist = to_shape_list(regions, coordsys)
     return shapelist.to_crtf(coordsys, fmt, radunit)
 
@@ -50,6 +49,8 @@ def crtf_objects_to_string(regions, coordsys='fk5', fmt='.6f', radunit='deg'):
 def write_crtf(regions, filename, coordsys='fk5', fmt='.6f', radunit='deg'):
     """
     Converts a `list` of `~regions.Region` to CRTF string and write to file.
+
+    See :ref:`gs-crtf`
 
     Parameters
     ----------
@@ -65,21 +66,7 @@ def write_crtf(regions, filename, coordsys='fk5', fmt='.6f', radunit='deg'):
         which is accurate to 0.0036 arcseconds.
     radunit : `str`, optional
         This denotes the unit of the radius. Default is deg (degrees)
-
-    Examples
-    --------
-    >>> from astropy import units as u
-    >>> from astropy.coordinates import SkyCoord
-    >>> from regions import CircleSkyRegion, write_crtf
-    >>> reg_sky = CircleSkyRegion(SkyCoord(1 * u.deg, 2 * u.deg), 5 * u.deg)
-    >>> write_crtf([reg_sky], 'test_write.crtf')
-    >>> with open('test_write.crtf') as f:
-    ...      print(f.read())
-    #CRTF
-    circle[[1.000007deg, 2.000002deg], 5.000000deg], coord=FK5,
-
     """
-
     output = crtf_objects_to_string(regions, coordsys, fmt, radunit)
     with open(filename, 'w') as fh:
         fh.write(output)

--- a/regions/io/ds9/write.py
+++ b/regions/io/ds9/write.py
@@ -13,6 +13,8 @@ def ds9_objects_to_string(regions, coordsys='fk5', fmt='.6f', radunit='deg'):
     """
     Converts a `list` of `~regions.Region` to DS9 region string.
 
+    See :ref:`gs-ds9`
+
     Parameters
     ----------
     regions : `list`
@@ -30,17 +32,6 @@ def ds9_objects_to_string(regions, coordsys='fk5', fmt='.6f', radunit='deg'):
     -------
     region_string : `str`
         DS9 region string
-
-    Examples
-    --------
-    >>> from astropy import units as u
-    >>> from astropy.coordinates import SkyCoord
-    >>> from regions import CircleSkyRegion, ds9_objects_to_string
-    >>> reg_sky = CircleSkyRegion(SkyCoord(1 * u.deg, 2 * u.deg), 5 * u.deg)
-    >>> print(ds9_objects_to_string([reg_sky]))
-    # Region file format: DS9 astropy/regions
-    fk5
-    circle(1.000007,2.000002,5.000000)
     """
     shapelist = to_shape_list(regions, coordsys)
     return shapelist.to_ds9(coordsys, fmt, radunit)
@@ -49,6 +40,8 @@ def ds9_objects_to_string(regions, coordsys='fk5', fmt='.6f', radunit='deg'):
 def write_ds9(regions, filename, coordsys='fk5', fmt='.6f', radunit='deg'):
     """
     Converts a `list` of `~regions.Region` to DS9 string and write to file.
+
+    See :ref:`gs-ds9`
 
     Parameters
     ----------
@@ -64,19 +57,6 @@ def write_ds9(regions, filename, coordsys='fk5', fmt='.6f', radunit='deg'):
         which is accurate to 0.0036 arcseconds.
     radunit : `str`, optional
         This denotes the unit of the radius. Default is deg (degrees)
-
-    Examples
-    --------
-    >>> from astropy import units as u
-    >>> from astropy.coordinates import SkyCoord
-    >>> from regions import CircleSkyRegion, write_ds9
-    >>> reg_sky = CircleSkyRegion(SkyCoord(1 * u.deg, 2 * u.deg), 5 * u.deg)
-    >>> write_ds9([reg_sky], 'test_write.reg')
-    >>> with open('test_write.reg') as f:
-    ...      print(f.read())
-    # Region file format: DS9 astropy/regions
-    fk5
-    circle(1.000007,2.000002,5.000000)
     """
     output = ds9_objects_to_string(regions, coordsys, fmt, radunit)
     with open(filename, 'w') as fh:

--- a/regions/io/fits/write.py
+++ b/regions/io/fits/write.py
@@ -16,6 +16,8 @@ def fits_region_objects_to_table(regions):
     """
     Converts list of regions to FITS region table.
 
+    See :ref:`gs-ds9`
+
     Parameters
     ----------
     regions : list
@@ -25,19 +27,6 @@ def fits_region_objects_to_table(regions):
     -------
     region_string : `~astropy.table.Table`
         FITS region table
-
-    Examples
-    --------
-
-    >>> from regions import CirclePixelRegion, PixCoord
-    >>> reg_pixel = CirclePixelRegion(PixCoord(1, 2), 5)
-    >>> table = fits_region_objects_to_table([reg_pixel])
-    >>> print(table)
-    X [1] Y [1] SHAPE    R [4]    ROTANG COMPONENT
-    pix   pix            pix      deg
-    ----- ----- ------ ---------- ------ ---------
-      1.0   2.0 circle 5.0 .. 0.0      0         1
-
     """
     for reg in regions:
         if isinstance(reg, SkyRegion):
@@ -51,28 +40,16 @@ def write_fits_region(filename, regions, header=None):
     """
     Converts list of regions to FITS region table and write to a file.
 
+    See :ref:`gs-fits`
+
     Parameters
     ----------
-    filename: str
-        Filename in which the table is to be written. Default is 'new.fits'
-    regions: list
+    filename : str
+        Filename in which the table is to be written.
+    regions : list
         List of `regions.Region` objects
-    header: `~astropy.io.fits.header.Header` object
-        The FITS header.
-
-    Examples
-    --------
-
-    >>> from astropy.utils.data import get_pkg_data_filename
-    >>> from astropy.io import fits
-    >>> file_sample = get_pkg_data_filename(
-    ...     'data/fits_region.fits', package='regions.io.fits.tests')
-    >>> from regions import CirclePixelRegion, PixCoord, write_fits_region
-    >>> reg_pixel = CirclePixelRegion(PixCoord(1, 2), 5)
-    >>> with fits.open(file_sample) as hdul:
-    ...     write_fits_region('region_output.fits', regions=[reg_pixel],
-    ...                       header=hdul[1].header)
-
+    header : `~astropy.io.fits.Header`
+        The FITS header
     """
     output = fits_region_objects_to_table(regions)
 


### PR DESCRIPTION
This PR removes the examples in the region file write methods, and instead links to the user guide which has these same examples duplicated.

It fixes #267 by resolving the remaining issue mentioned in https://github.com/astropy/regions/issues/267#issuecomment-500592628 and discussed in the comments that follow.

@keflavich - You can check that these examples are already in the user guide: [ds9](https://astropy-regions.readthedocs.io/en/latest/ds9.html), [crtf](https://astropy-regions.readthedocs.io/en/latest/crtf.html), [fits_region](https://astropy-regions.readthedocs.io/en/latest/fits_region.html).

Are you OK with this change?

