### PR TITLE
Simplify property validation and add compound copy

### DIFF
--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -28,6 +28,8 @@ class RegionAttr(object):
         self.name = name
 
     def __get__(self, instance, owner):
+        if instance is None:
+            return self
         return instance.__dict__[self.name]
 
     def __set__(self, instance, value):

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -23,34 +23,23 @@ Also, contains RegionMeta and RegionVisual classes to handle meta data of region
 
 @six.add_metaclass(abc.ABCMeta)
 class RegionAttr(object):
-    """
-    Meta descriptor class for attribute of an `~regions.Region`
-    which makes sure that it's value is valid all the time.
-    """
-
+    """Descriptor base class"""
     def __init__(self, name):
-        self._name = name
-
-        # WeakKeyDictionary has an object instance as the key
-        # and the key value pair remains until the object instance is not
-        # free from memory, thus prevents memory leak.
-        self._values = weakref.WeakKeyDictionary()
+        self.name = name
 
     def __get__(self, instance, owner):
-        if instance is None:
-            return self
-        return self._values.get(instance, None)
+        return instance.__dict__[self.name]
 
     def __set__(self, instance, value):
         self._validate(value)
-        self._values[instance] = value
+        instance.__dict__[self.name] = value
 
-    def _validate(self, value):
-        """
-        Validates the value of the attribute. Raises an exception if invalid
-        else does nothing.
-        """
-        raise NotImplementedError
+    def __delete__(self, instance):
+        del instance.__dict__[self.name]
+
+    @abc.abstractmethod
+    def _validate(self):
+        pass
 
 
 class ScalarPix(RegionAttr):
@@ -60,9 +49,9 @@ class ScalarPix(RegionAttr):
     """
 
     def _validate(self, value):
-        if not(isinstance(value, PixCoord) and value.isscalar):
+        if not (isinstance(value, PixCoord) and value.isscalar):
             raise ValueError('The {} must be a 0D PixCoord object'
-                             .format(self._name))
+                             .format(self.name))
 
 
 class OneDPix(RegionAttr):
@@ -72,10 +61,10 @@ class OneDPix(RegionAttr):
     """
 
     def _validate(self, value):
-        if not(isinstance(value, PixCoord) and not value.isscalar
-               and value.x.ndim == 1):
+        if not (isinstance(value, PixCoord) and not value.isscalar
+                and value.x.ndim == 1):
             raise ValueError('The {} must be a 1D PixCoord object'
-                             .format(self._name))
+                             .format(self.name))
 
 
 class ScalarLength(RegionAttr):
@@ -87,7 +76,7 @@ class ScalarLength(RegionAttr):
     def _validate(self, value):
         if not np.isscalar(value):
             raise ValueError(
-                'The {} must be a scalar numpy/python number'.format(self._name))
+                'The {} must be a scalar numpy/python number'.format(self.name))
 
 
 class ScalarSky(RegionAttr):
@@ -97,9 +86,9 @@ class ScalarSky(RegionAttr):
     """
 
     def _validate(self, value):
-        if not(isinstance(value, SkyCoord) and value.isscalar):
+        if not (isinstance(value, SkyCoord) and value.isscalar):
             raise ValueError('The {} must be a 0D SkyCoord object'.
-                             format(self._name))
+                             format(self.name))
 
 
 class OneDSky(RegionAttr):
@@ -109,9 +98,9 @@ class OneDSky(RegionAttr):
     """
 
     def _validate(self, value):
-        if not(isinstance(value, SkyCoord) and value.ndim == 1):
+        if not (isinstance(value, SkyCoord) and value.ndim == 1):
             raise ValueError('The {} must be a 1D SkyCoord object'.
-                             format(self._name))
+                             format(self.name))
 
 
 class QuantityLength(RegionAttr):
