### PR TITLE
Simplify annulus regions?

### DIFF
--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -78,32 +78,6 @@ class OneDPix(RegionAttr):
                              .format(self._name))
 
 
-class AnnulusCenterPix(object):
-    """
-    This descriptor class is for the ``center`` of an
-    ``annulus`` `~regions.PixelRegion`. It takes a scalar
-    `~regions.PixCoord` object. It also makes sure that ``region1`` and
-    ``region2`` are in sync in case of an update.
-    """
-
-    def __get__(self, instance, owner):
-        if instance is None:
-            return self
-        reg1 = getattr(instance, 'region1')
-        return getattr(reg1, 'center')
-
-    def __set__(self, instance, value):
-
-        reg1 = getattr(instance, 'region1')
-        reg2 = getattr(instance, 'region2')
-
-        if isinstance(value, PixCoord) and value.isscalar:
-            setattr(reg1, 'center', value)
-            setattr(reg2, 'center', value)
-        else:
-            raise ValueError('The center must be a 0D PixCoord object')
-
-
 class ScalarLength(RegionAttr):
     """
     Descriptor class for `~regions.PixelRegion` which takes a scalar
@@ -114,72 +88,6 @@ class ScalarLength(RegionAttr):
         if not np.isscalar(value):
             raise ValueError(
                 'The {} must be a scalar numpy/python number'.format(self._name))
-
-
-class AnnulusInnerScalarLength(object):
-    """
-    This descriptor class is for an inner length of an
-    ``annulus`` `~regions.PixelRegion`. It takes a scalar
-    python/numpy number and makes sure that it is less than the outer
-    length of the annulus.
-    """
-
-    def __init__(self, name):
-        self._name = name
-
-    def __get__(self, instance, owner):
-        if instance is None:
-            return self
-        reg1 = getattr(instance, 'region1')
-        return getattr(reg1, self._name)
-
-    def __set__(self, instance, value):
-        reg1 = getattr(instance, 'region1')
-        reg2 = getattr(instance, 'region2')
-
-        if np.isscalar(value):
-            if getattr(reg2, self._name) < value:
-                raise ValueError("The inner {0} must be less than the outer {0}"
-                                .format(self._name)
-                             )
-            else:
-                setattr(reg1, self._name, value)
-        else:
-            raise ValueError('The inner {} must be a scalar numpy/python number'
-                             .format(self._name))
-
-
-class AnnulusOuterScalarLength(object):
-    """
-    This descriptor class is for an outer length of an
-    ``annulus`` `~regions.PixelRegion`. It takes a scalar
-    python/numpy number and makes sure that it is greater than the inner
-    length of the annulus.
-    """
-
-    def __init__(self, name):
-        self._name = name
-
-    def __get__(self, instance, owner):
-        if instance is None:
-            return self
-        reg2 = getattr(instance, 'region2')
-        return getattr(reg2, self._name)
-
-    def __set__(self, instance, value):
-        reg1 = getattr(instance, 'region1')
-        reg2 = getattr(instance, 'region2')
-
-        if np.isscalar(value):
-            if getattr(reg1, self._name) > value:
-                raise ValueError("The outer {0} must be greater than the outer"
-                                 " {0}".format(self._name)
-                                 )
-            else:
-                setattr(reg2, self._name, value)
-        else:
-            raise ValueError('The outer {} must be a scalar numpy/python number'
-                             .format(self._name))
 
 
 class ScalarSky(RegionAttr):
@@ -206,32 +114,6 @@ class OneDSky(RegionAttr):
                              format(self._name))
 
 
-class AnnulusCenterSky(object):
-    """
-    This descriptor class is for the ``center`` of an
-    ``annulus`` `~regions.SkyRegion`. It takes a scalar
-    `~astropy.coordinates.SkyCoord` object. It also makes sure that ``region1``
-    and ``region2`` are in sync in case of an update.
-    """
-
-    def __get__(self, instance, owner):
-        if instance is None:
-            return self
-        reg1 = getattr(instance, 'region1')
-        return getattr(reg1, 'center')
-
-    def __set__(self, instance, value):
-
-        reg1 = getattr(instance, 'region1')
-        reg2 = getattr(instance, 'region2')
-
-        if isinstance(value, SkyCoord) and value.isscalar:
-            setattr(reg1, 'center', value)
-            setattr(reg2, 'center', value)
-        else:
-            raise ValueError('The center must be a 0D SkyCoord object')
-
-
 class QuantityLength(RegionAttr):
     """
     Descriptor class for `~regions.SkyRegion`  which takes a scalar
