### PR TITLE
Change copy and add rotate methods

### DIFF
--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import abc
 import six
+import copy
 import operator
 import inspect
 
@@ -65,6 +66,14 @@ class Region(object):
     """
     Base class for all regions.
     """
+
+    def copy(self, **changes):
+        """Make an independent (deep) copy."""
+        for field in self._fields:
+            if field not in changes:
+                changes[field] = copy.deepcopy(getattr(self, field))
+
+        return self.__class__(**changes)
 
     def __repr__(self):
         if hasattr(self, 'center'):

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -69,7 +69,15 @@ class Region(object):
 
     def copy(self, **changes):
         """Make an independent (deep) copy."""
-        for field in self._fields:
+        fields = []
+        if hasattr(self, "center"):
+            fields.append("center")
+        if hasattr(self, "vertices"):
+            fields.append("vertices")
+        fields.extend(self._repr_params)
+        fields.extend(["meta", "visual"])
+
+        for field in fields:
             if field not in changes:
                 changes[field] = copy.deepcopy(getattr(self, field))
 

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import copy
 import numpy as np
 from astropy.coordinates import SkyCoord
+
 from .core import _DEFAULT_WCS_ORIGIN, _DEFAULT_WCS_MODE
 
 __all__ = ['PixCoord']
@@ -175,3 +176,31 @@ class PixCoord(object):
         A 2-tuple ``(x, y)`` for this coordinate.
         """
         return (self.x, self.y)
+
+    def rotate(self, center, angle):
+        """Make a rotated pixel coordinate.
+
+        Rotates counter-clockwise for positive ``angle``.
+
+        Parameters
+        ----------
+        center : PixCoord
+            Rotation center point
+        angle : Angle
+            Rotation angle
+
+        Returns
+        -------
+        coord : PixCoord
+            Rotated coordinates (an independent copy)
+        """
+        dx = self.x - center.x
+        dy = self.y - center.y
+        vec = np.array([dx, dy])
+
+        c, s = np.cos(angle), np.sin(angle)
+        rotation_matrix = np.array([[c, -s], [s, c]])
+
+        vec = np.matmul(rotation_matrix, vec)
+
+        return self.__class__(center.x + vec[0], center.y + vec[1])

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 import pytest
+from astropy import units as u
 from ..._utils.examples import make_example_dataset
 from ..pixcoord import PixCoord
 
@@ -228,3 +229,17 @@ def test_pixcoord_xy():
 
     assert pc.xy[0] == pc.x
     assert pc.xy[1] == pc.y
+
+
+def test_pixcoord_rotate_scalar():
+    point = PixCoord(3, 4)
+    center = PixCoord(2, 3)
+    point = point.rotate(center, 90 * u.deg)
+    assert_allclose(point.xy, (1, 4))
+
+
+def test_pixcoord_rotate_array():
+    point = PixCoord([3, 3], [4, 4])
+    center = PixCoord(2, 3)
+    point = point.rotate(center, 90 * u.deg)
+    assert_allclose(point.xy, ([1, 1], [4, 4]))

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -63,7 +63,6 @@ class CirclePixelRegion(PixelRegion):
         self.radius = radius
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._fields = ('center', 'radius', 'meta', 'visual')
         self._repr_params = ('radius',)
 
     @property
@@ -194,7 +193,6 @@ class CircleSkyRegion(SkyRegion):
         self.radius = radius
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._fields = ('center', 'radius', 'meta', 'visual')
         self._repr_params = ('radius',)
 
     def to_pixel(self, wcs):

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import copy
 import numpy as np
 import math
 
@@ -64,16 +63,8 @@ class CirclePixelRegion(PixelRegion):
         self.radius = radius
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
+        self._fields = ('center', 'radius', 'meta', 'visual')
         self._repr_params = ('radius',)
-
-    def copy(self):
-        """Make an independent (deep) copy."""
-        return self.__class__(
-            self.center.copy(),
-            copy.deepcopy(self.radius),
-            copy.deepcopy(self.meta),
-            copy.deepcopy(self.visual),
-        )
 
     @property
     def area(self):
@@ -183,16 +174,8 @@ class CircleSkyRegion(SkyRegion):
         self.radius = radius
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = ('radius',)
         self._fields = ('center', 'radius', 'meta', 'visual')
-
-    def copy(self, **changes):
-        """Make an independent (deep) copy."""
-        for field in self._fields:
-            if field not in changes:
-                changes[field] = copy.deepcopy(getattr(self, field))
-
-        return self.__class__(**changes)
+        self._repr_params = ('radius',)
 
     def to_pixel(self, wcs):
         center, scale, _ = skycoord_to_pixel_scale_angle(self.center, wcs)

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -149,6 +149,26 @@ class CirclePixelRegion(PixelRegion):
 
         return Circle(xy=xy, radius=radius, **mpl_params)
 
+    def rotate(self, center, angle):
+        """Make a rotated region.
+
+        Rotates counter-clockwise for positive ``angle``.
+
+        Parameters
+        ----------
+        center : PixCoord
+            Rotation center point
+        angle : Angle
+            Rotation angle
+
+        Returns
+        -------
+        region : CircleSkyRegion
+            Rotated region (an independent copy)
+        """
+        center = self.center.rotate(center, angle)
+        return self.copy(center=center)
+
 
 class CircleSkyRegion(SkyRegion):
     """

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -155,14 +155,14 @@ class CirclePixelRegion(PixelRegion):
 
         Parameters
         ----------
