### PR TITLE
Fix pytest.raises usage for pytest 5

### DIFF
--- a/regions/io/crtf/tests/test_crtf_language.py
+++ b/regions/io/crtf/tests/test_crtf_language.py
@@ -33,10 +33,10 @@ def test_valid_crtf_line():
     """
     line_str = 'coord=B1950_VLA, frame=BARY, corr=[I, Q], color=blue'
 
-    with pytest.raises(CRTFRegionParserError) as err:
+    with pytest.raises(CRTFRegionParserError) as excinfo:
         CRTFParser(line_str)
 
-    assert 'Not a valid CRTF line:' in str(err)
+    assert 'Not a valid CRTF line:' in str(excinfo.value)
 
 
 def test_valid_region_type():
@@ -45,10 +45,10 @@ def test_valid_region_type():
     """
     reg_str = 'hyperbola[[18h12m24s, -23d11m00s], 2.3arcsec]'
 
-    with pytest.raises(CRTFRegionParserError) as err:
+    with pytest.raises(CRTFRegionParserError) as excinfo:
         CRTFParser(reg_str)
 
-    assert "Not a valid CRTF Region type: 'hyperbola'" in str(err)
+    assert "Not a valid CRTF Region type: 'hyperbola'" in str(excinfo.value)
 
 
 def test_valid_global_meta_key():
@@ -58,10 +58,10 @@ def test_valid_global_meta_key():
 
     global_test_str = str("global label=B1950_VLA, frame=BARY, corr=[I, Q], color=blue")
 
-    with pytest.raises(CRTFRegionParserError) as err:
+    with pytest.raises(CRTFRegionParserError) as excinfo:
         CRTFParser(global_test_str)
 
-    assert "'label' is not a valid global meta key" in str(err)
+    assert "'label' is not a valid global meta key" in str(excinfo.value)
 
 
 def test_valid_meta_key():
@@ -71,10 +71,10 @@ def test_valid_meta_key():
 
     meta_test_str = str("annulus[[17h51m03.2s, -45d17m50s], [0.10deg, 4.12deg]], hello='My label here'")
 
-    with pytest.raises(CRTFRegionParserError) as err:
+    with pytest.raises(CRTFRegionParserError) as excinfo:
         CRTFParser(meta_test_str)
 
-    assert "'hello' is not a valid meta key" in str(err)
+    assert "'hello' is not a valid meta key" in str(excinfo.value)
 
 
 def test_valid_region_syntax():
@@ -84,45 +84,45 @@ def test_valid_region_syntax():
 
     reg_str1 = "circle[[18h12m24s, -23d11m00s], [2.3arcsec,4.5arcsec]"
 
-    with pytest.raises(CRTFRegionParserError) as err:
+    with pytest.raises(CRTFRegionParserError) as excinfo:
         CRTFParser(reg_str1)
 
-    assert "Not in proper format: ('2.3arcsec', '4.5arcsec') should be a single length" in str(err)
+    assert "Not in proper format: ('2.3arcsec', '4.5arcsec') should be a single length" in str(excinfo.value)
 
     reg_str2 = "symbol[[32.1423deg, 12.1412deg], 12deg], linewidth=2, coord=J2000, symsize=2"
 
-    with pytest.raises(CRTFRegionParserError) as err:
+    with pytest.raises(CRTFRegionParserError) as excinfo:
         CRTFParser(reg_str2)
 
-    assert "Not in proper format: '12deg' should be a symbol" in str(err)
+    assert "Not in proper format: '12deg' should be a symbol" in str(excinfo.value)
 
     reg_str3 = "circle[[18h12m24s, -23d11m00s]"
 
-    with pytest.raises(CRTFRegionParserError) as err:
+    with pytest.raises(CRTFRegionParserError) as excinfo:
         CRTFParser(reg_str3)
 