@@ -242,96 +124,6 @@ class QuantityLength(RegionAttr):
         if not(isinstance(value, Quantity) and value.isscalar):
             raise ValueError('The {} must be a scalar astropy Quantity object'
                              .format(self._name))
-
-
-class AnnulusInnerQuantityLength(object):
-    """
-    This descriptor class is for an inner length of an ``annulus``
-    `~regions.SkyRegion`. It takes a scalar `astropy.units.Quantity` object and
-    makes sure that it is less than the outer length of the annulus.
-    """
-
-    def __init__(self, name):
-        self._name = name
-
-    def __get__(self, instance, owner):
-        if instance is None:
-            return self
-        reg1 = getattr(instance, 'region1')
-        return getattr(reg1, self._name)
-
-    def __set__(self, instance, value):
-        reg1 = getattr(instance, 'region1')
-        reg2 = getattr(instance, 'region2')
-
-        if isinstance(value, Quantity) and value.isscalar:
-            if getattr(reg2, self._name) < value:
-                raise ValueError("The inner {0} must be less than the outer {0}"
-                                 .format(self._name)
-                                 )
-            else:
-                setattr(reg1, self._name, value)
-        else:
-            raise ValueError('The inner {} must be a scalar astropy Quantity '
-                             'object'.format(self._name))
-
-
-class AnnulusOuterQuantityLength(object):
-    """
-    This descriptor class is for an outer length of an ``annulus``
-    `~regions.SkyRegion`. It takes a scalar `astropy.units.Quantity` object
-    and makes sure that it is less than the inner length of the annulus.
-    """
-
-    def __init__(self, name):
-        self._name = name
-
-    def __get__(self, instance, owner):
-        if instance is None:
-            return self
-        reg2 = getattr(instance, 'region2')
-        return getattr(reg2, self._name)
-
-    def __set__(self, instance, value):
-        reg1 = getattr(instance, 'region1')
-        reg2 = getattr(instance, 'region2')
-
-        if isinstance(value, Quantity) and value.isscalar:
-            if getattr(reg1, self._name) > value:
-                raise ValueError("The inner {0} must be less than the outer {0}"
-                                 .format(self._name)
-                                 )
-            else:
-                setattr(reg2, self._name, value)
-        else:
-            raise ValueError('The outer {} must be a scalar astropy Quantity '
-                             'object'.format(self._name))
-
-
-class AnnulusAngle(object):
-    """
-    This descriptor class is for the ``center`` of an ``annulus``
-    `~regions.SkyRegion`. It takes a scalar `~astropy.units.Quantity` object.
-    It also makes sure that ``region1`` and ``region2`` are in sync in case of
-    an update.
-    """
-
-    def __get__(self, instance, owner):
-        if instance is None:
-            return self
-        reg1 = getattr(instance, 'region1')
-        return getattr(reg1, 'angle')
-
-    def __set__(self, instance, value):
-
-        reg1 = getattr(instance, 'region1')
-        reg2 = getattr(instance, 'region2')
-
-        if isinstance(value, Quantity) and value.isscalar:
-            setattr(reg1, 'angle', value)
-            setattr(reg2, 'angle', value)
-        else:
-            raise ValueError('The angle must be a scalar astropy quantity object')
 
 
 class CompoundRegionPix(RegionAttr):

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -16,7 +16,7 @@ from regions.core.attributes import ScalarPix, ScalarLength
 from regions.core.attributes import ScalarSky
 from .._utils.wcs_helpers import skycoord_to_pixel_scale_angle
 from ..core import PixelRegion, SkyRegion, PixCoord
