### PR TITLE
Fix helpers warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ rst_epilog += """
 # -- Project information ------------------------------------------------------
 
 # This does not *have* to match the package name, but typically does
-project = setup_cfg['package_name']
+project = setup_cfg['name']
 author = setup_cfg['author']
 copyright = '{0}, {1}'.format(
     datetime.datetime.now().year, setup_cfg['author'])
@@ -85,8 +85,8 @@ copyright = '{0}, {1}'.format(
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-__import__(setup_cfg['package_name'])
-package = sys.modules[setup_cfg['package_name']]
+__import__(setup_cfg['name'])
+package = sys.modules[setup_cfg['name']]
 
 # The short X.Y version.
 version = package.__version__.split('-', 1)[0]
@@ -153,7 +153,7 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 if eval(setup_cfg.get('edit_on_github')):
     extensions += ['astropy_helpers.sphinx.ext.edit_on_github']
 
-    versionmod = __import__(setup_cfg['package_name'] + '.version')
+    versionmod = __import__(setup_cfg['name'] + '.version')
     edit_on_github_project = setup_cfg['github_project']
     if versionmod.version.release:
         edit_on_github_branch = "v" + versionmod.version.version
@@ -166,7 +166,7 @@ if eval(setup_cfg.get('edit_on_github')):
 github_issues_url = 'https://github.com/astropy/regions/issues/'
 
 plot_rcparams = {'savefig.bbox': 'tight',
-                 'savefig.facecolor':'none',
+                 'savefig.facecolor': 'none',
                  'axes.formatter.useoffset': False,
                  'xtick.labelsize': 9,
                  'ytick.labelsize': 9,

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,8 @@ doctest_plus = enabled
 auto_use = True
 
 [metadata]
-package_name = regions
+name = regions
+version = 0.5.dev
 description = Astropy affilated package for region handling
 author = Astropy developers
 license = BSD

--- a/setup.py
+++ b/setup.py
@@ -5,20 +5,19 @@ import glob
 import os
 import sys
 
-import ah_bootstrap
+import ah_bootstrap  # noqa
 from setuptools import setup
 
-#A dirty hack to get around some early import/configurations ambiguities
+# A dirty hack to get around some early import/configurations ambiguities
 if sys.version_info[0] >= 3:
     import builtins
 else:
     import __builtin__ as builtins
 builtins._ASTROPY_SETUP_ = True
 
-from astropy_helpers.setup_helpers import (register_commands, get_debug_option,
-                                           get_package_info)
-from astropy_helpers.git_helpers import get_git_devstr
-from astropy_helpers.version_helpers import generate_version_py
+from astropy_helpers.setup_helpers import register_commands, get_package_info  # noqa
+from astropy_helpers.git_helpers import get_git_devstr  # noqa
+from astropy_helpers.version_helpers import generate_version_py  # noqa
 
 # Get some values from the setup.cfg
 try:
@@ -30,7 +29,7 @@ conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 
-PACKAGENAME = metadata.get('package_name', 'packagename')
+PACKAGENAME = metadata.get('name', 'packagename')
 DESCRIPTION = metadata.get('description', 'Astropy affiliated package')
 AUTHOR = metadata.get('author', '')
 AUTHOR_EMAIL = metadata.get('author_email', '')
@@ -47,7 +46,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '0.5.dev'
+VERSION = metadata.get('version', '0.0.dev')
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION
@@ -58,11 +57,10 @@ if not RELEASE:
 # Populate the dict of setup command overrides; this should be done before
 # invoking any other functionality from distutils since it can potentially
 # modify distutils' behavior.
-cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
+cmdclassd = register_commands()
 
 # Freeze build information in version.py
-generate_version_py(PACKAGENAME, VERSION, RELEASE,
-                    get_debug_option(PACKAGENAME))
+generate_version_py()
 
 # Treat everything in scripts except README.rst as a script to be installed
 scripts = [fname for fname in glob.glob(os.path.join('scripts', '*'))
@@ -127,5 +125,4 @@ setup(name=PACKAGENAME,
       use_2to3=False,
       entry_points=entry_points,
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
-      **package_info
-)
+      **package_info)


### PR DESCRIPTION
This fixes the following warnings seen when installing from source using `python setup.py install`:

```
.../regions/astropy_helpers/astropy_helpers/setup_helpers.py:165: AstropyDeprecationWarning: The package argument to generate_version_py has been deprecated and will be removed in future. Specify the package name in setup.cfg instead
  'the package name in setup.cfg instead', AstropyDeprecationWarning)
.../regions/astropy_helpers/astropy_helpers/setup_helpers.py:170: AstropyDeprecationWarning: The version argument to generate_version_py has been deprecated and will be removed in future. Specify the version number in setup.cfg instead
  'the version number in setup.cfg instead', AstropyDeprecationWarning)
.../regions/astropy_helpers/astropy_helpers/setup_helpers.py:176: AstropyDeprecationWarning: The release argument to generate_version_py has been deprecated and will be removed in future. We now use the presence of the "dev" string in the version to determine whether this is a release
  'determine whether this is a release', AstropyDeprecationWarning)
.../regions/astropy_helpers/astropy_helpers/setup_helpers.py:190: AstropyDeprecationWarning: Specifying the package name using the "package_name" option in setup.cfg is deprecated - use the "name" option instead.
  'option instead.', AstropyDeprecationWarning)
.../regions/astropy_helpers/astropy_helpers/version_helpers.py:244: AstropyDeprecationWarning: The packagename argument to generate_version_py has been deprecated and will be removed in future. Specify the package name in setup.cfg instead
  'the package name in setup.cfg instead', AstropyDeprecationWarning)
.../regions/astropy_helpers/astropy_helpers/version_helpers.py:249: AstropyDeprecationWarning: The version argument to generate_version_py has been deprecated and will be removed in future. Specify the version number in setup.cfg instead
  'the version number in setup.cfg instead', AstropyDeprecationWarning)
.../regions/astropy_helpers/astropy_helpers/version_helpers.py:255: AstropyDeprecationWarning: The release argument to generate_version_py has been deprecated and will be removed in future. We now use the presence of the "dev" string in the version to determine whether this is a release
  'determine whether this is a release', AstropyDeprecationWarning)
.../regions/astropy_helpers/astropy_helpers/version_helpers.py:269: AstropyDeprecationWarning: Specifying the package name using the "package_name" option in setup.cfg is deprecated - use the "name" option instead.
  'option instead.', AstropyDeprecationWarning)
```