@@ -121,9 +110,9 @@ class QuantityLength(RegionAttr):
     """
 
     def _validate(self, value):
-        if not(isinstance(value, Quantity) and value.isscalar):
+        if not (isinstance(value, Quantity) and value.isscalar):
             raise ValueError('The {} must be a scalar astropy Quantity object'
-                             .format(self._name))
+                             .format(self.name))
 
 
 class CompoundRegionPix(RegionAttr):
@@ -135,7 +124,7 @@ class CompoundRegionPix(RegionAttr):
     def _validate(self, value):
         if not isinstance(value, PixelRegion):
             raise ValueError('The {} must be a PixelRegion object'
-                             .format(self._name))
+                             .format(self.name))
 
 
 class CompoundRegionSky(RegionAttr):
@@ -147,7 +136,7 @@ class CompoundRegionSky(RegionAttr):
     def _validate(self, value):
         if not isinstance(value, SkyRegion):
             raise ValueError('The {} must be a SkyRegion object'
-                             .format(self._name))
+                             .format(self.name))
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/regions/core/tests/test_compound.py
+++ b/regions/core/tests/test_compound.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-
+import operator
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -16,6 +16,23 @@ class TestCompoundPixel(object):
     # Two circles that overlap in one column
     c1 = CirclePixelRegion(PixCoord(5, 5), 4)
     c2 = CirclePixelRegion(PixCoord(11, 5), 4)
+
+    def test_copy(self):
+        reg = (self.c1 | self.c2).copy()
+        assert isinstance(reg, CompoundPixelRegion)
+        assert reg.operator == operator.or_
+
+        assert isinstance(reg.region1, CirclePixelRegion)
+        assert reg.region1.center.xy == (5, 5)
+        assert reg.region1.radius == 4
+        assert reg.region1.meta == {}
+        assert reg.region1.visual == {}
+
+        assert isinstance(reg.region2, CirclePixelRegion)
+        assert reg.region2.center.xy == (11, 5)
+        assert reg.region2.radius == 4
+        assert reg.region2.meta == {}
+        assert reg.region2.visual == {}
 
     def test_union(self):
         union = self.c1 | self.c2

--- a/regions/core/tests/test_compound.py
+++ b/regions/core/tests/test_compound.py
@@ -12,58 +12,60 @@ from ...core import PixCoord, CompoundPixelRegion
 from ...tests.helpers import make_simple_wcs
 
 
-def test_compound_pixel():
+class TestCompoundPixel(object):
     # Two circles that overlap in one column
-    pixcoord1 = PixCoord(5, 5)
-    c1 = CirclePixelRegion(pixcoord1, 4)
-    pixcoord2 = PixCoord(11, 5)
-    c2 = CirclePixelRegion(pixcoord2, 4)
+    c1 = CirclePixelRegion(PixCoord(5, 5), 4)
+    c2 = CirclePixelRegion(PixCoord(11, 5), 4)
 
-    union = c1 | c2
-    assert isinstance(union, CompoundPixelRegion)
-    mask = union.to_mask()
-    assert_allclose(mask.data[:,7], [0, 0, 1, 1, 1, 1, 1, 0, 0])
-    assert_allclose(mask.data[:,6], [0, 1, 1, 1, 1, 1, 1, 1, 0])
+    def test_union(self):
+        union = self.c1 | self.c2
+        assert isinstance(union, CompoundPixelRegion)
+        mask = union.to_mask()
+        assert_allclose(mask.data[:, 7], [0, 0, 1, 1, 1, 1, 1, 0, 0])
+        assert_allclose(mask.data[:, 6], [0, 1, 1, 1, 1, 1, 1, 1, 0])
 
-    intersection = c1 & c2
-    mask = intersection.to_mask()
-    assert_allclose(mask.data[:,7], [0, 0, 1, 1, 1, 1, 1, 0, 0])
-    assert_allclose(mask.data[:,6], [0, 0, 0, 0, 0, 0, 0, 0, 0])
+    def test_intersection(self):
+        intersection = self.c1 & self.c2
+        mask = intersection.to_mask()
+        assert_allclose(mask.data[:, 7], [0, 0, 1, 1, 1, 1, 1, 0, 0])
+        assert_allclose(mask.data[:, 6], [0, 0, 0, 0, 0, 0, 0, 0, 0])
 
-    symdiff = c1 ^ c2
-    mask = symdiff.to_mask()
-    assert_allclose(mask.data[:,7], [0, 0, 0, 0, 0, 0, 0, 0, 0])
-    assert_allclose(mask.data[:,6], [0, 1, 1, 1, 1, 1, 1, 1, 0])
+    def test_symdiff(self):
+        symdiff = self.c1 ^ self.c2
+        mask = symdiff.to_mask()
+        assert_allclose(mask.data[:, 7], [0, 0, 0, 0, 0, 0, 0, 0, 0])
+        assert_allclose(mask.data[:, 6], [0, 1, 1, 1, 1, 1, 1, 1, 0])
 
-    # fixes #168
-    pixcoord3 = PixCoord(1, 1)
-    c3 = CirclePixelRegion(pixcoord3, 4)
-    union2 = c1 | c3
-    mask1 = union2.to_mask()
+    def test_to_mask(self):
+        # fixes #168
+        pixcoord3 = PixCoord(1, 1)
+        c3 = CirclePixelRegion(pixcoord3, 4)
+        union2 = self.c1 | c3
+        mask1 = union2.to_mask()
 
-    pixcoord4 = PixCoord(9, 9)
-    c4 = CirclePixelRegion(pixcoord4, 4)
-    union3 = c1 | c4
-    mask2 = union3.to_mask()
+        pixcoord4 = PixCoord(9, 9)
+        c4 = CirclePixelRegion(pixcoord4, 4)
+        union3 = self.c1 | c4
+        mask2 = union3.to_mask()
 
-    # mask1 and mask2 should be equal
-    assert_allclose(mask1.data, mask2.data)
+        # mask1 and mask2 should be equal
+        assert_allclose(mask1.data, mask2.data)
 
-    ref_data = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                         [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0],
-                         [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0],
-                         [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0],
-                         [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0],
-                         [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
-                         [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
-                         [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0],
-                         [0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
-                         [0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
-                         [0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
-                         [0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
-                         [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
-                        )
-    assert_allclose(mask1.data, ref_data)
+        ref_data = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0],
+                             [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0],
+                             [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0],
+                             [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0],
+                             [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+                             [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+                             [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0],
+                             [0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+                             [0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+                             [0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+                             [0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
+                            )
+        assert_allclose(mask1.data, ref_data)
 
 
 def test_compound_sky():


### PR DESCRIPTION
This PR simplifies property validation to store the data in the instance dict, basically following the standard pattern from the example here: https://docs.python.org/3.7/howto/descriptor.html#descriptor-example

This means region objects now have a `__dict__` as normal Python objects do, which IMO is very useful for debugging:
```
>>> import regions
>>> reg = regions.CirclePixelRegion(regions.PixCoord(3, 4), 5) 
>>> reg
<CirclePixelRegion(PixCoord(x=3, y=4), radius=5)>
>>> reg.__dict__
{'center': PixCoord(x=3, y=4), 'radius': 5, 'meta': {}, 'visual': {}, '_repr_params': ('radius',)}
```

This change also makes `region.copy` just work for compound regions, because it calls `copy.deepcopy` on the two components, which works for objects with a `__dict__`.

So here a test is added showing that compound region copy is working, but the code for that is unchanged.