-    assert "Does not contain expected number of parameters for the region 'circle'" in str(err)
+    assert "Does not contain expected number of parameters for the region 'circle'" in str(excinfo.value)
 
     reg_str4 = "poly[[1, 2], [3,4], [5, 6]]"
 
-    with pytest.raises(CRTFRegionParserError) as err:
+    with pytest.raises(CRTFRegionParserError) as excinfo:
         CRTFParser(reg_str4)
 
-    assert "polygon should have > 4 coordinates" in str(err)
+    assert "polygon should have > 4 coordinates" in str(excinfo.value)
 
     reg_str5 = "poly[[1, 2], [3,4], [5, 6],[1,6]]"
 
-    with pytest.raises(CRTFRegionParserError) as err:
+    with pytest.raises(CRTFRegionParserError) as excinfo:
         CRTFParser(reg_str5)
 
-    assert "In polygon, the last and first coordinates should be same" in str(err)
+    assert "In polygon, the last and first coordinates should be same" in str(excinfo.value)
 
     reg_str6 = "rotbox[[12h01m34.1s, 12d23m33s], [3arcmin,], 12deg]"
 
-    with pytest.raises(CRTFRegionParserError) as err:
+    with pytest.raises(CRTFRegionParserError) as excinfo:
         CRTFParser(reg_str6)
 
-    assert "('3arcmin', '') should be a pair of length" in str(err)
+    assert "('3arcmin', '') should be a pair of length" in str(excinfo.value)
 
 
 @pytest.mark.parametrize('filename', ['data/CRTFgeneral.crtf', 'data/CRTFgeneraloutput.crtf'])

--- a/regions/io/fits/tests/test_fits_region.py
+++ b/regions/io/fits/tests/test_fits_region.py
@@ -76,20 +76,20 @@ def test_only_pixel_regions():
 
     reg_sky = CircleSkyRegion(SkyCoord(1, 2, unit='deg'), 5 * u.deg)
 
-    with pytest.raises(TypeError) as err:
+    with pytest.raises(TypeError) as excinfo:
         fits_region_objects_to_table([reg_sky])
 
-    assert 'Every region must be a pixel region' in str(err)
+    assert 'Every region must be a pixel region' in str(excinfo.value)
 
 
 def test_valid_columns():
 
     t = Table([[1, 2, 3]], names=('a'))
 
-    with pytest.raises(FITSRegionParserError) as err:
+    with pytest.raises(FITSRegionParserError) as excinfo:
         FITSRegionParser(t)
 
-    assert "This table has an invalid column name: 'a'" in str(err)
+    assert "This table has an invalid column name: 'a'" in str(excinfo.value)
 
 
 def test_valid_row():
@@ -101,23 +101,23 @@ def test_valid_row():
     t['X'].unit = 'pix'
     t['Y'].unit = 'pix'
 
-    with pytest.raises(FITSRegionParserError) as err:
+    with pytest.raises(FITSRegionParserError) as excinfo:
         FITSRegionParser(t)
 
-    assert "The column: 'R' is missing in the table" in str(err)
+    assert "The column: 'R' is missing in the table" in str(excinfo.value)
 
     t[0]['SHAPE'] = 'PONT'
 
-    with pytest.raises(FITSRegionParserError) as err:
+    with pytest.raises(FITSRegionParserError) as excinfo:
         FITSRegionParser(t)
 
-    assert "'PONT' is not a valid FITS Region type" in str(err)
+    assert "'PONT' is not a valid FITS Region type" in str(excinfo.value)
 
     t['ROTANG'] = [[20, 30]]
     t['ROTANG'].unit = 'deg'
     t[0]['SHAPE'] = 'PIE'
 
-    with pytest.raises(FITSRegionParserError) as err:
+    with pytest.raises(FITSRegionParserError) as excinfo:
         FITSRegionParser(t)
 
-    assert "'PIE' is currently not supported in regions" in str(err)
+    assert "'PIE' is currently not supported in regions" in str(excinfo.value)