-from ..shapes.circle import CirclePixelRegion, CircleSkyRegion
+from ..shapes.circle import CirclePixelRegion
 from ..shapes.ellipse import EllipsePixelRegion, EllipseSkyRegion
 from ..shapes.rectangle import RectanglePixelRegion, RectangleSkyRegion
 
@@ -174,17 +174,9 @@ class CircleAnnulusSkyRegion(SkyRegion):
 
 @six.add_metaclass(abc.ABCMeta)
 class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
-    """
-    An asymmetrical annulus in pixel coordinates.
+    """Helper class for asymmetric annuli sky regions.
 
-    region1 : `~regions.PixelRegion` object
-        The inner asymmetric region
-    region2 : `~regions.PixelRegion` object
-        The outer asymmetric region
-    meta : `~regions.RegionMeta` object, optional
-        A dictionary which stores the meta attributes of this region.
-    visual : `~regions.RegionVisual` object, optional
-        A dictionary which stores the visual meta attributes of this region.
+    Used for ellipse and rectangle annuli below.
     """
 
     center = ScalarPix("center")
@@ -258,19 +250,9 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
 
 @six.add_metaclass(abc.ABCMeta)
 class AsymmetricAnnulusSkyRegion(SkyRegion):
-    """
-    A rectangular annulus in `~astropy.coordinates.SkyCoord` coordinates.
+    """Helper class for asymmetric annuli sky regions.
 
-    Parameters
-    ----------
-    region1 : `~regions.SkyRegion` object
-        The inner asymmetric region
-    region2 : `~regions.SkyRegion` object
-        The outer asymmetric region
-    meta : `~regions.RegionMeta` object, optional
-        A dictionary which stores the meta attributes of this region.
-    visual : `~regions.RegionVisual` object, optional
-        A dictionary which stores the visual meta attributes of this region.
+    Used for ellipse and rectangle annuli below.
     """
 
     center = ScalarSky("center")
@@ -305,28 +287,6 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
             "outer_width",
             "outer_height",
             "angle",
-        )
-
-    @property
-    def _inner_region(self):
-        return self._component_class(
-            self.center,
-            self.inner_width,
-            self.inner_height,
-            self.angle,
-            self.meta,
-            self.visual,
-        )
-
-    @property
-    def _outer_region(self):
-        return self._component_class(
-            self.center,
-            self.outer_width,
-            self.outer_height,
-            self.angle,
-            self.meta,
-            self.visual,
         )
 
     def to_pixel_args(self, wcs):

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -5,33 +5,66 @@ import operator
 import six
 import abc
 
-
 from astropy import units as u
 from astropy.wcs.utils import pixel_to_skycoord
 
+from regions import CompoundPixelRegion
+from regions import RegionMeta
+from regions import RegionVisual
+from regions.core.attributes import QuantityLength
+from regions.core.attributes import ScalarPix, ScalarLength
+from regions.core.attributes import ScalarSky
 from .._utils.wcs_helpers import skycoord_to_pixel_scale_angle
-from ..core import CompoundPixelRegion, CompoundSkyRegion, PixCoord
+from ..core import PixelRegion, SkyRegion, PixCoord
 from ..shapes.circle import CirclePixelRegion, CircleSkyRegion
 from ..shapes.ellipse import EllipsePixelRegion, EllipseSkyRegion
 from ..shapes.rectangle import RectanglePixelRegion, RectangleSkyRegion
-from ..core.attributes import (AnnulusCenterPix, AnnulusInnerScalarLength,
-                         AnnulusOuterScalarLength, AnnulusCenterSky,
-                         AnnulusInnerQuantityLength, AnnulusOuterQuantityLength,
-                         AnnulusAngle)
 