-        center : PixCoord
+        center : `PixCoord`
             Rotation center point
-        angle : Angle
+        angle : `~astropy.coordinates.Angle`
             Rotation angle
 
         Returns
         -------
-        region : CircleSkyRegion
+        region : `CirclePixelRegion`
             Rotated region (an independent copy)
         """
         center = self.center.rotate(center, angle)
@@ -199,23 +199,3 @@ class CircleSkyRegion(SkyRegion):
         center, scale, _ = skycoord_to_pixel_scale_angle(self.center, wcs)
         radius = self.radius.to('deg').value * scale
         return CirclePixelRegion(center, radius, self.meta, self.visual)
-
-    def rotate(self, center, angle):
-        """Make a rotated region.
-
-        Rotates counter-clockwise for positive ``angle``.
-
-        Parameters
-        ----------
-        center : PixCoord
-            Rotation center point
-        angle : Angle
-            Rotation angle
-
-        Returns
-        -------
-        region : CircleSkyRegion
-            Rotated region (an independent copy)
-        """
-        center = self.center.rotate(center, angle)
-        return self.copy(center=center)

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import math
-import copy
 
 import numpy as np
 from astropy import units as u
@@ -79,18 +78,8 @@ class EllipsePixelRegion(PixelRegion):
         self.angle = angle
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
+        self._fields = ("center", "width", "height", "angle", "meta", "visual")
         self._repr_params = ('width', 'height', 'angle')
-
-    def copy(self):
-        """Make an independent (deep) copy."""
-        return self.__class__(
-            self.center.copy(),
-            copy.deepcopy(self.width),
-            copy.deepcopy(self.height),
-            copy.deepcopy(self.angle),
-            copy.deepcopy(self.meta),
-            copy.deepcopy(self.visual),
-        )
 
     @property
     def area(self):
@@ -260,18 +249,8 @@ class EllipseSkyRegion(SkyRegion):
         self.angle = angle
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
+        self._fields = ("center", "width", "height", "angle", "meta", "visual")
         self._repr_params = ('width', 'height', 'angle')
-
-    def copy(self):
-        """Make an independent (deep) copy."""
-        return self.__class__(
-            self.center.copy(),
-            copy.deepcopy(self.width),
-            copy.deepcopy(self.height),
-            copy.deepcopy(self.angle),
-            copy.deepcopy(self.meta),
-            copy.deepcopy(self.visual),
-        )
 
     def to_pixel(self, wcs):
         center, scale, north_angle = skycoord_to_pixel_scale_angle(self.center, wcs)

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -78,7 +78,6 @@ class EllipsePixelRegion(PixelRegion):
         self.angle = angle
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._fields = ("center", "width", "height", "angle", "meta", "visual")
         self._repr_params = ('width', 'height', 'angle')
 
     @property
@@ -249,7 +248,6 @@ class EllipseSkyRegion(SkyRegion):
         self.angle = angle
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._fields = ("center", "width", "height", "angle", "meta", "visual")
         self._repr_params = ('width', 'height', 'angle')
 
     def to_pixel(self, wcs):

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -213,6 +213,27 @@ class EllipsePixelRegion(PixelRegion):
         return Ellipse(xy=xy, width=width, height=height, angle=angle,
                        **mpl_params)
 
+    def rotate(self, center, angle):
+        """Make a rotated region.
+
+        Rotates counter-clockwise for positive ``angle``.
+
+        Parameters
+        ----------
+        center : `PixCoord`
+            Rotation center point
+        angle : `~astropy.coordinates.Angle`
+            Rotation angle
+
+        Returns
+        -------
+        region : `EllipsePixelRegion`
+            Rotated region (an independent copy)
+        """
+        center = self.center.rotate(center, angle)
+        angle = self.angle + angle
+        return self.copy(center=center, angle=angle)
+
 
 class EllipseSkyRegion(SkyRegion):
     """

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -149,6 +149,26 @@ class PolygonPixelRegion(PixelRegion):
 
         return Polygon(xy=xy, **mpl_params)
 
