### PR TITLE
Add region copy test for all regions

### DIFF
--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -56,7 +56,7 @@ class PointPixelRegion(PixelRegion):
         self.center = center
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = None
+        self._repr_params = tuple()
 
     @property
     def area(self):
@@ -136,7 +136,7 @@ class PointSkyRegion(SkyRegion):
         self.center = center
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = None
+        self._repr_params = tuple()
 
     def contains(self, skycoord, wcs):
         if self.meta.get('include', True):

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import numpy as np
+from numpy.testing import assert_allclose
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
@@ -30,13 +31,20 @@ class TestCircleAnnulusPixelRegion(BaseTestPixelRegion):
         assert_quantity_allclose(self.reg.inner_radius, 2)
         assert_quantity_allclose(self.reg.outer_radius, 3)
 
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert reg.center.xy == (3, 4)
+        assert reg.inner_radius == 2
+        assert reg.outer_radius == 3
+        assert reg.visual == {}
+        assert reg.meta == {}
+
     def test_transformation(self):
         skyannulus = self.reg.to_sky(wcs=self.wcs)
         assert isinstance(skyannulus, CircleAnnulusSkyRegion)
 
 
 class TestCircleAnnulusSkyRegion(BaseTestSkyRegion):
-
     reg = CircleAnnulusSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg), 20 * u.arcsec, 30 * u.arcsec)
     skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='icrs')
     wcs = make_simple_wcs(skycoord, 5 * u.arcsec, 20)
@@ -49,8 +57,16 @@ class TestCircleAnnulusSkyRegion(BaseTestSkyRegion):
 
     def test_init(self):
         assert_quantity_allclose(self.reg.center.ra, self.skycoord.ra)
-        assert_quantity_allclose(self.reg.inner_radius, 20*u.arcsec)
-        assert_quantity_allclose(self.reg.outer_radius, 30*u.arcsec)
+        assert_quantity_allclose(self.reg.inner_radius, 20 * u.arcsec)
+        assert_quantity_allclose(self.reg.outer_radius, 30 * u.arcsec)
+
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert_allclose(reg.center.ra.deg, 3)
+        assert_allclose(reg.inner_radius.to_value("arcsec"), 20)
+        assert_allclose(reg.outer_radius.to_value("arcsec"), 30)
+        assert reg.visual == {}
+        assert reg.meta == {}
 
     def test_contains(self):
         assert not self.reg.contains(self.skycoord, self.wcs)
@@ -71,9 +87,9 @@ class TestEllipseAnnulusPixelRegion(BaseTestPixelRegion):
     expected_repr = ('<EllipseAnnulusPixelRegion(PixCoord(x=3, y=4), '
                      'inner width=2, inner height=5, outer width=5, '
                      'outer height=8, angle=0.0 deg)>')
-    expected_str =  ('Region: EllipseAnnulusPixelRegion\ncenter: PixCoord(x=3, y=4)'
-                     '\ninner width: 2\ninner height: 5\nouter width: 5\n'
-                     'outer height: 8\nangle: 0.0 deg')
+    expected_str = ('Region: EllipseAnnulusPixelRegion\ncenter: PixCoord(x=3, y=4)'
+                    '\ninner width: 2\ninner height: 5\nouter width: 5\n'
+                    'outer height: 8\nangle: 0.0 deg')
 
     skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='icrs')
     wcs = make_simple_wcs(skycoord, 5 * u.arcsec, 20)
@@ -86,13 +102,23 @@ class TestEllipseAnnulusPixelRegion(BaseTestPixelRegion):
         assert_quantity_allclose(self.reg.outer_width, 5)
         assert_quantity_allclose(self.reg.outer_height, 8)
 
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert reg.center.xy == (3, 4)
+        assert reg.inner_width == 2
+        assert reg.inner_height == 5
+        assert reg.outer_width == 5
+        assert reg.outer_height == 8
+        assert_allclose(reg.angle.to_value("deg"), 0)
+        assert reg.visual == {}
+        assert reg.meta == {}
+
     def test_transformation(self):
         skyannulus = self.reg.to_sky(wcs=self.wcs)
         assert isinstance(skyannulus, EllipseAnnulusSkyRegion)
 
 
 class TestEllipseAnnulusSkyRegion(BaseTestSkyRegion):
-
     skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='icrs')
     reg = EllipseAnnulusSkyRegion(skycoord, 20 * u.arcsec, 50 * u.arcsec,
                                   50 * u.arcsec, 80 * u.arcsec)