--- a/regions/io/tests/test_shape_object.py
+++ b/regions/io/tests/test_shape_object.py
@@ -68,16 +68,16 @@ def test_valid_shape():
 
     shape = CRTFParser(reg_str).shapes[0]
 
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError) as excinfo:
         shape.region_type = 'box'
 
-    assert "'box' is not a valid region type in this package" in str(err)
+    assert "'box' is not a valid region type in this package" in str(excinfo.value)
 
     shape = CRTFParser(reg_str).shapes[0]
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError) as excinfo:
         shape.coordsys = 'hello'
 
-    assert "'hello' is not a valid coordinate reference frame in astropy" in str(err)
+    assert "'hello' is not a valid coordinate reference frame in astropy" in str(excinfo.value)
 
 
 def test_valid_ellipse_ds9():

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -137,9 +137,9 @@ def test_attribute_validation_pixel_regions(region):
     for attr in invalid_values:
         if hasattr(region, attr):
             for val in invalid_values.get(attr, None):
-                with pytest.raises(ValueError) as err:
+                with pytest.raises(ValueError) as excinfo:
                     setattr(region, attr, val)
-                assert 'The {} must be'.format(attr) in str(err)
+                assert 'The {} must be'.format(attr) in str(excinfo.value)
 
 
 @pytest.mark.parametrize('region', SKY_REGIONS, ids=ids_func)
@@ -167,6 +167,6 @@ def test_attribute_validation_sky_regions(region):
     for attr in invalid_values:
         if hasattr(region, attr):
             for val in invalid_values.get(attr, None):
-                with pytest.raises(ValueError) as err:
+                with pytest.raises(ValueError) as excinfo:
                     setattr(region, attr, val)
-                assert 'The {} must be'.format(attr) in str(err)
+                assert 'The {} must be'.format(attr) in str(excinfo.value)

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -96,9 +96,9 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
     def test_dimension_center(self):
         center = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
         radius = 2 * u.arcsec
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueError) as excinfo:
             CircleSkyRegion(center, radius)
-        assert 'The center must be a 0D SkyCoord object' in str(err)
+        assert 'The center must be a 0D SkyCoord object' in str(excinfo.value)
 
     def test_contains(self, wcs):
         position = SkyCoord([1, 3] * u.deg, [2, 4] * u.deg)

--- a/regions/shapes/tests/test_common.py
+++ b/regions/shapes/tests/test_common.py
@@ -59,9 +59,9 @@ class BaseTestPixelRegion(BaseTestRegion):
         assert_equal(actual[:len(self.inside)], True)
         assert_equal(actual[len(self.inside):], False)
 
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError) as excinfo:
             pixcoord in self.reg
-        assert 'coord must be scalar' in str(exc)
+        assert 'coord must be scalar' in str(excinfo.value)
 
     def test_contains_array_2d(self):
 

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -112,9 +112,9 @@ class TestEllipseSkyRegion(BaseTestSkyRegion):
         center = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
         width = 2 * u.arcsec
         height = 3 * u.arcsec
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(ValueError) as excinfo:
             EllipseSkyRegion(center, width, height)
-        assert 'The center must be a 0D SkyCoord object' in str(err)
+        assert 'The center must be a 0D SkyCoord object' in str(excinfo.value)
 
     def test_contains(self, wcs):
         position = SkyCoord([1, 3] * u.deg, [2, 4] * u.deg)


### PR DESCRIPTION
This PR fixes #288, i.e. the pytest.raises related fails that appeared with the pytest 5 release.

I have changed from `err` or `exc` to `expinfo` to make it clear(er) that it's an an `ExceptionInfo` object, not an `Exception` object. This is following the variable name pytest uses in its docs: https://docs.pytest.org/en/latest/assert.html#assertions-about-expected-exceptions

@bsipocz - I would suggest to revert #287 for now, and only then merge this in. Assigning to you.