+    def rotate(self, center, angle):
+        """Make a rotated region.
+
+        Rotates counter-clockwise for positive ``angle``.
+
+        Parameters
+        ----------
+        center : `PixCoord`
+            Rotation center point
+        angle : `~astropy.coordinates.Angle`
+            Rotation angle
+
+        Returns
+        -------
+        region : `PolygonPixelRegion`
+            Rotated region (an independent copy)
+        """
+        vertices = self.vertices.rotate(center, angle)
+        return self.copy(vertices=vertices)
+
 
 class PolygonSkyRegion(SkyRegion):
     """

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import copy
 import numpy as np
 
 from astropy.wcs.utils import skycoord_to_pixel, pixel_to_skycoord
@@ -57,15 +56,8 @@ class PolygonPixelRegion(PixelRegion):
         self.vertices = vertices
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
+        self._fields = ("vertices", "meta", "visual")
         self._repr_params = ('vertices',)
-
-    def copy(self):
-        """Make an independent (deep) copy."""
-        return self.__class__(
-            self.vertices.copy(),
-            copy.deepcopy(self.meta),
-            copy.deepcopy(self.visual),
-        )
 
     @property
     def area(self):
@@ -179,15 +171,8 @@ class PolygonSkyRegion(SkyRegion):
         self.vertices = vertices
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
+        self._fields = ("vertices", "meta", "visual")
         self._repr_params = ('vertices',)
-
-    def copy(self):
-        """Make an independent (deep) copy."""
-        return self.__class__(
-            self.vertices.copy(),
-            copy.deepcopy(self.meta),
-            copy.deepcopy(self.visual),
-        )
 
     def to_pixel(self, wcs):
         x, y = skycoord_to_pixel(self.vertices, wcs)

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -56,7 +56,6 @@ class PolygonPixelRegion(PixelRegion):
         self.vertices = vertices
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._fields = ("vertices", "meta", "visual")
         self._repr_params = ('vertices',)
 
     @property
@@ -171,7 +170,6 @@ class PolygonSkyRegion(SkyRegion):
         self.vertices = vertices
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._fields = ("vertices", "meta", "visual")
         self._repr_params = ('vertices',)
 
     def to_pixel(self, wcs):

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import copy
 import numpy as np
 from astropy import units as u
 
@@ -77,18 +76,8 @@ class RectanglePixelRegion(PixelRegion):
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
+        self._fields = ("center", "width", "height", "angle", "meta", "visual")
         self._repr_params = ('width', 'height', 'angle')
-
-    def copy(self):
-        """Make an independent (deep) copy."""
-        return self.__class__(
-            self.center.copy(),
-            copy.deepcopy(self.width),
-            copy.deepcopy(self.height),
-            copy.deepcopy(self.angle),
-            copy.deepcopy(self.meta),
-            copy.deepcopy(self.visual),
-        )
 
     @property
     def area(self):
@@ -287,18 +276,8 @@ class RectangleSkyRegion(SkyRegion):
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
+        self._fields = ("center", "width", "height", "angle", "meta", "visual")
         self._repr_params = ('width', 'height', 'angle')
-
-    def copy(self):
-        """Make an independent (deep) copy."""
-        return self.__class__(
-            self.center.copy(),
-            copy.deepcopy(self.width),
-            copy.deepcopy(self.height),
-            copy.deepcopy(self.angle),
-            copy.deepcopy(self.meta),
-            copy.deepcopy(self.visual),
-        )
 
     def to_pixel(self, wcs):
         center, scale, north_angle = skycoord_to_pixel_scale_angle(self.center, wcs)

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -240,6 +240,27 @@ class RectanglePixelRegion(PixelRegion):
         y = self.center.y + dy
         return x, y
 
+    def rotate(self, center, angle):
+        """Make a rotated region.
+
+        Rotates counter-clockwise for positive ``angle``.
+
+        Parameters
+        ----------
+        center : `PixCoord`
+            Rotation center point
+        angle : `~astropy.coordinates.Angle`
+            Rotation angle
+
+        Returns
+        -------
+        region : `RectanglePixelRegion`
+            Rotated region (an independent copy)
+        """
+        center = self.center.rotate(center, angle)
+        angle = self.angle + angle
+        return self.copy(center=center, angle=angle)
+
 
 class RectangleSkyRegion(SkyRegion):
     """

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -76,7 +76,6 @@ class RectanglePixelRegion(PixelRegion):
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
-        self._fields = ("center", "width", "height", "angle", "meta", "visual")
         self._repr_params = ('width', 'height', 'angle')
 
     @property
