### PR TITLE
Change _repr_params to _fields, including center

### DIFF
--- a/docs/crtf.rst
+++ b/docs/crtf.rst
@@ -59,5 +59,5 @@ read from a file in addition to doing the region serialisation and parsing.
     >>> write_crtf(regions, filename)
     >>> regions = read_crtf(filename)
     >>> regions
-    [<CircleSkyRegion(<SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
+    [<CircleSkyRegion(center=<SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
         (42., 43.)>, radius=3.0 deg)>]

--- a/docs/ds9.rst
+++ b/docs/ds9.rst
@@ -46,7 +46,7 @@ read from a file in addition to doing the region serialisation and parsing.
     >>> write_ds9(regions, filename)
     >>> regions = read_ds9(filename)
     >>> regions
-    [<CircleSkyRegion(<SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
+    [<CircleSkyRegion(center=<SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
         (245.347655, 24.429081)>, radius=3.0 deg)>]
 
 The ``visual`` metadata includes items used for display, e.g.:

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -29,7 +29,7 @@ class CompoundPixelRegion(PixelRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _fields = ('region1', 'region2', 'operator')
+    _params = ('region1', 'region2', 'operator')
     region1 = CompoundRegionPix('region1')
     region2 = CompoundRegionPix('region2')
 
@@ -203,7 +203,7 @@ class CompoundSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _fields = ('region1', 'region2', 'operator')
+    _params = ('region1', 'region2', 'operator')
     region1 = CompoundRegionSky('region1')
     region2 = CompoundRegionSky('region2')
 

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -29,7 +29,7 @@ class CompoundPixelRegion(PixelRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-
+    _repr_params = ('region1', 'region2', 'operator')
     region1 = CompoundRegionPix('region1')
     region2 = CompoundRegionPix('region2')
 
@@ -49,7 +49,6 @@ class CompoundPixelRegion(PixelRegion):
         else:
             self.visual = RegionVisual()
         self._operator = operator
-        self._repr_params = ('region1', 'region2', 'operator')
 
     @property
     def operator(self):
@@ -204,6 +203,7 @@ class CompoundSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
+    _repr_params = ('region1', 'region2', 'operator')
     region1 = CompoundRegionSky('region1')
     region2 = CompoundRegionSky('region2')
 
@@ -222,8 +222,6 @@ class CompoundSkyRegion(SkyRegion):
         else:
             self.visual = RegionVisual()
         self._operator = operator
-
-        self._repr_params = ('region1', 'region2', 'operator')
 
     @property
     def operator(self):

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -29,7 +29,7 @@ class CompoundPixelRegion(PixelRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ('region1', 'region2', 'operator')
+    _fields = ('region1', 'region2', 'operator')
     region1 = CompoundRegionPix('region1')
     region2 = CompoundRegionPix('region2')
 
@@ -203,7 +203,7 @@ class CompoundSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ('region1', 'region2', 'operator')
+    _fields = ('region1', 'region2', 'operator')
     region1 = CompoundRegionSky('region1')
     region2 = CompoundRegionSky('region2')
 

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -69,7 +69,7 @@ class Region(object):
 
     def copy(self, **changes):
         """Make an independent (deep) copy."""
-        fields = list(self._fields) + ["meta", "visual"]
+        fields = list(self._params) + ["meta", "visual"]
 
         for field in fields:
             if field not in changes:
@@ -79,8 +79,8 @@ class Region(object):
 
     def __repr__(self):
         params = []
-        if self._fields is not None:
-            for key in self._fields:
+        if self._params is not None:
+            for key in self._params:
                 params.append('{0}={1}'.format(key.replace("_", " "),
                                                getattr(self, key)))
         params = ', '.join(params)
@@ -89,9 +89,9 @@ class Region(object):
 
     def __str__(self):
         cls_info = [('Region', self.__class__.__name__)]
-        if self._fields is not None:
+        if self._params is not None:
             params_value = [(x.replace("_", " "), getattr(self, x))
-                            for x in self._fields]
+                            for x in self._params]
             cls_info += params_value
         fmt = ['{0}: {1}'.format(key, val) for key, val in cls_info]
 

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -69,7 +69,7 @@ class Region(object):
 
     def copy(self, **changes):
         """Make an independent (deep) copy."""
-        fields = list(self._repr_params) + ["meta", "visual"]
+        fields = list(self._fields) + ["meta", "visual"]
 
         for field in fields:
             if field not in changes:
@@ -79,8 +79,8 @@ class Region(object):
 
     def __repr__(self):
         params = []
-        if self._repr_params is not None:
-            for key in self._repr_params:
+        if self._fields is not None:
+            for key in self._fields:
                 params.append('{0}={1}'.format(key.replace("_", " "),
                                                getattr(self, key)))
         params = ', '.join(params)
@@ -89,9 +89,9 @@ class Region(object):
 
     def __str__(self):
         cls_info = [('Region', self.__class__.__name__)]
-        if self._repr_params is not None:
+        if self._fields is not None:
             params_value = [(x.replace("_", " "), getattr(self, x))
-                            for x in self._repr_params]
+                            for x in self._fields]
             cls_info += params_value
         fmt = ['{0}: {1}'.format(key, val) for key, val in cls_info]
 

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -69,13 +69,7 @@ class Region(object):
 
     def copy(self, **changes):
         """Make an independent (deep) copy."""
-        fields = []
-        if hasattr(self, "center"):
-            fields.append("center")
-        if hasattr(self, "vertices"):
-            fields.append("vertices")
-        fields.extend(self._repr_params)
-        fields.extend(["meta", "visual"])
+        fields = list(self._repr_params) + ["meta", "visual"]
 
         for field in fields:
             if field not in changes:
@@ -84,10 +78,7 @@ class Region(object):
         return self.__class__(**changes)
 
     def __repr__(self):
-        if hasattr(self, 'center'):
-            params = [repr(self.center)]
-        else:
-            params = []
+        params = []
         if self._repr_params is not None:
             for key in self._repr_params:
                 params.append('{0}={1}'.format(key.replace("_", " "),
@@ -98,8 +89,6 @@ class Region(object):
 
     def __str__(self):
         cls_info = [('Region', self.__class__.__name__)]
-        if hasattr(self, 'center'):
-            cls_info.append(('center', self.center))
         if self._repr_params is not None:
             params_value = [(x.replace("_", " "), getattr(self, x))
                             for x in self._repr_params]

--- a/regions/io/fits/read.py
+++ b/regions/io/fits/read.py
@@ -42,7 +42,7 @@ class FITSRegionParser(object):
     >>> shapes = parser.shapes
     >>> regions = shapes.to_regions()
     >>> regions[5]
-    <PointPixelRegion(PixCoord(x=341.0, y=345.0))>
+    <PointPixelRegion(center=PixCoord(x=341.0, y=345.0))>
     """
 
     valid_columns = ['X', 'Y', 'SHAPE', 'COMPONENT', 'R', 'ROTANG']

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -124,6 +124,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
     """
     _component_class = CirclePixelRegion
 
+    _repr_params = ("inner_radius", "outer_radius")
     center = ScalarPix("center")
     inner_radius = ScalarLength("inner_radius")
     outer_radius = ScalarLength("outer_radius")
@@ -134,7 +135,6 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
         self.outer_radius = outer_radius
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = ("inner_radius", "outer_radius")
 
     @property
     def _inner_region(self):
@@ -171,7 +171,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-
+    _repr_params = ("inner_radius", "outer_radius")
     center = ScalarSky("center")
     inner_radius = QuantityLength("inner_radius")
     outer_radius = QuantityLength("outer_radius")
@@ -182,7 +182,6 @@ class CircleAnnulusSkyRegion(SkyRegion):
         self.outer_radius = outer_radius
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = ("inner_radius", "outer_radius")
 
     def to_pixel(self, wcs):
         center, scale, _ = skycoord_to_pixel_scale_angle(self.center, wcs)
@@ -201,7 +200,13 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
 
     Used for ellipse and rectangle annuli below.
     """
-
+    _repr_params = (
+        "inner_width",
+        "inner_height",
+        "outer_width",
+        "outer_height",
+        "angle",
+    )
     center = ScalarPix("center")
     inner_width = ScalarLength("inner_width")
     outer_width = ScalarLength("outer_width")
@@ -228,13 +233,6 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
         self.angle = angle
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = (
-            "inner_width",
-            "inner_height",
-            "outer_width",
-            "outer_height",
-            "angle",
-        )
 
     @property
     def _inner_region(self):

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -124,7 +124,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
     """
     _component_class = CirclePixelRegion
 
-    _repr_params = ("inner_radius", "outer_radius")
+    _repr_params = ("center", "inner_radius", "outer_radius")
     center = ScalarPix("center")
     inner_radius = ScalarLength("inner_radius")
     outer_radius = ScalarLength("outer_radius")
@@ -171,7 +171,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ("inner_radius", "outer_radius")
+    _repr_params = ("center", "inner_radius", "outer_radius")
     center = ScalarSky("center")
     inner_radius = QuantityLength("inner_radius")
     outer_radius = QuantityLength("outer_radius")
@@ -201,6 +201,7 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
     Used for ellipse and rectangle annuli below.
     """
     _repr_params = (
+        "center",
         "inner_width",
         "inner_height",
         "outer_width",
@@ -303,6 +304,7 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
         self._repr_params = (
+            "center",
             "inner_width",
             "inner_height",
             "outer_width",

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -124,7 +124,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
     """
     _component_class = CirclePixelRegion
 
-    _repr_params = ("center", "inner_radius", "outer_radius")
+    _fields = ("center", "inner_radius", "outer_radius")
     center = ScalarPix("center")
     inner_radius = ScalarLength("inner_radius")
     outer_radius = ScalarLength("outer_radius")
@@ -171,7 +171,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ("center", "inner_radius", "outer_radius")
+    _fields = ("center", "inner_radius", "outer_radius")
     center = ScalarSky("center")
     inner_radius = QuantityLength("inner_radius")
     outer_radius = QuantityLength("outer_radius")
@@ -200,7 +200,7 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
 
     Used for ellipse and rectangle annuli below.
     """
-    _repr_params = (
+    _fields = (
         "center",
         "inner_width",
         "inner_height",
@@ -303,7 +303,7 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
         self.angle = angle
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = (
+        self._fields = (
             "center",
             "inner_width",
             "inner_height",

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -124,7 +124,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
     """
     _component_class = CirclePixelRegion
 
-    _fields = ("center", "inner_radius", "outer_radius")
+    _params = ("center", "inner_radius", "outer_radius")
     center = ScalarPix("center")
     inner_radius = ScalarLength("inner_radius")
     outer_radius = ScalarLength("outer_radius")
@@ -171,7 +171,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _fields = ("center", "inner_radius", "outer_radius")
+    _params = ("center", "inner_radius", "outer_radius")
     center = ScalarSky("center")
     inner_radius = QuantityLength("inner_radius")
     outer_radius = QuantityLength("outer_radius")
@@ -200,7 +200,7 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
 
     Used for ellipse and rectangle annuli below.
     """
-    _fields = (
+    _params = (
         "center",
         "inner_width",
         "inner_height",
@@ -276,7 +276,7 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
 
     Used for ellipse and rectangle annuli below.
     """
-    _fields = (
+    _params = (
         "center",
         "inner_width",
         "inner_height",

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -276,7 +276,14 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
 
     Used for ellipse and rectangle annuli below.
     """
-
+    _fields = (
+        "center",
+        "inner_width",
+        "inner_height",
+        "outer_width",
+        "outer_height",
+        "angle",
+    )
     center = ScalarSky("center")
     inner_width = QuantityLength("inner_width")
     outer_width = QuantityLength("outer_width")
@@ -303,14 +310,6 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
         self.angle = angle
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._fields = (
-            "center",
-            "inner_width",
-            "inner_height",
-            "outer_width",
-            "outer_height",
-            "angle",
-        )
 
     def to_pixel_args(self, wcs):
         center, scale, north_angle = skycoord_to_pixel_scale_angle(self.center, wcs)

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -53,7 +53,7 @@ class CirclePixelRegion(PixelRegion):
         plt.ylim(0, 15)
         ax.set_aspect('equal')
     """
-    _repr_params = ('radius',)
+    _repr_params = ('center', 'radius')
     center = ScalarPix('center')
     radius = ScalarLength('radius')
 
@@ -182,7 +182,7 @@ class CircleSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ('radius',)
+    _repr_params = ('center', 'radius')
     center = ScalarSky('center')
     radius = QuantityLength("radius")
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -53,7 +53,7 @@ class CirclePixelRegion(PixelRegion):
         plt.ylim(0, 15)
         ax.set_aspect('equal')
     """
-    _fields = ('center', 'radius')
+    _params = ('center', 'radius')
     center = ScalarPix('center')
     radius = ScalarLength('radius')
 
@@ -182,7 +182,7 @@ class CircleSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _fields = ('center', 'radius')
+    _params = ('center', 'radius')
     center = ScalarSky('center')
     radius = QuantityLength("radius")
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -53,7 +53,7 @@ class CirclePixelRegion(PixelRegion):
         plt.ylim(0, 15)
         ax.set_aspect('equal')
     """
-    _repr_params = ('center', 'radius')
+    _fields = ('center', 'radius')
     center = ScalarPix('center')
     radius = ScalarLength('radius')
 
@@ -182,7 +182,7 @@ class CircleSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ('center', 'radius')
+    _fields = ('center', 'radius')
     center = ScalarSky('center')
     radius = QuantityLength("radius")
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -53,7 +53,7 @@ class CirclePixelRegion(PixelRegion):
         plt.ylim(0, 15)
         ax.set_aspect('equal')
     """
-
+    _repr_params = ('radius',)
     center = ScalarPix('center')
     radius = ScalarLength('radius')
 
@@ -62,7 +62,6 @@ class CirclePixelRegion(PixelRegion):
         self.radius = radius
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = ('radius',)
 
     @property
     def area(self):
@@ -183,7 +182,7 @@ class CircleSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-
+    _repr_params = ('radius',)
     center = ScalarSky('center')
     radius = QuantityLength("radius")
 
@@ -192,7 +191,6 @@ class CircleSkyRegion(SkyRegion):
         self.radius = radius
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = ('radius',)
 
     def to_pixel(self, wcs):
         center, scale, _ = skycoord_to_pixel_scale_angle(self.center, wcs)

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -63,7 +63,7 @@ class EllipsePixelRegion(PixelRegion):
         ax.add_patch(patch)
 
     """
-    _repr_params = ('width', 'height', 'angle')
+    _repr_params = ('center', 'width', 'height', 'angle')
     center = ScalarPix('center')
     width = ScalarLength('width')
     height = ScalarLength('height')
@@ -254,7 +254,7 @@ class EllipseSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ('width', 'height', 'angle')
+    _repr_params = ('center', 'width', 'height', 'angle')
     center = ScalarSky('center')
     width = QuantityLength('width')
     height = QuantityLength('height')

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -63,7 +63,7 @@ class EllipsePixelRegion(PixelRegion):
         ax.add_patch(patch)
 
     """
-
+    _repr_params = ('width', 'height', 'angle')
     center = ScalarPix('center')
     width = ScalarLength('width')
     height = ScalarLength('height')
@@ -77,7 +77,6 @@ class EllipsePixelRegion(PixelRegion):
         self.angle = angle
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = ('width', 'height', 'angle')
 
     @property
     def area(self):
@@ -255,7 +254,7 @@ class EllipseSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-
+    _repr_params = ('width', 'height', 'angle')
     center = ScalarSky('center')
     width = QuantityLength('width')
     height = QuantityLength('height')
@@ -268,7 +267,6 @@ class EllipseSkyRegion(SkyRegion):
         self.angle = angle
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = ('width', 'height', 'angle')
 
     def to_pixel(self, wcs):
         center, scale, north_angle = skycoord_to_pixel_scale_angle(self.center, wcs)

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -63,7 +63,7 @@ class EllipsePixelRegion(PixelRegion):
         ax.add_patch(patch)
 
     """
-    _repr_params = ('center', 'width', 'height', 'angle')
+    _fields = ('center', 'width', 'height', 'angle')
     center = ScalarPix('center')
     width = ScalarLength('width')
     height = ScalarLength('height')
@@ -254,7 +254,7 @@ class EllipseSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ('center', 'width', 'height', 'angle')
+    _fields = ('center', 'width', 'height', 'angle')
     center = ScalarSky('center')
     width = QuantityLength('width')
     height = QuantityLength('height')

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -63,7 +63,7 @@ class EllipsePixelRegion(PixelRegion):
         ax.add_patch(patch)
 
     """
-    _fields = ('center', 'width', 'height', 'angle')
+    _params = ('center', 'width', 'height', 'angle')
     center = ScalarPix('center')
     width = ScalarLength('width')
     height = ScalarLength('height')
@@ -254,7 +254,7 @@ class EllipseSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _fields = ('center', 'width', 'height', 'angle')
+    _params = ('center', 'width', 'height', 'angle')
     center = ScalarSky('center')
     width = QuantityLength('width')
     height = QuantityLength('height')

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -52,7 +52,7 @@ class LinePixelRegion(PixelRegion):
         plt.ylim(0, 30)
         ax.set_aspect('equal')
     """
-
+    _repr_params = ('start', 'end')
     start = ScalarPix('start')
     end = ScalarPix('end')
 
@@ -61,7 +61,6 @@ class LinePixelRegion(PixelRegion):
         self.end = end
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = ('start', 'end')
 
     @property
     def area(self):
@@ -170,7 +169,7 @@ class LineSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-
+    _repr_params = ('start', 'end')
     start = ScalarSky('start')
     end = ScalarSky('end')
 
@@ -179,7 +178,6 @@ class LineSkyRegion(SkyRegion):
         self.end = end
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = ('start', 'end')
 
     def contains(self, skycoord, wcs):
         if self.meta.get('include', True):

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -52,7 +52,7 @@ class LinePixelRegion(PixelRegion):
         plt.ylim(0, 30)
         ax.set_aspect('equal')
     """
-    _fields = ('start', 'end')
+    _params = ('start', 'end')
     start = ScalarPix('start')
     end = ScalarPix('end')
 
@@ -169,7 +169,7 @@ class LineSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _fields = ('start', 'end')
+    _params = ('start', 'end')
     start = ScalarSky('start')
     end = ScalarSky('end')
 

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -52,7 +52,7 @@ class LinePixelRegion(PixelRegion):
         plt.ylim(0, 30)
         ax.set_aspect('equal')
     """
-    _repr_params = ('start', 'end')
+    _fields = ('start', 'end')
     start = ScalarPix('start')
     end = ScalarPix('end')
 
@@ -169,7 +169,7 @@ class LineSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ('start', 'end')
+    _fields = ('start', 'end')
     start = ScalarSky('start')
     end = ScalarSky('end')
 

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -49,7 +49,7 @@ class PointPixelRegion(PixelRegion):
         ax.set_aspect('equal')
 
     """
-    _repr_params = tuple()
+    _repr_params = ('center',)
     center = ScalarPix('center')
 
     def __init__(self, center, meta=None, visual=None):
@@ -148,7 +148,7 @@ class PointSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = tuple()
+    _repr_params = ('center',)
     center = ScalarSky('center')
 
     def __init__(self, center, meta=None, visual=None):

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -49,14 +49,13 @@ class PointPixelRegion(PixelRegion):
         ax.set_aspect('equal')
 
     """
-
+    _repr_params = tuple()
     center = ScalarPix('center')
 
     def __init__(self, center, meta=None, visual=None):
         self.center = center
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = tuple()
 
     @property
     def area(self):
@@ -149,14 +148,13 @@ class PointSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-
+    _repr_params = tuple()
     center = ScalarSky('center')
 
     def __init__(self, center, meta=None, visual=None):
         self.center = center
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = tuple()
 
     def contains(self, skycoord, wcs):
         if self.meta.get('include', True):

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -49,7 +49,7 @@ class PointPixelRegion(PixelRegion):
         ax.set_aspect('equal')
 
     """
-    _repr_params = ('center',)
+    _fields = ('center',)
     center = ScalarPix('center')
 
     def __init__(self, center, meta=None, visual=None):
@@ -148,7 +148,7 @@ class PointSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ('center',)
+    _fields = ('center',)
     center = ScalarSky('center')
 
     def __init__(self, center, meta=None, visual=None):

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -49,7 +49,7 @@ class PointPixelRegion(PixelRegion):
         ax.set_aspect('equal')
 
     """
-    _fields = ('center',)
+    _params = ('center',)
     center = ScalarPix('center')
 
     def __init__(self, center, meta=None, visual=None):
@@ -148,7 +148,7 @@ class PointSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _fields = ('center',)
+    _params = ('center',)
     center = ScalarSky('center')
 
     def __init__(self, center, meta=None, visual=None):

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -48,14 +48,13 @@ class PolygonPixelRegion(PixelRegion):
         plt.ylim(50, 80)
         ax.set_aspect('equal')
     """
-
+    _repr_params = ('vertices',)
     vertices = OneDPix('vertices')
 
     def __init__(self, vertices, meta=None, visual=None):
         self.vertices = vertices
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = ('vertices',)
 
     @property
     def area(self):
@@ -182,14 +181,13 @@ class PolygonSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-
+    _repr_params = ('vertices',)
     vertices = OneDSky('vertices')
 
     def __init__(self, vertices, meta=None, visual=None):
         self.vertices = vertices
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
-        self._repr_params = ('vertices',)
 
     def to_pixel(self, wcs):
         x, y = skycoord_to_pixel(self.vertices, wcs)

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -48,7 +48,7 @@ class PolygonPixelRegion(PixelRegion):
         plt.ylim(50, 80)
         ax.set_aspect('equal')
     """
-    _repr_params = ('vertices',)
+    _fields = ('vertices',)
     vertices = OneDPix('vertices')
 
     def __init__(self, vertices, meta=None, visual=None):
@@ -181,7 +181,7 @@ class PolygonSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ('vertices',)
+    _fields = ('vertices',)
     vertices = OneDSky('vertices')
 
     def __init__(self, vertices, meta=None, visual=None):

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -48,7 +48,7 @@ class PolygonPixelRegion(PixelRegion):
         plt.ylim(50, 80)
         ax.set_aspect('equal')
     """
-    _fields = ('vertices',)
+    _params = ('vertices',)
     vertices = OneDPix('vertices')
 
     def __init__(self, vertices, meta=None, visual=None):
@@ -181,7 +181,7 @@ class PolygonSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _fields = ('vertices',)
+    _params = ('vertices',)
     vertices = OneDSky('vertices')
 
     def __init__(self, vertices, meta=None, visual=None):

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -62,7 +62,7 @@ class RectanglePixelRegion(PixelRegion):
         plt.ylim(0, 20)
         ax.set_aspect('equal')
     """
-
+    _repr_params = ('width', 'height', 'angle')
     center = ScalarPix('center')
     width = ScalarLength('width')
     height = ScalarLength('height')
@@ -75,7 +75,6 @@ class RectanglePixelRegion(PixelRegion):
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
-        self._repr_params = ('width', 'height', 'angle')
 
     @property
     def area(self):
@@ -282,7 +281,7 @@ class RectangleSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-
+    _repr_params = ('width', 'height', 'angle')
     center = ScalarSky('center')
     width = QuantityLength('width')
     height = QuantityLength('height')
@@ -295,7 +294,6 @@ class RectangleSkyRegion(SkyRegion):
         self.angle = angle
         self.meta = meta or {}
         self.visual = visual or {}
-        self._repr_params = ('width', 'height', 'angle')
 
     def to_pixel(self, wcs):
         center, scale, north_angle = skycoord_to_pixel_scale_angle(self.center, wcs)

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -62,7 +62,7 @@ class RectanglePixelRegion(PixelRegion):
         plt.ylim(0, 20)
         ax.set_aspect('equal')
     """
-    _repr_params = ('center', 'width', 'height', 'angle')
+    _fields = ('center', 'width', 'height', 'angle')
     center = ScalarPix('center')
     width = ScalarLength('width')
     height = ScalarLength('height')
@@ -281,7 +281,7 @@ class RectangleSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ('center', 'width', 'height', 'angle')
+    _fields = ('center', 'width', 'height', 'angle')
     center = ScalarSky('center')
     width = QuantityLength('width')
     height = QuantityLength('height')

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -62,7 +62,7 @@ class RectanglePixelRegion(PixelRegion):
         plt.ylim(0, 20)
         ax.set_aspect('equal')
     """
-    _fields = ('center', 'width', 'height', 'angle')
+    _params = ('center', 'width', 'height', 'angle')
     center = ScalarPix('center')
     width = ScalarLength('width')
     height = ScalarLength('height')
@@ -281,7 +281,7 @@ class RectangleSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _fields = ('center', 'width', 'height', 'angle')
+    _params = ('center', 'width', 'height', 'angle')
     center = ScalarSky('center')
     width = QuantityLength('width')
     height = QuantityLength('height')

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -62,7 +62,7 @@ class RectanglePixelRegion(PixelRegion):
         plt.ylim(0, 20)
         ax.set_aspect('equal')
     """
-    _repr_params = ('width', 'height', 'angle')
+    _repr_params = ('center', 'width', 'height', 'angle')
     center = ScalarPix('center')
     width = ScalarLength('width')
     height = ScalarLength('height')
@@ -281,7 +281,7 @@ class RectangleSkyRegion(SkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ('width', 'height', 'angle')
+    _repr_params = ('center', 'width', 'height', 'angle')
     center = ScalarSky('center')
     width = QuantityLength('width')
     height = QuantityLength('height')

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -19,7 +19,7 @@ class TestCircleAnnulusPixelRegion(BaseTestPixelRegion):
     inside = [(3, 2)]
     outside = [(3, 0)]
     expected_area = 5 * np.pi
-    expected_repr = '<CircleAnnulusPixelRegion(PixCoord(x=3, y=4), inner radius=2, outer radius=3)>'
+    expected_repr = '<CircleAnnulusPixelRegion(center=PixCoord(x=3, y=4), inner radius=2, outer radius=3)>'
     expected_str = 'Region: CircleAnnulusPixelRegion\ncenter: PixCoord(x=3, y=4)\ninner radius: 2\nouter radius: 3'
 
     skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='icrs')
@@ -53,7 +53,7 @@ class TestCircleAnnulusSkyRegion(BaseTestSkyRegion):
     skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='icrs')
     wcs = make_simple_wcs(skycoord, 5 * u.arcsec, 20)
 
-    expected_repr = ('<CircleAnnulusSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+    expected_repr = ('<CircleAnnulusSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in '
                      'deg\n    ( 3.,  4.)>, inner radius=20.0 arcsec, outer radius=30.0 arcsec)>')
     expected_str = ('Region: CircleAnnulusSkyRegion\ncenter: <SkyCoord (ICRS): '
                     '(ra, dec) in deg\n    ( 3.,  4.)>\ninner radius: 20.0 '
@@ -88,7 +88,7 @@ class TestEllipseAnnulusPixelRegion(BaseTestPixelRegion):
     inside = [(3, 7)]
     outside = [(3, 4)]
     expected_area = 7.5 * np.pi
-    expected_repr = ('<EllipseAnnulusPixelRegion(PixCoord(x=3, y=4), '
+    expected_repr = ('<EllipseAnnulusPixelRegion(center=PixCoord(x=3, y=4), '
                      'inner width=2, inner height=5, outer width=5, '
                      'outer height=8, angle=0.0 deg)>')
     expected_str = ('Region: EllipseAnnulusPixelRegion\ncenter: PixCoord(x=3, y=4)'
@@ -133,7 +133,7 @@ class TestEllipseAnnulusSkyRegion(BaseTestSkyRegion):
                                   50 * u.arcsec, 80 * u.arcsec)
     wcs = make_simple_wcs(skycoord, 5 * u.arcsec, 20)
 
-    expected_repr = ('<EllipseAnnulusSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+    expected_repr = ('<EllipseAnnulusSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in '
                      'deg\n    (3., 4.)>, inner width=20.0 arcsec, '
                      'inner height=50.0 arcsec, outer width=50.0 arcsec, '
                      'outer height=80.0 arcsec, angle=0.0 deg)>')
@@ -174,7 +174,7 @@ class TestRectangleAnnulusPixelRegion(BaseTestPixelRegion):
     inside = [(3, 7)]
     outside = [(3, 4)]
     expected_area = 30
-    expected_repr = ('<RectangleAnnulusPixelRegion(PixCoord(x=3, y=4), '
+    expected_repr = ('<RectangleAnnulusPixelRegion(center=PixCoord(x=3, y=4), '
                      'inner width=2, inner height=5, outer width=5, '
                      'outer height=8, angle=0.0 deg)>')
     expected_str = ('Region: RectangleAnnulusPixelRegion\ncenter: PixCoord(x=3, y=4)'
@@ -217,7 +217,7 @@ class TestRectangleAnnulusSkyRegion(BaseTestSkyRegion):
                                     50 * u.arcsec, 80 * u.arcsec)
     wcs = make_simple_wcs(skycoord, 5 * u.arcsec, 20)
 
-    expected_repr = ('<RectangleAnnulusSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+    expected_repr = ('<RectangleAnnulusSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in '
                      'deg\n    (3., 4.)>, inner width=20.0 arcsec, '
                      'inner height=50.0 arcsec, outer width=50.0 arcsec, '
                      'outer height=80.0 arcsec, angle=0.0 deg)>')

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -33,7 +33,7 @@ class TestCirclePixelRegion(BaseTestPixelRegion):
     inside = [(3, 4)]
     outside = [(3, 0)]
     expected_area = 4 * np.pi
-    expected_repr = '<CirclePixelRegion(PixCoord(x=3, y=4), radius=2)>'
+    expected_repr = '<CirclePixelRegion(center=PixCoord(x=3, y=4), radius=2)>'
     expected_str = 'Region: CirclePixelRegion\ncenter: PixCoord(x=3, y=4)\nradius: 2'
 
     def test_copy(self):
@@ -64,7 +64,7 @@ class TestCirclePixelRegion(BaseTestPixelRegion):
 class TestCircleSkyRegion(BaseTestSkyRegion):
     reg = CircleSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg), 2 * u.arcsec)
 
-    expected_repr = ('<CircleSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+    expected_repr = ('<CircleSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in '
                      'deg\n    ( 3.,  4.)>, radius=2.0 arcsec)>')
     expected_str = ('Region: CircleSkyRegion\ncenter: <SkyCoord (ICRS): '
                     '(ra, dec) in deg\n    ( 3.,  4.)>\nradius: 2.0 '

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -33,7 +33,7 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
     inside = [(4.5, 4)]
     outside = [(5, 4)]
     expected_area = 3 * np.pi
-    expected_repr = '<EllipsePixelRegion(PixCoord(x=3, y=4), width=4, height=3, angle=5.0 deg)>'
+    expected_repr = '<EllipsePixelRegion(center=PixCoord(x=3, y=4), width=4, height=3, angle=5.0 deg)>'
     expected_str = ('Region: EllipsePixelRegion\ncenter: PixCoord(x=3, y=4)\n'
                     'width: 4\nheight: 3\nangle: 5.0 deg')
 
@@ -92,7 +92,7 @@ class TestEllipseSkyRegion(BaseTestSkyRegion):
         angle=5 * u.deg,
     )
 
-    expected_repr = ('<EllipseSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+    expected_repr = ('<EllipseSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in '
                      'deg\n    ( 3.,  4.)>, width=4.0 deg, height=3.0 deg,'
                      ' angle=5.0 deg)>')
     expected_str = ('Region: EllipseSkyRegion\ncenter: <SkyCoord (ICRS): '

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -33,7 +33,7 @@ class TestPointPixelRegion(BaseTestPixelRegion):
     inside = []
     outside = [(3.1, 4.2), (5, 4)]
     expected_area = 0
-    expected_repr = '<PointPixelRegion(PixCoord(x=3, y=4))>'
+    expected_repr = '<PointPixelRegion(center=PixCoord(x=3, y=4))>'
     expected_str = 'Region: PointPixelRegion\ncenter: PixCoord(x=3, y=4)'
 
     def test_copy(self):
@@ -67,7 +67,7 @@ class TestPointSkyRegion(BaseTestSkyRegion):
 
     reg = PointSkyRegion(SkyCoord(3, 4, unit='deg'))
 
-    expected_repr = ('<PointSkyRegion(<SkyCoord (ICRS): (ra, dec) in deg\n'
+    expected_repr = ('<PointSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in deg\n'
                      '    ( 3.,  4.)>)>')
     expected_str = ('Region: PointSkyRegion\ncenter: <SkyCoord (ICRS): '
                     '(ra, dec) in deg\n    ( 3.,  4.)>')

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -63,7 +63,7 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
     inside = [(4.5, 4)]
     outside = [(5, 2.5)]
     expected_area = 12
-    expected_repr = '<RectanglePixelRegion(PixCoord(x=3, y=4), width=4, height=3, angle=5.0 deg)>'
+    expected_repr = '<RectanglePixelRegion(center=PixCoord(x=3, y=4), width=4, height=3, angle=5.0 deg)>'
     expected_str = ('Region: RectanglePixelRegion\ncenter: PixCoord(x=3, y=4)\n'
                     'width: 4\nheight: 3\nangle: 5.0 deg')
 
@@ -149,7 +149,7 @@ class TestRectangleSkyRegion(BaseTestSkyRegion):
         angle=5 * u.deg,
     )
 
-    expected_repr = ('<RectangleSkyRegion(<SkyCoord (ICRS): (ra, dec) in '
+    expected_repr = ('<RectangleSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in '
                 'deg\n    ( 3.,  4.)>, width=4.0 deg, height=3.0 '
                 'deg, angle=5.0 deg)>')
     expected_str = ('Region: RectangleSkyRegion\ncenter: <SkyCoord '

--- a/regions/shapes/tests/test_text.py
+++ b/regions/shapes/tests/test_text.py
@@ -31,7 +31,7 @@ class TestTextPixelRegion(BaseTestPixelRegion):
     inside = []
     outside = [(3.1, 4.2), (5, 4)]
     expected_area = 0
-    expected_repr = '<TextPixelRegion(PixCoord(x=3, y=4), text=Sample Text)>'
+    expected_repr = '<TextPixelRegion(center=PixCoord(x=3, y=4), text=Sample Text)>'
     expected_str = 'Region: TextPixelRegion\ncenter: PixCoord(x=3, y=4)\ntext: Sample Text'
 
     def test_copy(self):
@@ -55,7 +55,7 @@ class TestTextPixelRegion(BaseTestPixelRegion):
 class TestTextSkyRegion(BaseTestSkyRegion):
     reg = TextSkyRegion(SkyCoord(3, 4, unit='deg'), "Sample Text")
 
-    expected_repr = ('<TextSkyRegion(<SkyCoord (ICRS): (ra, dec) in deg\n'
+    expected_repr = ('<TextSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in deg\n'
                      '    ( 3.,  4.)>, text=Sample Text)>')
     expected_str = ('Region: TextSkyRegion\ncenter: <SkyCoord (ICRS): '
                     '(ra, dec) in deg\n    ( 3.,  4.)>\ntext: Sample Text')

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -46,12 +46,11 @@ class TextPixelRegion(PointPixelRegion):
         plt.ylim(2.5, 20)
         ax.set_aspect('equal')
     """
+    _repr_params = ('text',)
 
     def __init__(self, center, text, meta=None, visual=None):
-
         super(TextPixelRegion, self).__init__(center, meta, visual)
         self.text = text
-        self._repr_params = ('text',)
 
     def to_sky(self, wcs):
         center = pixel_to_skycoord(self.center.x, self.center.y, wcs=wcs)
@@ -99,11 +98,11 @@ class TextSkyRegion(PointSkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    def __init__(self, center, text, meta=None, visual=None):
+    _repr_params = ('text',)
 
+    def __init__(self, center, text, meta=None, visual=None):
         super(TextSkyRegion, self).__init__(center,  meta, visual)
         self.text = text
-        self._repr_params = ('text',)
 
     def to_pixel(self, wcs):
         center_x, center_y = skycoord_to_pixel(self.center, wcs=wcs)

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -46,7 +46,7 @@ class TextPixelRegion(PointPixelRegion):
         plt.ylim(2.5, 20)
         ax.set_aspect('equal')
     """
-    _repr_params = ('center', 'text')
+    _fields = ('center', 'text')
 
     def __init__(self, center, text, meta=None, visual=None):
         super(TextPixelRegion, self).__init__(center, meta, visual)
@@ -98,7 +98,7 @@ class TextSkyRegion(PointSkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ('center', 'text')
+    _fields = ('center', 'text')
 
     def __init__(self, center, text, meta=None, visual=None):
         super(TextSkyRegion, self).__init__(center,  meta, visual)

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -46,7 +46,7 @@ class TextPixelRegion(PointPixelRegion):
         plt.ylim(2.5, 20)
         ax.set_aspect('equal')
     """
-    _fields = ('center', 'text')
+    _params = ('center', 'text')
 
     def __init__(self, center, text, meta=None, visual=None):
         super(TextPixelRegion, self).__init__(center, meta, visual)
@@ -98,7 +98,7 @@ class TextSkyRegion(PointSkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _fields = ('center', 'text')
+    _params = ('center', 'text')
 
     def __init__(self, center, text, meta=None, visual=None):
         super(TextSkyRegion, self).__init__(center,  meta, visual)

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -46,7 +46,7 @@ class TextPixelRegion(PointPixelRegion):
         plt.ylim(2.5, 20)
         ax.set_aspect('equal')
     """
-    _repr_params = ('text',)
+    _repr_params = ('center', 'text')
 
     def __init__(self, center, text, meta=None, visual=None):
         super(TextPixelRegion, self).__init__(center, meta, visual)
@@ -98,7 +98,7 @@ class TextSkyRegion(PointSkyRegion):
     visual : `~regions.RegionVisual` object, optional
         A dictionary which stores the visual meta attributes of this region.
     """
-    _repr_params = ('text',)
+    _repr_params = ('center', 'text')
 
     def __init__(self, center, text, meta=None, visual=None):
         super(TextSkyRegion, self).__init__(center,  meta, visual)


### PR DESCRIPTION
This PR does some cleanup, following the discussion in 
 https://github.com/astropy/regions/pull/281#issuecomment-502833611

* Renames `_repr_params` to `_fields`, since it's now not just used for repr, but also copy
* Put `_fields` at the class level (before was `__init__`), right above the fields that are declared
* Add `center` to `_fields`

The last point might be a bit controversial, so here's my argument: explicit is better than implicit, and not all regions have a center (e.g. line and point and text and polygon), so before there was special code in the base class to treat those different cases, which I could now remove.

One more small change: the repr changed so that now `center=` appears. I think this is good, a repr should be explicit, it should show the attribute names. It's also more consitent now with `__str__` which already showed "center:" before.