@@ -109,8 +135,19 @@ class TestEllipseAnnulusSkyRegion(BaseTestSkyRegion):
 
     def test_init(self):
         assert_quantity_allclose(self.reg.center.ra, self.skycoord.ra)
-        assert_quantity_allclose(self.reg.inner_width, 20*u.arcsec)
-        assert_quantity_allclose(self.reg.inner_height, 50*u.arcsec)
+        assert_quantity_allclose(self.reg.inner_width, 20 * u.arcsec)
+        assert_quantity_allclose(self.reg.inner_height, 50 * u.arcsec)
+
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert_allclose(reg.center.ra.deg, 3)
+        assert_allclose(reg.inner_width.to_value("arcsec"), 20)
+        assert_allclose(reg.inner_height.to_value("arcsec"), 50)
+        assert_allclose(reg.outer_width.to_value("arcsec"), 50)
+        assert_allclose(reg.outer_height.to_value("arcsec"), 80)
+        assert_allclose(reg.angle.to_value("deg"), 0)
+        assert reg.visual == {}
+        assert reg.meta == {}
 
     def test_contains(self):
         assert not self.reg.contains(self.skycoord, self.wcs)
@@ -131,9 +168,9 @@ class TestRectangleAnnulusPixelRegion(BaseTestPixelRegion):
     expected_repr = ('<RectangleAnnulusPixelRegion(PixCoord(x=3, y=4), '
                      'inner width=2, inner height=5, outer width=5, '
                      'outer height=8, angle=0.0 deg)>')
-    expected_str =  ('Region: RectangleAnnulusPixelRegion\ncenter: PixCoord(x=3, y=4)'
-                     '\ninner width: 2\ninner height: 5\nouter width: 5\n'
-                     'outer height: 8\nangle: 0.0 deg')
+    expected_str = ('Region: RectangleAnnulusPixelRegion\ncenter: PixCoord(x=3, y=4)'
+                    '\ninner width: 2\ninner height: 5\nouter width: 5\n'
+                    'outer height: 8\nangle: 0.0 deg')
 
     skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='icrs')
     wcs = make_simple_wcs(skycoord, 5 * u.arcsec, 20)
@@ -146,16 +183,24 @@ class TestRectangleAnnulusPixelRegion(BaseTestPixelRegion):
         assert_quantity_allclose(self.reg.outer_width, 5)
         assert_quantity_allclose(self.reg.outer_height, 8)
 
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert_quantity_allclose(reg.center.x, 3)
+        assert_quantity_allclose(reg.center.y, 4)
+        assert_quantity_allclose(reg.inner_width, 2)
+        assert_quantity_allclose(reg.inner_height, 5)
+        assert_quantity_allclose(reg.outer_width, 5)
+        assert_quantity_allclose(reg.outer_height, 8)
+
     def test_transformation(self):
         skyannulus = self.reg.to_sky(wcs=self.wcs)
         assert isinstance(skyannulus, RectangleAnnulusSkyRegion)
 
 
 class TestRectangleAnnulusSkyRegion(BaseTestSkyRegion):
-
     skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='icrs')
     reg = RectangleAnnulusSkyRegion(skycoord, 20 * u.arcsec, 50 * u.arcsec,
-                                  50 * u.arcsec, 80 * u.arcsec)
+                                    50 * u.arcsec, 80 * u.arcsec)
     wcs = make_simple_wcs(skycoord, 5 * u.arcsec, 20)
 
     expected_repr = ('<RectangleAnnulusSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
@@ -169,8 +214,19 @@ class TestRectangleAnnulusSkyRegion(BaseTestSkyRegion):
 
     def test_init(self):
         assert_quantity_allclose(self.reg.center.ra, self.skycoord.ra)
-        assert_quantity_allclose(self.reg.inner_width, 20*u.arcsec)
-        assert_quantity_allclose(self.reg.inner_height, 50*u.arcsec)
+        assert_quantity_allclose(self.reg.inner_width, 20 * u.arcsec)
+        assert_quantity_allclose(self.reg.inner_height, 50 * u.arcsec)
+
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert_allclose(reg.center.ra.deg, 3)
+        assert_allclose(reg.inner_width.to_value("arcsec"), 20)
+        assert_allclose(reg.inner_height.to_value("arcsec"), 50)
+        assert_allclose(reg.outer_width.to_value("arcsec"), 50)
+        assert_allclose(reg.outer_height.to_value("arcsec"), 80)
+        assert_allclose(reg.angle.to_value("deg"), 0)
+        assert reg.visual == {}
+        assert reg.meta == {}
 
     def test_contains(self):
         assert not self.reg.contains(self.skycoord, self.wcs)

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -33,7 +33,8 @@ PIXEL_REGIONS = [
     PolygonPixelRegion(PixCoord([1, 4, 3], [2, 4, 4])),
     RectanglePixelRegion(PixCoord(6, 5), width=3, height=5),
     RectangleAnnulusPixelRegion(PixCoord(6, 5), 3, 6, 5, 7),
-    PointPixelRegion(PixCoord(1, 2))]
+    PointPixelRegion(PixCoord(1, 2)),
+]
 
 SKY_REGIONS = [
     CircleSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg), radius=5 * u.deg),