-__all__ = ['CircleAnnulusPixelRegion', 'CircleAnnulusSkyRegion',
-           'EllipseAnnulusPixelRegion', 'EllipseAnnulusSkyRegion',
-           'RectangleAnnulusPixelRegion', 'RectangleAnnulusSkyRegion'
-           ]
+__all__ = [
+    "CircleAnnulusPixelRegion",
+    "CircleAnnulusSkyRegion",
+    "EllipseAnnulusPixelRegion",
+    "EllipseAnnulusSkyRegion",
+    "RectangleAnnulusPixelRegion",
+    "RectangleAnnulusSkyRegion",
+]
 
 
-class CircleAnnulusPixelRegion(CompoundPixelRegion):
+@six.add_metaclass(abc.ABCMeta)
+class AnnulusPixelRegion(PixelRegion):
+    """Annulus pixel region."""
+
+    @property
+    def _compound_region(self):
+        return CompoundPixelRegion(
+            self._inner_region, self._outer_region, operator.xor, self.meta, self.visual
+        )
+
+    @property
+    def area(self):
+        return self._outer_region.area - self._inner_region.area
+
+    @property
+    def bounding_box(self):
+        return self._outer_region.bounding_box
+
+    def contains(self, pixcoord):
+        return self._compound_region.contains(pixcoord)
+
+    def as_artist(self, origin=(0, 0), **kwargs):
+        return self._compound_region.as_artist(origin, **kwargs)
+
+    def to_mask(self, mode="center", subpixels=5):
+        return self._compound_region.to_mask(mode, subpixels)
+
+
+class CircleAnnulusPixelRegion(AnnulusPixelRegion):
     """
     A circular annulus in pixel coordinates.
 
     Parameters
     ----------
-    center : :class:`~regions.core.pixcoord.PixCoord`
+    center : `~regions.PixCoord`
         The position of the center of the annulus.
     inner_radius : `float`
         The inner radius of the annulus
@@ -65,51 +98,50 @@ class CircleAnnulusPixelRegion(CompoundPixelRegion):
         plt.xlim(-5, 20)
         plt.ylim(-5, 20)
         ax.set_aspect('equal')
-
     """
+    _component_class = CirclePixelRegion
 
-    center = AnnulusCenterPix()
-    inner_radius = AnnulusInnerScalarLength("radius")
-    outer_radius = AnnulusOuterScalarLength("radius")
+    center = ScalarPix("center")
+    inner_radius = ScalarLength("inner_radius")
+    outer_radius = ScalarLength("outer_radius")
 
     def __init__(self, center, inner_radius, outer_radius, meta=None, visual=None):
-        region1 = CirclePixelRegion(center, inner_radius)
-        region2 = CirclePixelRegion(center, outer_radius)
-        super(CircleAnnulusPixelRegion, self).__init__(region1=region1,
-                                                       region2=region2,
-                                                       operator=operator.xor,
-                                                       meta=meta,
-                                                       visual=visual)
-        self._repr_params = ('inner_radius', 'outer_radius')
+        self.center = center
+        self.inner_radius = inner_radius
+        self.outer_radius = outer_radius
+        self.meta = meta or RegionMeta()
+        self.visual = visual or RegionVisual()
+        self._repr_params = ("inner_radius", "outer_radius")
 
     @property
-    def area(self):
-        return self.region2.area - self.region1.area
+    def _inner_region(self):
+        return self._component_class(self.center, self.inner_radius, self.meta, self.visual)
 
     @property
-    def bounding_box(self):
-        return self.region2.bounding_box
+    def _outer_region(self):
+        return self._component_class(self.center, self.outer_radius, self.meta, self.visual)
 
     def to_sky(self, wcs):
         center = pixel_to_skycoord(self.center.x, self.center.y, wcs)
         _, scale, _ = skycoord_to_pixel_scale_angle(center, wcs)
         inner_radius = self.inner_radius / scale * u.deg
         outer_radius = self.outer_radius / scale * u.deg
