### PR TITLE
Implement rotate method for more regions

### DIFF
--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -165,6 +165,27 @@ class CompoundPixelRegion(PixelRegion):
     def area(self):
         raise NotImplementedError
 
+    def rotate(self, center, angle):
+        """Make a rotated region.
+
+        Rotates counter-clockwise for positive ``angle``.
+
+        Parameters
+        ----------
+        center : `PixCoord`
+            Rotation center point
+        angle : `~astropy.coordinates.Angle`
+            Rotation angle
+
+        Returns
+        -------
+        region : `CompoundPixelRegion`
+            Rotated region (an independent copy)
+        """
+        region1 = self.region1.rotate(center, angle)
+        region2 = self.region2.rotate(center, angle)
+        return self.copy(region1=region1, region2=region2)
+
 
 class CompoundSkyRegion(SkyRegion):
     """

--- a/regions/core/tests/test_compound.py
+++ b/regions/core/tests/test_compound.py
@@ -34,6 +34,23 @@ class TestCompoundPixel(object):
         assert reg.region2.meta == {}
         assert reg.region2.visual == {}
 
+    def test_rotate(self):
+        reg = (self.c1 | self.c2).rotate(PixCoord(0, 0), 360 * u.deg)
+        assert isinstance(reg, CompoundPixelRegion)
+        assert reg.operator == operator.or_
+
+        assert isinstance(reg.region1, CirclePixelRegion)
+        assert_allclose(reg.region1.center.xy, (5, 5))
+        assert reg.region1.radius == 4
+        assert reg.region1.meta == {}
+        assert reg.region1.visual == {}
+
+        assert isinstance(reg.region2, CirclePixelRegion)
+        assert_allclose(reg.region2.center.xy, (11, 5))
+        assert reg.region2.radius == 4
+        assert reg.region2.meta == {}
+        assert reg.region2.visual == {}
+
     def test_union(self):
         union = self.c1 | self.c2
         assert isinstance(union, CompoundPixelRegion)

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -57,6 +57,29 @@ class AnnulusPixelRegion(PixelRegion):
     def to_mask(self, mode="center", subpixels=5):
         return self._compound_region.to_mask(mode, subpixels)
 
+    def rotate(self, center, angle):
+        """Make a rotated region.
+
+        Rotates counter-clockwise for positive ``angle``.
+
+        Parameters
+        ----------
+        center : `PixCoord`
+            Rotation center point
+        angle : `~astropy.coordinates.Angle`
+            Rotation angle
+
+        Returns
+        -------
+        region : `PixelRegion`
+            Rotated region (an independent copy)
+        """
+        changes = {}
+        changes["center"] = self.center.rotate(center, angle)
+        if hasattr(self, "angle"):
+            changes["angle"] = self.angle + angle
+        return self.copy(**changes)
+
 
 class CircleAnnulusPixelRegion(AnnulusPixelRegion):
     """
@@ -187,15 +210,15 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
     angle = QuantityLength("angle")
 
     def __init__(
-        self,
-        center,
-        inner_width,
-        outer_width,
-        inner_height,
-        outer_height,
-        angle=0 * u.deg,
-        meta=None,
-        visual=None,
+            self,
+            center,
+            inner_width,
+            outer_width,
+            inner_height,
+            outer_height,
+            angle=0 * u.deg,
+            meta=None,
+            visual=None,
     ):
         self.center = center
         self.inner_width = inner_width
@@ -263,15 +286,15 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
     angle = QuantityLength("angle")
 
     def __init__(
-        self,
-        center,
-        inner_width,
-        outer_width,
-        inner_height,
-        outer_height,
-        angle=0 * u.deg,
-        meta=None,
-        visual=None,
+            self,
+            center,
+            inner_width,
+            outer_width,
+            inner_height,
+            outer_height,
+            angle=0 * u.deg,
+            meta=None,
+            visual=None,
     ):
         self.center = center
         self.inner_width = inner_width

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -133,6 +133,27 @@ class LinePixelRegion(PixelRegion):
 
         return Arrow(x, y, dx, dy, **mpl_params)
 
+    def rotate(self, center, angle):
+        """Make a rotated region.
+
+        Rotates counter-clockwise for positive ``angle``.
+
+        Parameters
+        ----------
+        center : `PixCoord`
+            Rotation center point
+        angle : `~astropy.coordinates.Angle`
+            Rotation angle
+
+        Returns
+        -------
+        region : `LinePixelRegion`
+            Rotated region (an independent copy)
+        """
+        start = self.start.rotate(center, angle)
+        end = self.end.rotate(center, angle)
+        return self.copy(start=start, end=end)
+
 
 class LineSkyRegion(SkyRegion):
     """

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -115,6 +115,26 @@ class PointPixelRegion(PixelRegion):
 
         return point
 
+    def rotate(self, center, angle):
+        """Make a rotated region.
+
+        Rotates counter-clockwise for positive ``angle``.
+
+        Parameters
+        ----------
+        center : `PixCoord`
+            Rotation center point
+        angle : `~astropy.coordinates.Angle`
+            Rotation angle
+
+        Returns
+        -------
+        region : `PointPixelRegion`
+            Rotated region (an independent copy)
+        """
+        center = self.center.rotate(center, angle)
+        return self.copy(center=center)
+
 
 class PointSkyRegion(SkyRegion):
     """

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -43,6 +43,10 @@ class TestCircleAnnulusPixelRegion(BaseTestPixelRegion):
         skyannulus = self.reg.to_sky(wcs=self.wcs)
         assert isinstance(skyannulus, CircleAnnulusSkyRegion)
 