@@ -45,8 +46,9 @@ SKY_REGIONS = [
     PolygonSkyRegion(SkyCoord([1, 4, 3] * u.deg, [2, 4, 4] * u.deg)),
     RectangleSkyRegion(SkyCoord(6 * u.deg, 5 * u.deg), width=3 * u.deg, height=5 * u.deg),
     RectangleAnnulusSkyRegion(SkyCoord(6 * u.deg, 5 * u.deg), 3 * u.deg, 5 * u.deg,
-                       5 * u.deg, 7 * u.deg),
-    PointSkyRegion(SkyCoord(6 * u.deg, 5 * u.deg))]
+                              5 * u.deg, 7 * u.deg),
+    PointSkyRegion(SkyCoord(6 * u.deg, 5 * u.deg)),
+]
 
 MASK_MODES = ['center', 'exact', 'subpixels']
 COMMON_WCS = WCS(naxis=2)
@@ -62,7 +64,6 @@ def ids_func(arg):
 
 @pytest.mark.parametrize('region', PIXEL_REGIONS, ids=ids_func)
 def test_pix_in(region):
-    #TODO: needs to be implemented for some regions.
     PixCoord(1, 1) in region
 
 
@@ -76,7 +77,7 @@ def test_pix_area(region):
     assert not isinstance(area, u.Quantity)
 
 
-@pytest.mark.parametrize(('region'), PIXEL_REGIONS, ids=ids_func)
+@pytest.mark.parametrize('region', PIXEL_REGIONS, ids=ids_func)
 def test_pix_to_sky(region):
     try:
         sky_region = region.to_sky(COMMON_WCS)
@@ -100,9 +101,10 @@ def test_pix_to_mask(region, mode):
 def test_sky_in(region):
     region.contains(SkyCoord(1 * u.deg, 1 * u.deg, frame='icrs'), COMMON_WCS)
 
+
 @pytest.mark.parametrize('region', SKY_REGIONS, ids=ids_func)
 def test_sky_in_array(region):
-    region.contains(SkyCoord([1,2,3] * u.deg, [3,2,1] * u.deg, frame='icrs'), COMMON_WCS)
+    region.contains(SkyCoord([1, 2, 3] * u.deg, [3, 2, 1] * u.deg, frame='icrs'), COMMON_WCS)
 
 
 @pytest.mark.parametrize('region', SKY_REGIONS, ids=ids_func)
@@ -113,7 +115,6 @@ def test_sky_to_pix(region):
 
 @pytest.mark.parametrize('region', PIXEL_REGIONS, ids=ids_func)
 def test_attribute_validation_pixel_regions(region):