-        return CircleAnnulusSkyRegion(center, inner_radius, outer_radius,
-                                      self.meta, self.visual)
+        return CircleAnnulusSkyRegion(
+            center, inner_radius, outer_radius, self.meta, self.visual
+        )
 
 
-class CircleAnnulusSkyRegion(CompoundSkyRegion):
+class CircleAnnulusSkyRegion(SkyRegion):
     """
     A circular annulus in sky coordinates.
 
     Parameters
     ----------
-    center : :class:`~astropy.coordinates.SkyCoord`
+    center : `~astropy.coordinates.SkyCoord`
         The position of the center of the annulus.
-    inner_radius : :class:`~astropy.units.Quantity`
+    inner_radius : `~astropy.units.Quantity`
         The inner radius of the annulus in angular units
-    outer_radius : :class:`~astropy.units.Quantity`
+    outer_radius : `~astropy.units.Quantity`
         The outer radius of the annulus in angular units
     meta : `~regions.RegionMeta` object, optional
         A dictionary which stores the meta attributes of this region.
@@ -117,32 +149,31 @@ class CircleAnnulusSkyRegion(CompoundSkyRegion):
         A dictionary which stores the visual meta attributes of this region.
     """
 
-    center = AnnulusCenterSky()
-    inner_radius = AnnulusInnerQuantityLength("radius")
-    outer_radius = AnnulusOuterQuantityLength("radius")
+    center = ScalarSky("center")
+    inner_radius = QuantityLength("inner_radius")
+    outer_radius = QuantityLength("outer_radius")
 
     def __init__(self, center, inner_radius, outer_radius, meta=None, visual=None):
-        region1 = CircleSkyRegion(center, inner_radius)
-        region2 = CircleSkyRegion(center, outer_radius)
-        super(CircleAnnulusSkyRegion, self).__init__(region1=region1,
-                                                     operator=operator.xor,
-                                                     region2=region2,
-                                                     meta=meta,
-                                                     visual=visual)
-        self._repr_params = ('inner_radius', 'outer_radius')
+        self.center = center
+        self.inner_radius = inner_radius
+        self.outer_radius = outer_radius
+        self.meta = meta or RegionMeta()
+        self.visual = visual or RegionVisual()
+        self._repr_params = ("inner_radius", "outer_radius")
 
     def to_pixel(self, wcs):
         center, scale, _ = skycoord_to_pixel_scale_angle(self.center, wcs)
         # FIXME: The following line is needed to get a scalar PixCoord
         center = PixCoord(float(center.x), float(center.y))
-        inner_radius = self.inner_radius.to('deg').value * scale
-        outer_radius = self.outer_radius.to('deg').value * scale
-        return CircleAnnulusPixelRegion(center, inner_radius, outer_radius,
-                                        self.meta, self.visual)
+        inner_radius = self.inner_radius.to("deg").value * scale
+        outer_radius = self.outer_radius.to("deg").value * scale
+        return CircleAnnulusPixelRegion(
+            center, inner_radius, outer_radius, self.meta, self.visual
+        )
 
 
 @six.add_metaclass(abc.ABCMeta)
-class AsymmetricAnnulusPixelRegion(CompoundPixelRegion):
+class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
     """
     An asymmetrical annulus in pixel coordinates.
 
@@ -156,34 +187,63 @@ class AsymmetricAnnulusPixelRegion(CompoundPixelRegion):
         A dictionary which stores the visual meta attributes of this region.
     """
 
-    center = AnnulusCenterPix()
-    inner_width = AnnulusInnerScalarLength('width')
-    outer_width = AnnulusOuterScalarLength('width')
-    inner_height = AnnulusInnerScalarLength('height')
-    outer_height = AnnulusOuterScalarLength('height')
-    angle = AnnulusAngle()
+    center = ScalarPix("center")
+    inner_width = ScalarLength("inner_width")
+    outer_width = ScalarLength("outer_width")
+    inner_height = ScalarLength("inner_height")
+    outer_height = ScalarLength("outer_height")
+    angle = QuantityLength("angle")
 