+    def test_rotate(self):
+        reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
+        assert_allclose(reg.center.xy, (1, 4))
+
 
 class TestCircleAnnulusSkyRegion(BaseTestSkyRegion):
     reg = CircleAnnulusSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg), 20 * u.arcsec, 30 * u.arcsec)
@@ -116,6 +120,11 @@ class TestEllipseAnnulusPixelRegion(BaseTestPixelRegion):
     def test_transformation(self):
         skyannulus = self.reg.to_sky(wcs=self.wcs)
         assert isinstance(skyannulus, EllipseAnnulusSkyRegion)
+
+    def test_rotate(self):
+        reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
+        assert_allclose(reg.center.xy, (1, 4))
+        assert_allclose(reg.angle.to_value("deg"), 90)
 
 
 class TestEllipseAnnulusSkyRegion(BaseTestSkyRegion):
@@ -195,6 +204,11 @@ class TestRectangleAnnulusPixelRegion(BaseTestPixelRegion):
     def test_transformation(self):
         skyannulus = self.reg.to_sky(wcs=self.wcs)
         assert isinstance(skyannulus, RectangleAnnulusSkyRegion)
+
+    def test_rotate(self):
+        reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
+        assert_allclose(reg.center.xy, (1, 4))
+        assert_allclose(reg.angle.to_value("deg"), 90)
 
 
 class TestRectangleAnnulusSkyRegion(BaseTestSkyRegion):

--- a/regions/shapes/tests/test_line.py
+++ b/regions/shapes/tests/test_line.py
@@ -57,6 +57,11 @@ class TestLinePixelRegion(BaseTestPixelRegion):
         patch = self.reg.as_artist()
         assert 'Arrow' in str(patch)
 
+    def test_rotate(self):
+        reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
+        assert_allclose(reg.start.xy, (1, 4))
+        assert_allclose(reg.end.xy, (1, 5))
+
 
 class TestLineSkyRegion(BaseTestSkyRegion):
 

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -58,6 +58,10 @@ class TestPointPixelRegion(BaseTestPixelRegion):
 
         assert artist.get_data() == ([2], [3])
 
+    def test_rotate(self):
+        reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
+        assert_allclose(reg.center.xy, (1, 4))
+
 
 class TestPointSkyRegion(BaseTestSkyRegion):
 

--- a/regions/shapes/tests/test_text.py
+++ b/regions/shapes/tests/test_text.py
@@ -47,6 +47,10 @@ class TestTextPixelRegion(BaseTestPixelRegion):
         assert_allclose(reg_new.center.x, self.reg.center.x)
         assert_allclose(reg_new.center.y, self.reg.center.y)
 
+    def test_rotate(self):
+        reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
+        assert_allclose(reg.center.xy, (1, 4))
+
 
 class TestTextSkyRegion(BaseTestSkyRegion):
     reg = TextSkyRegion(SkyCoord(3, 4, unit='deg'), "Sample Text")


### PR DESCRIPTION
In this PR I finish implementing #265 by adding a rotate for all pixel regions.

The only region it's missing for is compound, I'll add that in this PR now.

@keflavich @astrofrog or @larrybradley - How do you feel about adding `PixelRegion.rotate`, i.e. something to the base class?

It could be an `abc.abstractmethod`, forcing all pixel regions to implement this. For us in Gammapy where we call `rotate` on user-provided regions, that would be a good thing. I would prefer that. But it would also mean that everyone subclassing `PixelRegion` has to implement it, or put this if they don't want to:
```
def rotate(center, angle):
    raise NotImplementedError
```

I could also put a generic implementation, that works for most built-in regions, allowing us to remove lines, i.e. put it as `PixelRegion.rotate` as a non-abstract method:
```
def rotate(center, angle):
        changes = {}
        changes["center"] = self.center.rotate(center, angle)
        if hasattr(self, "angle"):
            changes["angle"] = self.angle + angle
        # could add more here: "vertices", "start", "end"
        # could also scan `self._repr_params for PixCoord and transform those
        return self.copy(**changes)
```
But I think this is bad style, to rely on region specific attributes in the base class, and to silently return the wrong thing if some pixel region is different?