### PR TITLE
Fix corner-case issue in RegionMask.multiply()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,13 @@ New Features
 - Added ``union`` and ``intersection`` methods to the ``BoundingBox``
   class. [#277]
 
+Bug Fixes
+---------
+
+- Fixed a corner-case issue where ``RegionMask.multiply()`` would not set
+  non-finite data values outside of the mask but within the bounding box
+  to zero. [#278]
+
 
 0.3 (2018-09-09)
 ================

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -159,8 +159,8 @@ class RegionMask(object):
             A 2D array on which to apply the region mask.
 
         fill_value : float, optional
-            The value is used to fill pixels where the region mask
-            does not overlap with the input ``data``.  The default is 0.
+            The value used to fill pixels where the region mask does not
+            overlap with the input ``data``.  The default is 0.
 
         copy : bool, optional
             If `True` then the returned cutout array will always be hold

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -36,6 +36,7 @@ class RegionMask(object):
             raise ValueError('data and bounding box must have the same '
                              'shape.')
         self.bbox = bbox
+        self._mask = (self.data == 0)
 
     def __array__(self):
         """
@@ -245,4 +246,10 @@ class RegionMask(object):
         if cutout is None:
             return None
         else:
-            return cutout * self.data
+            weighted_cutout = cutout * self.data
+
+            # needed to zero out non-finite data values outside of the
+            # mask but within the bounding box
+            weighted_cutout[self._mask] = 0.0
+
+            return weighted_cutout


### PR DESCRIPTION
This PR fixes a corner-case bug where `RegionMask.multiply()` would not set non-finite (NaN, +/- inf) data values outside of the mask but within the mask bounding box to zero.  The array returned by `multiply` should be nonzero *only* within the mask.