-    def __init__(self, region1, region2, meta=None, visual=None):
-
-        super(AsymmetricAnnulusPixelRegion, self).__init__(region1=region1,
-                                                           region2=region2,
-                                                           operator=operator.xor,
-                                                           meta=meta,
-                                                           visual=visual)
-
-        self._repr_params = ('inner_width', 'inner_height',
-                             'outer_width', 'outer_height', 'angle')
+    def __init__(
+        self,
+        center,
+        inner_width,
+        outer_width,
+        inner_height,
+        outer_height,
+        angle=0 * u.deg,
+        meta=None,
+        visual=None,
+    ):
+        self.center = center
+        self.inner_width = inner_width
+        self.outer_width = outer_width
+        self.inner_height = inner_height
+        self.outer_height = outer_height
+        self.angle = angle
+        self.meta = meta or RegionMeta()
+        self.visual = visual or RegionVisual()
+        self._repr_params = (
+            "inner_width",
+            "inner_height",
+            "outer_width",
+            "outer_height",
+            "angle",
+        )
 
     @property
-    def area(self):
-        return self.region2.area - self.region1.area
+    def _inner_region(self):
+        return self._component_class(
+            self.center,
+            self.inner_width,
+            self.inner_height,
+            self.angle,
+            self.meta,
+            self.visual,
+        )
 
     @property
-    def bounding_box(self):
-        return self.region2.bounding_box
+    def _outer_region(self):
+        return self._component_class(
+            self.center,
+            self.outer_width,
+            self.outer_height,
+            self.angle,
+            self.meta,
+            self.visual,
+        )
 
     def to_sky_args(self, wcs):
-
         center = pixel_to_skycoord(self.center.x, self.center.y, wcs)
         _, scale, north_angle = skycoord_to_pixel_scale_angle(center, wcs)
 
@@ -197,7 +257,7 @@ class AsymmetricAnnulusPixelRegion(CompoundPixelRegion):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class AsymmetricAnnulusSkyRegion(CompoundSkyRegion):
+class AsymmetricAnnulusSkyRegion(SkyRegion):
     """
     A rectangular annulus in `~astropy.coordinates.SkyCoord` coordinates.
 
@@ -213,32 +273,69 @@ class AsymmetricAnnulusSkyRegion(CompoundSkyRegion):
         A dictionary which stores the visual meta attributes of this region.
     """
 
-    center = AnnulusCenterSky()
-    inner_width = AnnulusInnerQuantityLength('width')
-    outer_width = AnnulusOuterQuantityLength('width')
-    inner_height = AnnulusInnerQuantityLength('height')
-    outer_height = AnnulusOuterQuantityLength('height')
-    angle = AnnulusAngle()
+    center = ScalarSky("center")
+    inner_width = QuantityLength("inner_width")
+    outer_width = QuantityLength("outer_width")
+    inner_height = QuantityLength("inner_height")
+    outer_height = QuantityLength("outer_height")
+    angle = QuantityLength("angle")
 
-    def __init__(self, region1, region2, meta=None, visual=None):
+    def __init__(
+        self,
+        center,
+        inner_width,
+        outer_width,
+        inner_height,
+        outer_height,
+        angle=0 * u.deg,
+        meta=None,
+        visual=None,
+    ):
+        self.center = center
+        self.inner_width = inner_width
+        self.outer_width = outer_width
+        self.inner_height = inner_height
+        self.outer_height = outer_height
+        self.angle = angle
+        self.meta = meta or RegionMeta()
+        self.visual = visual or RegionVisual()
+        self._repr_params = (
+            "inner_width",
+            "inner_height",
+            "outer_width",
+            "outer_height",
+            "angle",
+        )
 