@@ -276,7 +275,6 @@ class RectangleSkyRegion(SkyRegion):
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
-        self._fields = ("center", "width", "height", "angle", "meta", "visual")
         self._repr_params = ('width', 'height', 'angle')
 
     def to_pixel(self, wcs):

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -56,6 +56,10 @@ class TestCirclePixelRegion(BaseTestPixelRegion):
         assert_allclose(patch.center, (3, 4))
         assert_allclose(patch.radius, 2)
 
+    def test_rotate(self):
+        reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
+        assert_allclose(reg.center.xy, (1, 4))
+
 
 class TestCircleSkyRegion(BaseTestSkyRegion):
     reg = CircleSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg), 2 * u.arcsec)

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -28,7 +28,6 @@ def wcs():
 
 
 class TestEllipsePixelRegion(BaseTestPixelRegion):
-
     reg = EllipsePixelRegion(center=PixCoord(3, 4), width=4, height=3, angle=5 * u.deg)
     sample_box = [-2, 8, -1, 9]
     inside = [(4.5, 4)]
@@ -79,9 +78,13 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
                                  angle=90. * u.deg)
         assert reg.bounding_box.shape == (a, b)
 
+    def test_rotate(self):
+        reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
+        assert_allclose(reg.center.xy, (1, 4))
+        assert_allclose(reg.angle.to_value("deg"), 95)
+
 
 class TestEllipseSkyRegion(BaseTestSkyRegion):
-
     reg = EllipseSkyRegion(
         center=SkyCoord(3, 4, unit='deg'),
         width=4 * u.deg,
@@ -99,7 +102,7 @@ class TestEllipseSkyRegion(BaseTestSkyRegion):
     def test_copy(self):
         reg = self.reg.copy()
         assert_allclose(reg.center.ra.deg, 3)
-        assert_allclose(reg.width.to_value("deg"),  4)
+        assert_allclose(reg.width.to_value("deg"), 4)
         assert_allclose(reg.height.to_value("deg"), 3)
         assert_allclose(reg.angle.to_value("deg"), 5)
         assert reg.visual == {}

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -99,6 +99,11 @@ class TestPolygonPixelRegion(BaseTestPixelRegion):
         expected = [[1, 1], [3, 1], [1, 4], [1, 1]]
         assert_allclose(patch.xy, expected)
 
+    def test_rotate(self):
+        reg = self.reg.rotate(PixCoord(3, 1), -90 * u.deg)
+        assert_allclose(reg.vertices.x, [3, 3, 6])
+        assert_allclose(reg.vertices.y, [3, 1, 3])
+
 
 class TestPolygonSkyRegion(BaseTestSkyRegion):
 

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -102,6 +102,11 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
         # correctly.
         # assert_allclose(patch._angle, 5)
 
+    def test_rotate(self):
+        reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
+        assert_allclose(reg.center.xy, (1, 4))
+        assert_allclose(reg.angle.to_value("deg"), 95)
+
 
 def test_rectangular_pixel_region_bbox():
     # odd sizes


### PR DESCRIPTION
This PR is a follow-up to #269 - I did implement the suggestion from https://github.com/astropy/regions/pull/269#issuecomment-501575413 and put `copy` in the base class. I'm not sure if that's good - comments welcome!

This PR also adds PixCoord and pixel region rotate methods, as I mentioned in #265 .

I'll continue a bit and add copy and rotate for a few more regions here.

@astrofrog @keflavich @registerrier or anyone - please review.