-
     invalid_values = dict(center=[PixCoord([1, 2], [2, 3]), 1,
                                   SkyCoord(1 * u.deg, 2 * u.deg)],
                           radius=[u.Quantity("1deg"), [1], PixCoord(1, 2)],
@@ -143,7 +144,6 @@ def test_attribute_validation_pixel_regions(region):
 
 @pytest.mark.parametrize('region', SKY_REGIONS, ids=ids_func)
 def test_attribute_validation_sky_regions(region):
-
     invalid_values = dict(center=[PixCoord([1, 2], [2, 3]), 1,
                                   SkyCoord([1 * u.deg], [2 * u.deg])],
                           radius=[u.Quantity([1 * u.deg, 5 * u.deg]),

--- a/regions/shapes/tests/test_line.py
+++ b/regions/shapes/tests/test_line.py
@@ -37,6 +37,13 @@ class TestLinePixelRegion(BaseTestPixelRegion):
     expected_repr = '<LinePixelRegion(start=PixCoord(x=3, y=4), end=PixCoord(x=4, y=4))>'
     expected_str = 'Region: LinePixelRegion\nstart: PixCoord(x=3, y=4)\nend: PixCoord(x=4, y=4)'
 
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert reg.start.xy == (3, 4)
+        assert reg.end.xy == (4, 4)
+        assert reg.visual == {}
+        assert reg.meta == {}
+
     def test_pix_sky_roundtrip(self):
         wcs = make_simple_wcs(SkyCoord(2 * u.deg, 3 * u.deg), 0.1 * u.deg, 20)
         reg_new = self.reg.to_sky(wcs).to_pixel(wcs)
@@ -63,6 +70,13 @@ class TestLineSkyRegion(BaseTestSkyRegion):
     expected_str = ('Region: LineSkyRegion\nstart: <SkyCoord (Galactic): (l, b) in deg\n'
                     '    ( 3.,  4.)>\nend: <SkyCoord (Galactic): (l, b) in deg\n'
                     '    ( 3.,  5.)>')
+
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert_allclose(reg.start.b.deg, 4)
+        assert_allclose(reg.end.b.deg, 5)
+        assert reg.visual == {}
+        assert reg.meta == {}
 
     def test_transformation(self, wcs):
         pixline = self.reg.to_pixel(wcs)

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -36,6 +36,12 @@ class TestPointPixelRegion(BaseTestPixelRegion):
     expected_repr = '<PointPixelRegion(PixCoord(x=3, y=4))>'
     expected_str = 'Region: PointPixelRegion\ncenter: PixCoord(x=3, y=4)'
 
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert reg.center.xy == (3, 4)
+        assert reg.visual == {}
+        assert reg.meta == {}
+
     def test_pix_sky_roundtrip(self):
         wcs = make_simple_wcs(SkyCoord(2 * u.deg, 3 * u.deg), 0.1 * u.deg, 20)
         reg_new = self.reg.to_sky(wcs).to_pixel(wcs)
@@ -61,6 +67,12 @@ class TestPointSkyRegion(BaseTestSkyRegion):
                      '    ( 3.,  4.)>)>')
     expected_str = ('Region: PointSkyRegion\ncenter: <SkyCoord (ICRS): '
                     '(ra, dec) in deg\n    ( 3.,  4.)>')
+
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert_allclose(reg.center.ra.deg, 3)
+        assert reg.visual == {}
+        assert reg.meta == {}
 
     def test_contains(self, wcs):
         position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)

--- a/regions/shapes/tests/test_text.py
+++ b/regions/shapes/tests/test_text.py
@@ -26,7 +26,6 @@ def wcs():
 
 
 class TestTextPixelRegion(BaseTestPixelRegion):
-
     reg = TextPixelRegion(PixCoord(3, 4), "Sample Text")
     sample_box = [-2, 8, -1, 9]
     inside = []
@@ -34,6 +33,13 @@ class TestTextPixelRegion(BaseTestPixelRegion):
     expected_area = 0
     expected_repr = '<TextPixelRegion(PixCoord(x=3, y=4), text=Sample Text)>'
     expected_str = 'Region: TextPixelRegion\ncenter: PixCoord(x=3, y=4)\ntext: Sample Text'
+
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert reg.center.xy == (3, 4)
+        assert reg.text == "Sample Text"
+        assert reg.visual == {}
+        assert reg.meta == {}
 
     def test_pix_sky_roundtrip(self):
         wcs = make_simple_wcs(SkyCoord(2 * u.deg, 3 * u.deg), 0.1 * u.deg, 20)
@@ -43,13 +49,19 @@ class TestTextPixelRegion(BaseTestPixelRegion):
 
 
 class TestTextSkyRegion(BaseTestSkyRegion):
-
     reg = TextSkyRegion(SkyCoord(3, 4, unit='deg'), "Sample Text")
 
     expected_repr = ('<TextSkyRegion(<SkyCoord (ICRS): (ra, dec) in deg\n'
-                         '    ( 3.,  4.)>, text=Sample Text)>')
+                     '    ( 3.,  4.)>, text=Sample Text)>')
     expected_str = ('Region: TextSkyRegion\ncenter: <SkyCoord (ICRS): '
                     '(ra, dec) in deg\n    ( 3.,  4.)>\ntext: Sample Text')
+
+    def test_copy(self):
+        reg = self.reg.copy()
+        assert_allclose(reg.center.ra.deg, 3)
+        assert reg.text == "Sample Text"
+        assert reg.visual == {}
+        assert reg.meta == {}
 
     def test_contains(self, wcs):
         position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)


### PR DESCRIPTION
This PR adds tests for the `copy` method for all regions.

There was one case that was broken, the point regions, but was easy to fix.

I'll merge if CI passes, I don't think there's anything controversial here.
(but comments welcome any time, we can always improve more)