-        super(AsymmetricAnnulusSkyRegion, self).__init__(region1=region1,
-                                                         region2=region2,
-                                                         operator=operator.xor,
-                                                         meta=meta,
-                                                         visual=visual)
+    @property
+    def _inner_region(self):
+        return self._component_class(
+            self.center,
+            self.inner_width,
+            self.inner_height,
+            self.angle,
+            self.meta,
+            self.visual,
+        )
 
-        self._repr_params = ('inner_width', 'inner_height',
-                             'outer_width', 'outer_height', 'angle')
+    @property
+    def _outer_region(self):
+        return self._component_class(
+            self.center,
+            self.outer_width,
+            self.outer_height,
+            self.angle,
+            self.meta,
+            self.visual,
+        )
 
     def to_pixel_args(self, wcs):
-        center, scale, north_angle = skycoord_to_pixel_scale_angle(self.center,
-                                                                   wcs)
+        center, scale, north_angle = skycoord_to_pixel_scale_angle(self.center, wcs)
         center = PixCoord(center.x, center.y)
-        inner_width = self.inner_width.to('deg').value * scale
-        inner_height = self.inner_height.to('deg').value * scale
-        outer_width = self.outer_width.to('deg').value * scale
-        outer_height = self.outer_height.to('deg').value * scale
+        inner_width = self.inner_width.to("deg").value * scale
+        inner_height = self.inner_height.to("deg").value * scale
+        outer_width = self.outer_width.to("deg").value * scale
+        outer_height = self.outer_height.to("deg").value * scale
         angle = self.angle + (north_angle - 90 * u.deg)
 
         return center, inner_width, inner_height, outer_width, outer_height, angle
@@ -299,20 +396,12 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
         plt.ylim(-5, 20)
         ax.set_aspect('equal')
     """
-
-    def __init__(self, center, inner_width, inner_height, outer_width,
-                 outer_height, angle=0 * u.deg, meta=None, visual=None):
-        region1 = EllipsePixelRegion(center, inner_width, inner_height, angle)
-        region2 = EllipsePixelRegion(center, outer_width, outer_height, angle)
-
-        super(EllipseAnnulusPixelRegion, self).__init__(region1=region1,
-                                                        region2=region2,
-                                                        meta=meta,
-                                                        visual=visual)
+    _component_class = EllipsePixelRegion
 
     def to_sky(self, wcs):
-        return EllipseAnnulusSkyRegion(*self.to_sky_args(wcs),
-                                       meta=self.meta, visual=self.visual)
+        return EllipseAnnulusSkyRegion(
+            *self.to_sky_args(wcs), meta=self.meta, visual=self.visual
+        )
 
 
 class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
@@ -340,20 +429,12 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-
-    def __init__(self, center, inner_width, inner_height, outer_width,
-                 outer_height, angle=0 * u.deg, meta=None, visual=None):
-        region1 = EllipseSkyRegion(center, inner_width, inner_height, angle)
-        region2 = EllipseSkyRegion(center, outer_width, outer_height, angle)
-
-        super(EllipseAnnulusSkyRegion, self).__init__(region1=region1,
-                                                      region2=region2,
-                                                      meta=meta,
-                                                      visual=visual)
+    _component_class = EllipseSkyRegion
 
     def to_pixel(self, wcs):
-        return EllipseAnnulusPixelRegion(*self.to_pixel_args(wcs),
-                                         meta=self.meta, visual=self.visual)
+        return EllipseAnnulusPixelRegion(
+            *self.to_pixel_args(wcs), meta=self.meta, visual=self.visual
+        )
 
 
 class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
@@ -411,18 +492,12 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
         plt.ylim(-5, 20)
         ax.set_aspect('equal')
     """
-
-    def __init__(self, center, inner_width, inner_height, outer_width,
-                 outer_height, angle=0 * u.deg, meta=None, visual=None):
-        region1 = RectanglePixelRegion(center, inner_width, inner_height, angle)
-        region2 = RectanglePixelRegion(center, outer_width, outer_height, angle)
-
-        super(RectangleAnnulusPixelRegion, self).__init__(
-            region1=region1, region2=region2, meta=meta, visual=visual)
+    _component_class = RectanglePixelRegion
 
     def to_sky(self, wcs):
-        return RectangleAnnulusSkyRegion(*self.to_sky_args(wcs),
-                                         meta=self.meta, visual=self.visual)
+        return RectangleAnnulusSkyRegion(
+            *self.to_sky_args(wcs), meta=self.meta, visual=self.visual
+        )
 
 
 class RectangleAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
@@ -450,15 +525,9 @@ class RectangleAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-
-    def __init__(self, center, inner_width, inner_height, outer_width,
-                 outer_height, angle=0 * u.deg, meta=None, visual=None):
-        region1 = RectangleSkyRegion(center, inner_width, inner_height, angle)
-        region2 = RectangleSkyRegion(center, outer_width, outer_height, angle)
-
-        super(RectangleAnnulusSkyRegion, self).__init__(
-            region1=region1, region2=region2, meta=meta, visual=visual)
+    _component_class = RectangleSkyRegion
 
     def to_pixel(self, wcs):
-        return RectangleAnnulusPixelRegion(*self.to_pixel_args(wcs),
-                                           meta=self.meta, visual=self.visual)
+        return RectangleAnnulusPixelRegion(
+            *self.to_pixel_args(wcs), meta=self.meta, visual=self.visual
+        )

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -138,7 +138,7 @@ def test_attribute_validation_pixel_regions(region):
             for val in invalid_values.get(attr, None):
                 with pytest.raises(ValueError) as err:
                     setattr(region, attr, val)
-                assert 'The {} must be'.format(attr.replace('_', ' ')) in str(err)
+                assert 'The {} must be'.format(attr) in str(err)
 
 
 @pytest.mark.parametrize('region', SKY_REGIONS, ids=ids_func)
@@ -169,4 +169,4 @@ def test_attribute_validation_sky_regions(region):
             for val in invalid_values.get(attr, None):
                 with pytest.raises(ValueError) as err:
                     setattr(region, attr, val)
-                assert 'The {} must be'.format(attr.replace('_', ' ')) in str(err)
+                assert 'The {} must be'.format(attr) in str(err)


### PR DESCRIPTION
While working on the region copy methods in #269 I noticed that all "annulus" regions (see [here](https://astropy-regions.readthedocs.io/en/latest/shapes.html)) are implemented in a complex way and I was wondering if we should change the implementations.

E.g. [RectangleAnnulusPixelRegion](https://astropy-regions.readthedocs.io/en/v0.3/_modules/regions/shapes/annulus.html#RectangleAnnulusPixelRegion) creates `region1` and `region2` in `__init__` and then `AsymmetricAnnulusPixelRegion` is involved which has class-level variables like
```
inner_width = AnnulusInnerScalarLength('width')
```
which is a descriptor which reaches back via `getattr(instance, 'region1')` to find the number:
https://github.com/astropy/regions/blob/d1a6dd34def9442133065041974b2e33cafaf1cf/regions/core/attributes.py#L119-L149

It looks like this "annulus region = (outer region) xor (inner region)" suggestion came from
https://github.com/astropy/regions/pull/28#issuecomment-223495505 and then was introduced in #128 and later got more complicated when descriptors for validation were introduced and e.g. `AnnulusInnerScalarLength` was added.

I feel like what we have now is very complicated for no good reason, and we should change to something simple similar to [photutils.RectangularAnnulus](https://photutils.readthedocs.io/en/stable/api/photutils.RectangularAnnulus.html) where the numbers are simply stored in `__init__`. This would allow us to delete complex code like the `AnnulusInnerScalarLength` class completely. `contains` or `as_artist` could still use `outer - inner` implementation e.g. to avoid code duplication.

@keflavich @larrybradley - Thoughts on how to best implement those regions?