### PR TITLE
Update to Python 3.6+ and Numpy 1.16+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
 
         # Try older numpy versions
         - env: PYTHON_VERSION=3.6
-               NUMPY_VERSION=1.11
+               NUMPY_VERSION=1.16
         - env: PYTHON_VERSION=3.5
                NUMPY_VERSION=1.10
                ASTROPY_VERSION=3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,6 @@ matrix:
         # Try older numpy versions
         - env: PYTHON_VERSION=3.6
                NUMPY_VERSION=1.16
-        - env: PYTHON_VERSION=3.5
-               NUMPY_VERSION=1.10
-               ASTROPY_VERSION=3.0
 
         # Do a PEP8 test with pycodestyle
         - env: MAIN_CMD='pycodestyle regions --count' SETUP_CMD=''

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,14 +8,13 @@ Installation
 
 The regions package requires the following packages:
 
-* Python 2.7 or 3.4 and above
-* `Numpy <http://www.numpy.org>`_ 1.9 or later
-* `Astropy <http://www.astropy.org>`__ 1.3 or later
-* `six <http://pypi.python.org/pypi/six/>`__
+* Python 3.6 or later
+* `Numpy <http://www.numpy.org>`_ 1.16 or later
+* `Astropy <http://www.astropy.org>`__ 2.0 or later
 
 In addition, the following packages are needed for optional functionality:
 
-* `Matplotlib <https://matplotlib.org>`__ 1.5 or later
+* `Matplotlib <https://matplotlib.org>`__ 2.0 or later
 
 Stable version
 ==============

--- a/regions/_geometry/circular_overlap.pyx
+++ b/regions/_geometry/circular_overlap.pyx
@@ -4,10 +4,6 @@
 The functions defined here allow one to determine the exact area of
 overlap of a rectangle and a circle (written by Thomas Robitaille).
 """
-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 cimport numpy as np
 

--- a/regions/_geometry/core.pyx
+++ b/regions/_geometry/core.pyx
@@ -1,15 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # cython: language_level=3
 """The functions here are the core geometry functions."""
-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 cimport numpy as np
-
-
-__all__ = ['elliptical_overlap_grid']
 
 
 cdef extern from "math.h":

--- a/regions/_geometry/elliptical_overlap.pyx
+++ b/regions/_geometry/elliptical_overlap.pyx
@@ -7,10 +7,6 @@ The approach is to divide the rectangle into two triangles, and
 reproject these so that the ellipse is a unit circle, then compute the
 intersection of a triangle with a unit circle.
 """
-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 cimport numpy as np
 

--- a/regions/_geometry/polygonal_overlap.pyx
+++ b/regions/_geometry/polygonal_overlap.pyx
@@ -1,8 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # cython: language_level=3
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 cimport numpy as np
 

--- a/regions/_geometry/rectangular_overlap.pyx
+++ b/regions/_geometry/rectangular_overlap.pyx
@@ -1,8 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # cython: language_level=3
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 cimport numpy as np
 

--- a/regions/_geometry/tests/test_circular_overlap_grid.py
+++ b/regions/_geometry/tests/test_circular_overlap_grid.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import itertools
 
 from numpy.testing import assert_allclose

--- a/regions/_geometry/tests/test_elliptical_overlap_grid.py
+++ b/regions/_geometry/tests/test_elliptical_overlap_grid.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import itertools
 
 from numpy.testing import assert_allclose

--- a/regions/_geometry/tests/test_rectangular_overlap_grid.py
+++ b/regions/_geometry/tests/test_rectangular_overlap_grid.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import itertools
 
 from numpy.testing import assert_allclose

--- a/regions/_utils/examples.py
+++ b/regions/_utils/examples.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.utils import lazyproperty
 from astropy.io import fits

--- a/regions/_utils/examples.py
+++ b/regions/_utils/examples.py
@@ -60,10 +60,10 @@ def make_example_dataset(data='simulated', config=None):
     elif data == 'fermi':
         return ExampleDatasetFermi(config=config)
     else:
-        raise ValueError('Invalid selection data: {}'.format(data))
+        raise ValueError(f'Invalid selection data: {data}')
 
 
-class ExampleDataset(object):
+class ExampleDataset:
     """Base class for example dataset.
     """
 

--- a/regions/_utils/tests/test_examples.py
+++ b/regions/_utils/tests/test_examples.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from numpy.testing import assert_allclose
 from ..examples import make_example_dataset

--- a/regions/_utils/wcs_helpers.py
+++ b/regions/_utils/wcs_helpers.py
@@ -76,10 +76,10 @@ def assert_angle_or_pixel(name, q):
         if q.unit.physical_type == 'angle' or q.unit is u.pixel:
             pass
         else:
-            raise ValueError("{0} should have angular or pixel "
+            raise ValueError("{} should have angular or pixel "
                              "units".format(name))
     else:
-        raise TypeError("{0} should be a Quantity instance".format(name))
+        raise TypeError(f"{name} should be a Quantity instance")
 
 
 def assert_angle(name, q):
@@ -90,6 +90,6 @@ def assert_angle(name, q):
         if q.unit.physical_type == 'angle':
             pass
         else:
-            raise ValueError("{0} should have angular units".format(name))
+            raise ValueError(f"{name} should have angular units")
     else:
-        raise TypeError("{0} should be a Quantity instance".format(name))
+        raise TypeError(f"{name} should be a Quantity instance")

--- a/regions/_utils/wcs_helpers.py
+++ b/regions/_utils/wcs_helpers.py
@@ -76,8 +76,7 @@ def assert_angle_or_pixel(name, q):
         if q.unit.physical_type == 'angle' or q.unit is u.pixel:
             pass
         else:
-            raise ValueError("{} should have angular or pixel "
-                             "units".format(name))
+            raise ValueError(f"{name} should have angular or pixel units")
     else:
         raise TypeError(f"{name} should be a Quantity instance")
 

--- a/regions/_utils/wcs_helpers.py
+++ b/regions/_utils/wcs_helpers.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # (taken from photutils: should probably migrate into astropy.wcs)
-from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import UnitSphericalRepresentation

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -76,7 +76,7 @@ class ScalarLength(RegionAttr):
     def _validate(self, value):
         if not np.isscalar(value):
             raise ValueError(
-                'The {} must be a scalar numpy/python number'.format(self.name))
+                f'The {self.name} must be a scalar numpy/python number')
 
 
 class ScalarSky(RegionAttr):
@@ -143,7 +143,7 @@ class Meta(dict):
 
     def __init__(self, seq=None, **kwargs):
 
-        super(Meta, self).__init__()
+        super().__init__()
 
         if seq:
             if isinstance(seq, dict):
@@ -160,14 +160,14 @@ class Meta(dict):
     def __setitem__(self, key, value):
         key = self.key_mapping.get(key, key)
         if key in self.valid_keys:
-            super(Meta, self).__setitem__(key, value)
+            super().__setitem__(key, value)
         else:
             raise KeyError(
-                "{} is not a valid key for this class.".format(key))
+                f"{key} is not a valid key for this class.")
 
     def __getitem__(self, item):
         item = self.key_mapping.get(item, item)
-        return super(Meta, self).__getitem__(item)
+        return super().__getitem__(item)
 
 
 class RegionMeta(Meta):

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import abc
-import six
 import weakref
 
 from astropy.coordinates import SkyCoord
@@ -21,8 +20,7 @@ Also, contains RegionMeta and RegionVisual classes to handle meta data of region
 """
 
 
-@six.add_metaclass(abc.ABCMeta)
-class RegionAttr(object):
+class RegionAttr(abc.ABC):
     """Descriptor base class"""
     def __init__(self, name):
         self.name = name
@@ -141,7 +139,6 @@ class CompoundRegionSky(RegionAttr):
                              .format(self.name))
 
 
-@six.add_metaclass(abc.ABCMeta)
 class Meta(dict):
 
     def __init__(self, seq=None, **kwargs):

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import abc
-import weakref
 
 from astropy.coordinates import SkyCoord
 from astropy.units import Quantity
@@ -50,8 +49,7 @@ class ScalarPix(RegionAttr):
 
     def _validate(self, value):
         if not (isinstance(value, PixCoord) and value.isscalar):
-            raise ValueError('The {} must be a 0D PixCoord object'
-                             .format(self.name))
+            raise ValueError(f'The {self.name} must be a 0D PixCoord object')
 
 
 class OneDPix(RegionAttr):
@@ -63,8 +61,7 @@ class OneDPix(RegionAttr):
     def _validate(self, value):
         if not (isinstance(value, PixCoord) and not value.isscalar
                 and value.x.ndim == 1):
-            raise ValueError('The {} must be a 1D PixCoord object'
-                             .format(self.name))
+            raise ValueError(f'The {self.name} must be a 1D PixCoord object')
 
 
 class ScalarLength(RegionAttr):
@@ -111,8 +108,7 @@ class QuantityLength(RegionAttr):
 
     def _validate(self, value):
         if not (isinstance(value, Quantity) and value.isscalar):
-            raise ValueError('The {} must be a scalar astropy Quantity object'
-                             .format(self.name))
+            raise ValueError(f'The {self.name} must be a scalar astropy Quantity object')
 
 
 class CompoundRegionPix(RegionAttr):
@@ -123,8 +119,7 @@ class CompoundRegionPix(RegionAttr):
 
     def _validate(self, value):
         if not isinstance(value, PixelRegion):
-            raise ValueError('The {} must be a PixelRegion object'
-                             .format(self.name))
+            raise ValueError(f'The {self.name} must be a PixelRegion object')
 
 
 class CompoundRegionSky(RegionAttr):
@@ -135,8 +130,7 @@ class CompoundRegionSky(RegionAttr):
 
     def _validate(self, value):
         if not isinstance(value, SkyRegion):
-            raise ValueError('The {} must be a SkyRegion object'
-                             .format(self.name))
+            raise ValueError(f'The {self.name} must be a SkyRegion object')
 
 
 class Meta(dict):

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 from astropy.io.fits.util import _is_int
 

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -6,7 +6,7 @@ from astropy.io.fits.util import _is_int
 __all__ = ['BoundingBox']
 
 
-class BoundingBox(object):
+class BoundingBox:
     """
     A rectangular bounding box in integer (not float) pixel indices.
 

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import operator as op
 
 import numpy as np

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -1,8 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import abc
-import six
 import copy
 import operator
 import inspect
@@ -28,44 +25,8 @@ _DEFAULT_WCS_MODE = 'all'
 VALID_MASK_MODES = {'center', 'exact', 'subpixels'}
 
 
-class MetaRegion(abc.ABCMeta):
-    """
-    This is a sub metaclass of `abc.ABCMeta` that makes methods of a class
-    automatically have their docstrings filled in from the methods they override
-    in the base class.
-
-    If the class uses multiple inheritance, the docstring will be
-    chosen from the first class in the bases list, in the same way as
-    methods are normally resolved in Python.  If this results in
-    selecting the wrong docstring, the docstring will need to be
-    explicitly included on the method.
-
-    """
-
-    def __init__(cls, name, bases, dct):
-        def is_public_member(key):
-            return (
-                (key.startswith('__') and key.endswith('__')
-                 and len(key) > 4) or
-                not key.startswith('_'))
-
-        for key, val in six.iteritems(dct):
-            if (inspect.isfunction(val) and is_public_member(key)
-                    and val.__doc__ is None):
-                for base in cls.__mro__[1:]:
-                    super_method = getattr(base, key, None)
-                    if super_method is not None:
-                        val.__doc__ = super_method.__doc__
-                        break
-
-        super(MetaRegion, cls).__init__(name, bases, dct)
-
-
-@six.add_metaclass(MetaRegion)
-class Region(object):
-    """
-    Base class for all regions.
-    """
+class Region(abc.ABC):
+    """Base class for all regions."""
 
     def copy(self, **changes):
         """Make an independent (deep) copy."""

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -42,11 +42,11 @@ class Region(abc.ABC):
         params = []
         if self._params is not None:
             for key in self._params:
-                params.append('{0}={1}'.format(key.replace("_", " "),
+                params.append('{}={}'.format(key.replace("_", " "),
                                                getattr(self, key)))
         params = ', '.join(params)
 
-        return '<{0}({1})>'.format(self.__class__.__name__, params)
+        return f'<{self.__class__.__name__}({params})>'
 
     def __str__(self):
         cls_info = [('Region', self.__class__.__name__)]
@@ -54,7 +54,7 @@ class Region(abc.ABC):
             params_value = [(x.replace("_", " "), getattr(self, x))
                             for x in self._params]
             cls_info += params_value
-        fmt = ['{0}: {1}'.format(key, val) for key, val in cls_info]
+        fmt = [f'{key}: {val}' for key, val in cls_info]
 
         return '\n'.join(fmt)
 
@@ -133,7 +133,7 @@ class PixelRegion(Region):
 
     def __contains__(self, coord):
         if not coord.isscalar:
-            raise ValueError('coord must be scalar. coord={}'.format(coord))
+            raise ValueError(f'coord must be scalar. coord={coord}')
         return self.contains(coord)
 
     @abc.abstractmethod
@@ -195,11 +195,11 @@ class PixelRegion(Region):
     @staticmethod
     def _validate_mode(mode, subpixels):
         if mode not in VALID_MASK_MODES:
-            raise ValueError("Invalid mask mode: {0} (should be one "
-                             "of {1})".format(mode, '/'.join(VALID_MASK_MODES)))
+            raise ValueError("Invalid mask mode: {} (should be one "
+                             "of {})".format(mode, '/'.join(VALID_MASK_MODES)))
         if mode == 'subpixels':
             if not isinstance(subpixels, int) or subpixels <= 0:
-                raise ValueError("Invalid subpixels value: {0} (should be"
+                raise ValueError("Invalid subpixels value: {} (should be"
                                  " a strictly positive integer)".format(subpixels))
 
     @abc.abstractmethod

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -6,7 +6,7 @@ import astropy.units as u
 __all__ = ['RegionMask']
 
 
-class RegionMask(object):
+class RegionMask:
     """
     Class for a region mask.
 

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 import astropy.units as u
 

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import numpy as np
 from astropy.coordinates import SkyCoord

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -8,7 +8,7 @@ from .core import _DEFAULT_WCS_ORIGIN, _DEFAULT_WCS_MODE
 __all__ = ['PixCoord']
 
 
-class PixCoord(object):
+class PixCoord:
     """Pixel coordinates.
 
     This class can represent scalar or array pixel coordinates.
@@ -69,18 +69,18 @@ class PixCoord(object):
             The input object (at the moment unmodified, might do fix-ups here later)
         """
         if not isinstance(val, PixCoord):
-            raise TypeError('{} must be a PixCoord'.format(name))
+            raise TypeError(f'{name} must be a PixCoord')
 
         if expected == 'any':
             pass
         elif expected == 'scalar':
             if not val.isscalar:
-                raise ValueError('{} must be a scalar PixCoord'.format(name))
+                raise ValueError(f'{name} must be a scalar PixCoord')
         elif expected == 'not scalar':
             if val.isscalar:
-                raise ValueError('{} must be a non-scalar PixCoord'.format(name))
+                raise ValueError(f'{name} must be a non-scalar PixCoord')
         else:
-            raise ValueError('Invalid argument for `expected`: {}'.format(expected))
+            raise ValueError(f'Invalid argument for `expected`: {expected}')
 
         return val
 

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from numpy.testing import assert_allclose
 import pytest
 

--- a/regions/core/tests/test_compound.py
+++ b/regions/core/tests/test_compound.py
@@ -11,7 +11,7 @@ from ...core import PixCoord, CompoundPixelRegion
 from ...tests.helpers import make_simple_wcs
 
 
-class TestCompoundPixel(object):
+class TestCompoundPixel:
     # Two circles that overlap in one column
     c1 = CirclePixelRegion(PixCoord(5, 5), 4)
     c2 = CirclePixelRegion(PixCoord(11, 5), 4)

--- a/regions/core/tests/test_compound.py
+++ b/regions/core/tests/test_compound.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
 import operator
 import numpy as np
 from numpy.testing import assert_allclose

--- a/regions/core/tests/test_mask.py
+++ b/regions/core/tests/test_mask.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 import pytest

--- a/regions/io/core.py
+++ b/regions/io/core.py
@@ -65,7 +65,7 @@ valid_coordsys = {'DS9': ['image', 'physical', 'fk4', 'fk5', 'icrs', 'galactic',
                   'CRTF': ['image', 'fk5', 'fk4', 'galactic',
                            'geocentrictrueecliptic', 'supergalactic', 'icrs']
                   }
-valid_coordsys['DS9'] += ['wcs{}'.format(x) for x in string.ascii_lowercase]
+valid_coordsys['DS9'] += [f'wcs{x}' for x in string.ascii_lowercase]
 
 # Maps astropy's coordinate frame names with their respective name in the file format.
 coordsys_mapping = {'DS9': {x: x for x in valid_coordsys['DS9']},
@@ -86,11 +86,11 @@ class ShapeList(list):
         for shape in self:
             # Skip elliptical annulus for now
             if shape.region_type == 'ellipse' and len(shape.coord) > 5:
-                msg = 'Skipping elliptical annulus {}'.format(shape)
+                msg = f'Skipping elliptical annulus {shape}'
                 warn(msg, DS9RegionParserWarning)
                 continue
             if shape.region_type in ['box'] and shape.format_type == 'CRTF':
-                msg = 'Skipping {} {}'.format(shape.region_type, shape)
+                msg = f'Skipping {shape.region_type} {shape}'
                 warn(msg, CRTFRegionParserWarning)
                 continue
             log.debug(shape)
@@ -172,7 +172,7 @@ class ShapeList(list):
 
             if shape.meta.get('label', "") != "":
                 shape.meta['label'] = "'{}'".format(shape.meta['label'])
-            meta_str = ", ".join("{0}={1}".format(key, val) for key, val in
+            meta_str = ", ".join(f"{key}={val}" for key, val in
                                 shape.meta.items() if
                                 key not in ('include', 'comment', 'symbol',
                                             'coord', 'text', 'range', 'corr',
@@ -181,7 +181,7 @@ class ShapeList(list):
             # the first item should be the coordinates, since CASA cannot
             # recognize a region without an inline coordinate specification
             # It can be, but does not need to be, comma-separated at the start
-            meta_str = "coord={0}, ".format(coordsys.upper()) + meta_str
+            meta_str = "coord={}, ".format(coordsys.upper()) + meta_str
 
             if 'comment' in shape.meta:
                 meta_str += ", " + shape.meta['comment']
@@ -234,9 +234,9 @@ class ShapeList(list):
                 line = crtf_strings[shape.region_type].format(include, *coord)
 
             if meta_str.strip():
-                output += "{0}, {1}\n".format(line, meta_str)
+                output += f"{line}, {meta_str}\n"
             else:
-                output += "{0}\n".format(line)
+                output += f"{line}\n"
 
         return output
 
@@ -283,14 +283,14 @@ class ShapeList(list):
             if coordsys in coordsys_mapping['DS9'].values():
                 radunitstr = '"'
             else:
-                raise ValueError('Radius unit arcsec not valid for coordsys {}'.format(coordsys))
+                raise ValueError(f'Radius unit arcsec not valid for coordsys {coordsys}')
         else:
             radunitstr = ''
 
         for key, val in ds9_strings.items():
             ds9_strings[key] = val.replace("FMT", fmt).replace("RAD", radunitstr)
 
-        output += '{}\n'.format(coordsys)
+        output += f'{coordsys}\n'
 
         for shape in self:
 
@@ -306,12 +306,12 @@ class ShapeList(list):
             if 'symsize' in shape.meta:
                 shape.meta['point'] += " {}".format(shape.meta.pop('symsize'))
 
-            meta_str = " ".join("{0}={1}".format(key, val) for key, val in
+            meta_str = " ".join(f"{key}={val}" for key, val in
                                 shape.meta.items() if key not in ('include', 'tag', 'comment', 'font', 'text'))
             if 'tag' in shape.meta:
-                meta_str += " " + " ".join(["tag={0}".format(tag) for tag in shape.meta['tag']])
+                meta_str += " " + " ".join([f"tag={tag}" for tag in shape.meta['tag']])
             if 'font' in shape.meta:
-                meta_str += " " + 'font="{0}"'.format(shape.meta['font'])
+                meta_str += " " + 'font="{}"'.format(shape.meta['font'])
             if shape.meta.get('text', '') != '':
                 meta_str += " " + 'text={' + shape.meta['text'] + '}'
             if 'comment' in shape.meta:
@@ -356,9 +356,9 @@ class ShapeList(list):
                 line = ds9_strings[shape.region_type].format(include, *coord)
 
             if meta_str.strip():
-                output += "{0} # {1}\n".format(line, meta_str)
+                output += f"{line} # {meta_str}\n"
             else:
-                output += "{0}\n".format(line)
+                output += f"{line}\n"
 
         return output
 
@@ -433,7 +433,7 @@ class ShapeList(list):
         return table
 
 
-class Shape(object):
+class Shape:
     """
     Helper class to represent a DS9/CRTF Region.
 
@@ -510,15 +510,15 @@ class Shape(object):
     def __str__(self):
         ss = self.__class__.__name__
         ss += '\nType : {}'.format(self.meta.get('type', 'reg'))
-        ss += '\nCoord sys : {}'.format(self.coordsys)
-        ss += '\nRegion type : {}'.format(self.region_type)
+        ss += f'\nCoord sys : {self.coordsys}'
+        ss += f'\nRegion type : {self.region_type}'
         if self.region_type == 'symbol':
             ss += '\nSymbol : {}'.format(self.meta['symbol'])
         if self.region_type == 'text':
             ss += '\nText : {}'.format(self.meta['text'])
-        ss += '\nMeta: {}'.format(self.meta)
-        ss += '\nComposite: {}'.format(self.composite)
-        ss += '\nInclude: {}'.format(self.include)
+        ss += f'\nMeta: {self.meta}'
+        ss += f'\nComposite: {self.composite}'
+        ss += f'\nInclude: {self.include}'
         ss += '\n'
         return ss
 
@@ -633,11 +633,11 @@ class Shape(object):
         Checks for CRTF compatibility.
         """
         if self.region_type not in regions_attributes:
-            raise ValueError("'{0}' is not a valid region type in this package"
+            raise ValueError("'{}' is not a valid region type in this package"
                              "supported by CRTF".format(self.region_type))
 
         if self.coordsys not in valid_coordsys['CRTF']:
-            raise ValueError("'{0}' is not a valid coordinate reference frame in "
+            raise ValueError("'{}' is not a valid coordinate reference frame in "
                              "astropy supported by CRTF".format(self.coordsys))
 
     def check_ds9(self):
@@ -645,11 +645,11 @@ class Shape(object):
         Checks for DS9 compatibility.
         """
         if self.region_type not in regions_attributes:
-            raise ValueError("'{0}' is not a valid region type in this package"
+            raise ValueError("'{}' is not a valid region type in this package"
                              "supported by DS9".format(self.region_type))
 
         if self.coordsys not in valid_coordsys['DS9']:
-            raise ValueError("'{0}' is not a valid coordinate reference frame "
+            raise ValueError("'{}' is not a valid coordinate reference frame "
                              "in astropy supported by DS9".format(self.coordsys))
 
     def _validate(self):
@@ -657,11 +657,11 @@ class Shape(object):
         Checks whether all the attributes of this object is valid.
         """
         if self.region_type not in regions_attributes:
-            raise ValueError("'{0}' is not a valid region type in this package"
+            raise ValueError("'{}' is not a valid region type in this package"
                              .format(self.region_type))
 
         if self.coordsys not in valid_coordsys['DS9'] + valid_coordsys['CRTF']:
-            raise ValueError("'{0}' is not a valid coordinate reference frame "
+            raise ValueError("'{}' is not a valid coordinate reference frame "
                              "in astropy".format(self.coordsys))
 
 
@@ -766,7 +766,7 @@ def to_ds9_meta(shape_meta):
     meta = _to_io_meta(shape_meta, valid_keys, key_mappings)
 
     if 'font' in meta:
-        meta['font'] += " {0} {1} {2}".format(shape_meta.get('fontsize', 12),
+        meta['font'] += " {} {} {}".format(shape_meta.get('fontsize', 12),
                                               shape_meta.get('fontstyle', 'normal'),
                                               shape_meta.get('fontweight', 'roman'))
 

--- a/regions/io/core.py
+++ b/regions/io/core.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-from __future__ import absolute_import, division, print_function
 from warnings import warn
 import string
 import numbers

--- a/regions/io/crtf/core.py
+++ b/regions/io/crtf/core.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
-
 from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = [

--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -76,7 +76,7 @@ def read_crtf(filename, errors='strict'):
             raise CRTFRegionParserError('Every CRTF Region must start with "#CRTF" ')
 
 
-class CRTFParser(object):
+class CRTFParser:
     """
     Parses a CRTF string.
 
@@ -136,9 +136,9 @@ class CRTFParser(object):
 
     def __str__(self):
         ss = self.__class__.__name__
-        ss += '\nErrors: {}'.format(self.errors)
-        ss += '\nGlobal meta: {}'.format(self.global_meta)
-        ss += '\nShapes: {}'.format(self.shapes)
+        ss += f'\nErrors: {self.errors}'
+        ss += f'\nGlobal meta: {self.global_meta}'
+        ss += f'\nShapes: {self.shapes}'
         ss += '\n'
         return ss
 
@@ -176,10 +176,10 @@ class CRTFParser(object):
                                           *crtf_line.group('region', 'parameters'))
                 self.shapes.append(helper.shape)
             else:
-                self._raise_error("Not a valid CRTF Region type: '{0}'.".format(region_type))
+                self._raise_error(f"Not a valid CRTF Region type: '{region_type}'.")
 
         else:
-            self._raise_error("Not a valid CRTF line: '{0}'.".format(line))
+            self._raise_error(f"Not a valid CRTF line: '{line}'.")
             return
 
     def _raise_error(self, msg):
@@ -205,7 +205,7 @@ class CRTFParser(object):
             global_meta_str = regex_meta.findall(global_meta_str + ',')
         if global_meta_str:
             for par in global_meta_str:
-                if par[0] is not '':
+                if par[0] != '':
                     val1 = par[0].lower()
                     val2 = par[1]
                 else:
@@ -219,10 +219,10 @@ class CRTFParser(object):
                         val2 = [x.strip() for x in val2 if x]
                     self.global_meta[val1] = val2
                 else:
-                    self._raise_error("'{0}' is not a valid global meta key".format(val1))
+                    self._raise_error(f"'{val1}' is not a valid global meta key")
 
 
-class CRTFRegionParser(object):
+class CRTFRegionParser:
     """
     Parse a CRTF region string
 
@@ -330,14 +330,14 @@ class CRTFRegionParser(object):
 
         if self.region_type == 'poly':
             if len(coord_list_str) < 4:
-                self._raise_error('Not in proper format: {} polygon should have > 4 coordinates'.format(self.reg_str))
+                self._raise_error(f'Not in proper format: {self.reg_str} polygon should have > 4 coordinates')
             if coord_list_str[0] != coord_list_str[-1]:
-                self._raise_error("Not in proper format: '{0}', "
+                self._raise_error("Not in proper format: '{}', "
                                   "In polygon, the last and first coordinates should be same".format(self.reg_str))
         else:
             if len(coord_list_str) != len(self.language_spec[self.region_type]):
-                self._raise_error("Not in proper format: '{0}', "
-                                  "Does not contain expected number of parameters for the region '{1}'"
+                self._raise_error("Not in proper format: '{}', "
+                                  "Does not contain expected number of parameters for the region '{}'"
                                   .format(self.reg_str, self.region_type))
 
         for attr_spec, val_str in zip(self.language_spec[self.region_type], coord_list_str):
@@ -347,24 +347,24 @@ class CRTFRegionParser(object):
                     coord_list.append(CoordinateParser.parse_coordinate(val_str[0]))
                     coord_list.append(CoordinateParser.parse_coordinate(val_str[1]))
                 else:
-                    self._raise_error("Not in proper format: {0} should be a coordinate".format(val_str))
+                    self._raise_error(f"Not in proper format: {val_str} should be a coordinate")
             if attr_spec == 'pl':
                 if len(val_str) == 2 and val_str[1] != '':
                     coord_list.append(CoordinateParser.parse_angular_length_quantity(val_str[0]))
                     coord_list.append(CoordinateParser.parse_angular_length_quantity(val_str[1]))
                 else:
-                    self._raise_error("Not in proper format: {0} should be a pair of length".format(val_str))
+                    self._raise_error(f"Not in proper format: {val_str} should be a pair of length")
             if attr_spec == 'l':
                 if isinstance(val_str, str):
                     coord_list.append(CoordinateParser.parse_angular_length_quantity(val_str))
                 else:
-                    self._raise_error("Not in proper format: {0} should be a single length".format(val_str))
+                    self._raise_error(f"Not in proper format: {val_str} should be a single length")
             if attr_spec == 's':
                 if self.region_type == 'symbol':
                     if val_str in valid_symbols:
                         self.meta['symbol'] = val_str
                     else:
-                        self._raise_error("Not in proper format: '{0}' should be a symbol".format(val_str))
+                        self._raise_error(f"Not in proper format: '{val_str}' should be a symbol")
                 elif self.region_type == 'text':
                     self.meta['text'] = val_str[1:-1]
 
@@ -378,7 +378,7 @@ class CRTFRegionParser(object):
             self.meta_str = regex_meta.findall(self.meta_str + ',')
         if self.meta_str:
             for par in self.meta_str:
-                if par[0] is not '':
+                if par[0] != '':
                     val1 = par[0]
                     val2 = par[1]
                 else:
@@ -392,7 +392,7 @@ class CRTFRegionParser(object):
                         val2 = [x.strip() for x in val2]
                     self.meta[val1] = val2
                 else:
-                    self._raise_error("'{0}' is not a valid meta key".format(val1))
+                    self._raise_error(f"'{val1}' is not a valid meta key")
 
         self.meta['include'] = self.include != '-'
         self.include = self.meta['include']
@@ -429,7 +429,7 @@ class CRTFRegionParser(object):
                            )
 
 
-class CoordinateParser(object):
+class CoordinateParser:
     """
     Helper class to structure coordinate parser
     """
@@ -474,4 +474,4 @@ class CoordinateParser(object):
                 return u.Quantity(str.group(1), unit=unit_mapping[unit])
             return u.Quantity(str.group(1))
         else:
-            raise CRTFRegionParserError('Units must be specified for {0} '.format(string_rep))
+            raise CRTFRegionParserError(f'Units must be specified for {string_rep} ')

--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
 import re
-import six
 import copy
 import itertools
 from warnings import warn
@@ -357,7 +355,7 @@ class CRTFRegionParser(object):
                 else:
                     self._raise_error("Not in proper format: {0} should be a pair of length".format(val_str))
             if attr_spec == 'l':
-                if isinstance(val_str, six.string_types):
+                if isinstance(val_str, str):
                     coord_list.append(CoordinateParser.parse_angular_length_quantity(val_str))
                 else:
                     self._raise_error("Not in proper format: {0} should be a single length".format(val_str))

--- a/regions/io/crtf/tests/test_crtf_language.py
+++ b/regions/io/crtf/tests/test_crtf_language.py
@@ -1,4 +1,3 @@
-
 import distutils.version as vers
 import pytest
 
@@ -21,7 +20,7 @@ def test_global_parser():
     """
     Checks that the global_parser does what's expected.
     """
-    global_test_str = str("global coord=B1950_VLA, frame=BARY, corr=[I, Q], color=blue")
+    global_test_str = "global coord=B1950_VLA, frame=BARY, corr=[I, Q], color=blue"
     global_parser = CRTFParser(global_test_str)
     assert dict(global_parser.global_meta) == {'coord': 'B1950_VLA', 'frame': 'BARY',
                                                'corr': ['I', 'Q'], 'color': 'blue'}
@@ -56,7 +55,7 @@ def test_valid_global_meta_key():
     Checks whether the global key is valid or not.
     """
 
-    global_test_str = str("global label=B1950_VLA, frame=BARY, corr=[I, Q], color=blue")
+    global_test_str = "global label=B1950_VLA, frame=BARY, corr=[I, Q], color=blue"
 
     with pytest.raises(CRTFRegionParserError) as excinfo:
         CRTFParser(global_test_str)
@@ -69,7 +68,7 @@ def test_valid_meta_key():
     Checks whether the key is valid or not.
     """
 
-    meta_test_str = str("annulus[[17h51m03.2s, -45d17m50s], [0.10deg, 4.12deg]], hello='My label here'")
+    meta_test_str = "annulus[[17h51m03.2s, -45d17m50s], [0.10deg, 4.12deg]], hello='My label here'"
 
     with pytest.raises(CRTFRegionParserError) as excinfo:
         CRTFParser(meta_test_str)

--- a/regions/io/crtf/write.py
+++ b/regions/io/crtf/write.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from ..core import to_shape_list
 
 __all__ = [

--- a/regions/io/ds9/core.py
+++ b/regions/io/ds9/core.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
-
 from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = [

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -72,7 +72,7 @@ def read_ds9(filename, errors='strict'):
     return parser.shapes.to_regions()
 
 
-class CoordinateParser(object):
+class CoordinateParser:
     """
     Helper class to structure coordinate parser
     """
@@ -90,7 +90,7 @@ class CoordinateParser(object):
         # Any ds9 coordinate representation (sexagesimal or degrees)
         elif 'd' in string_rep or 'h' in string_rep:
             return coordinates.Angle(string_rep)
-        elif unit is 'hour_or_deg':
+        elif unit == 'hour_or_deg':
             if ':' in string_rep:
                 spl = tuple([float(x) for x in string_rep.split(":")])
                 return coordinates.Angle(spl, u.hourangle)
@@ -134,7 +134,7 @@ class CoordinateParser(object):
             return u.Quantity(float(string_rep), unit=unit)
 
 
-class DS9Parser(object):
+class DS9Parser:
     """
     Parse a DS9 string
 
@@ -171,7 +171,7 @@ class DS9Parser(object):
 
     # List of valid coordinate system
     coordinate_systems = ['fk5', 'fk4', 'icrs', 'galactic', 'wcs', 'physical', 'image', 'ecliptic', 'J2000']
-    coordinate_systems += ['wcs{0}'.format(letter) for letter in string.ascii_lowercase]
+    coordinate_systems += [f'wcs{letter}' for letter in string.ascii_lowercase]
 
     # Map to convert coordinate system names
     coordsys_mapping = dict(zip(coordinates.frame_transform_graph.get_names(),
@@ -197,10 +197,10 @@ class DS9Parser(object):
 
     def __str__(self):
         ss = self.__class__.__name__
-        ss += '\nErrors: {}'.format(self.errors)
-        ss += '\nCoordsys: {}'.format(self.coordsys)
-        ss += '\nGlobal meta: {}'.format(self.global_meta)
-        ss += '\nShapes: {}'.format(self.shapes)
+        ss += f'\nErrors: {self.errors}'
+        ss += f'\nCoordsys: {self.coordsys}'
+        ss += f'\nGlobal meta: {self.global_meta}'
+        ss += f'\nShapes: {self.shapes}'
         ss += '\n'
         return ss
 
@@ -222,13 +222,13 @@ class DS9Parser(object):
         for line_ in self.region_string.split('\n'):
             for line in line_.split(";"):
                 self.parse_line(line)
-                log.debug('Global state: {}'.format(self))
+                log.debug(f'Global state: {self}')
 
     def parse_line(self, line):
         """
         Parse one line
         """
-        log.debug('Parsing {}'.format(line))
+        log.debug(f'Parsing {line}')
 
         # Skip blanks
         if line == '':
@@ -254,7 +254,7 @@ class DS9Parser(object):
             include = region_type_search.groups()[0]
             region_type = region_type_search.groups()[1]
         else:
-            self._raise_error("No region type found for line '{0}'.".format(line))
+            self._raise_error(f"No region type found for line '{line}'.")
             return
 
         if region_type in self.coordinate_systems:
@@ -262,7 +262,7 @@ class DS9Parser(object):
             self.set_coordsys(region_type)
             return
         if region_type not in DS9RegionParser.language_spec:
-            self._raise_error("Region type '{0}' was identified, but it is not one of "
+            self._raise_error("Region type '{}' was identified, but it is not one of "
                               "the known region types.".format(region_type))
             return
         else:
@@ -307,7 +307,7 @@ class DS9Parser(object):
                 if key == 'tag':
                     result[key].append(val)
                 else:
-                    raise ValueError("Duplicate key {0} found".format(key))
+                    raise ValueError(f"Duplicate key {key} found")
             else:
                 if key == 'tag':
                     result[key] = [val]
@@ -344,7 +344,7 @@ angle = CoordinateParser.parse_angular_length_quantity
 coordinate = CoordinateParser.parse_coordinate
 
 
-class DS9RegionParser(object):
+class DS9RegionParser:
     """
     Parse a DS9 region string
 
@@ -378,7 +378,7 @@ class DS9RegionParser(object):
                         'wcs': (u.dimensionless_unscaled, u.dimensionless_unscaled),
                         }
     for letter in string.ascii_lowercase:
-        coordinate_units['wcs{0}'.format(letter)] = (u.dimensionless_unscaled, u.dimensionless_unscaled)
+        coordinate_units[f'wcs{letter}'] = (u.dimensionless_unscaled, u.dimensionless_unscaled)
 
     # DS9 language specification. This defines how a certain region is read.
     language_spec = {'point': (coordinate, coordinate),
@@ -412,11 +412,11 @@ class DS9RegionParser(object):
 
     def __str__(self):
         ss = self.__class__.__name__
-        ss += '\nLine : {}'.format(self.line)
-        ss += '\nRegion end : {}'.format(self.region_end)
-        ss += '\nMeta string : {}'.format(self.meta_str)
-        ss += '\nCoord string: {}'.format(self.coord_str)
-        ss += '\nShape: {}'.format(self.shape)
+        ss += f'\nLine : {self.line}'
+        ss += f'\nRegion end : {self.region_end}'
+        ss += f'\nMeta string : {self.meta_str}'
+        ss += f'\nCoord string: {self.coord_str}'
+        ss += f'\nShape: {self.shape}'
         ss += '\n'
         return ss
 

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
 import string
 import itertools
 import re

--- a/regions/io/ds9/tests/test_ds9_language.py
+++ b/regions/io/ds9/tests/test_ds9_language.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 import distutils.version as vers
 

--- a/regions/io/ds9/write.py
+++ b/regions/io/ds9/write.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from ..core import to_shape_list
 
 __all__ = [

--- a/regions/io/fits/core.py
+++ b/regions/io/fits/core.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
-
 from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = [

--- a/regions/io/fits/read.py
+++ b/regions/io/fits/read.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function
-
 from warnings import warn
 
 from astropy import units as u

--- a/regions/io/fits/read.py
+++ b/regions/io/fits/read.py
@@ -13,7 +13,7 @@ from ..core import Shape, ShapeList, reg_mapping
 __all__ = ['FITSRegionParser', 'read_fits_region', 'FITSRegionRowParser']
 
 
-class FITSRegionParser(object):
+class FITSRegionParser:
     """
     Parses a FITS Region table.
 
@@ -134,7 +134,7 @@ class FITSRegionRowParser():
         if region_type in language_spec:
             self.region_type = region_type
         else:
-            self._raise_error("'{0}' is not a valid FITS Region type"
+            self._raise_error("'{}' is not a valid FITS Region type"
                               .format(region_type))
 
         self.component = str(self.row['COMPONENT'])
@@ -155,14 +155,14 @@ class FITSRegionRowParser():
                 if index < len(val) and val[index] is not None:
                     return val[index], unit
                 else:
-                    raise ValueError("The column: {0} must have more than {1} value for the "
-                                     "region {2}".format(colname, index,
+                    raise ValueError("The column: {} must have more than {} value for the "
+                                     "region {}".format(colname, index,
                                                         self.region_type))
             else:
                 return val, unit
         except KeyError:
             if default is None:
-                self._raise_error("The column: '{0}' is missing in the table"
+                self._raise_error("The column: '{}' is missing in the table"
                                   .format(colname))
             else:
                 return default
@@ -196,7 +196,7 @@ class FITSRegionRowParser():
         if region_type in reg_mapping['FITS_REGION']:
             region_type = reg_mapping['FITS_REGION'][region_type]
         else:
-            self._raise_error("'{0}' is currently not supported in "
+            self._raise_error("'{}' is currently not supported in "
                               "regions".format(self.region_type))
 
         return self.component, Shape('physical', region_type,
@@ -212,7 +212,7 @@ class FITSRegionRowParser():
         if unit is not None:
             return val * units.get(str(unit), unit)
         else:
-            self._raise_error("The unit: {} is invalid".format(unit))
+            self._raise_error(f"The unit: {unit} is invalid")
 
 
 def read_fits_region(filename, errors='strict'):

--- a/regions/io/fits/write.py
+++ b/regions/io/fits/write.py
@@ -28,7 +28,7 @@ def fits_region_objects_to_table(regions):
     """
     for reg in regions:
         if isinstance(reg, SkyRegion):
-            raise TypeError('Every region must be a pixel region'.format(reg))
+            raise TypeError(f'Every region must be a pixel region')
 
     shape_list = to_shape_list(regions, coordinate_system='image')
     return shape_list.to_fits()

--- a/regions/io/fits/write.py
+++ b/regions/io/fits/write.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from astropy.io import fits
 
 from ..core import to_shape_list, SkyRegion

--- a/regions/io/tests/test_shape_object.py
+++ b/regions/io/tests/test_shape_object.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import pytest
 
 from astropy.tests.helper import assert_quantity_allclose

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -1,10 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import operator
-import six
 import abc
-
 from astropy import units as u
 from astropy.wcs.utils import pixel_to_skycoord
 
@@ -30,8 +26,7 @@ __all__ = [
 ]
 
 
-@six.add_metaclass(abc.ABCMeta)
-class AnnulusPixelRegion(PixelRegion):
+class AnnulusPixelRegion(PixelRegion, abc.ABC):
     """Annulus pixel region."""
 
     @property
@@ -194,7 +189,6 @@ class CircleAnnulusSkyRegion(SkyRegion):
         )
 
 
-@six.add_metaclass(abc.ABCMeta)
 class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
     """Helper class for asymmetric annuli sky regions.
 
@@ -270,7 +264,6 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
         return center, inner_width, inner_height, outer_width, outer_height, angle
 
 
-@six.add_metaclass(abc.ABCMeta)
 class AsymmetricAnnulusSkyRegion(SkyRegion):
     """Helper class for asymmetric annuli sky regions.
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import math
 

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import math
 
 import numpy as np

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import numpy as np
 import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
 from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 
 from astropy.wcs.utils import skycoord_to_pixel, pixel_to_skycoord

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy import units as u
 

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import numpy as np
 from numpy.testing import assert_allclose
 

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -136,7 +136,7 @@ def test_attribute_validation_pixel_regions(region):
             for val in invalid_values.get(attr, None):
                 with pytest.raises(ValueError) as excinfo:
                     setattr(region, attr, val)
-                assert 'The {} must be'.format(attr) in str(excinfo.value)
+                assert f'The {attr} must be' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('region', SKY_REGIONS, ids=ids_func)
@@ -166,4 +166,4 @@ def test_attribute_validation_sky_regions(region):
             for val in invalid_values.get(attr, None):
                 with pytest.raises(ValueError) as excinfo:
                     setattr(region, attr, val)
-                assert 'The {} must be'.format(attr) in str(excinfo.value)
+                assert f'The {attr} must be' in str(excinfo.value)

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -3,9 +3,6 @@
 The tests in this file simply check what functionality is currently
 implemented and doesn't check anything about correctness.
 """
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import itertools
 import pytest
 

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest

--- a/regions/shapes/tests/test_common.py
+++ b/regions/shapes/tests/test_common.py
@@ -6,7 +6,7 @@ import pytest
 
 from ...core import PixCoord, BoundingBox
 
-class BaseTestRegion(object):
+class BaseTestRegion:
 
     def test_repr(self):
         assert repr(self.reg).replace(" ","") == self.expected_repr.replace(" ","")

--- a/regions/shapes/tests/test_common.py
+++ b/regions/shapes/tests/test_common.py
@@ -1,8 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # Base class for all shape tests
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 import pytest

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest

--- a/regions/shapes/tests/test_line.py
+++ b/regions/shapes/tests/test_line.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from numpy.testing import assert_allclose
 import numpy as np
 import pytest

--- a/regions/shapes/tests/test_masks.py
+++ b/regions/shapes/tests/test_masks.py
@@ -39,7 +39,7 @@ def label(value):
     elif isinstance(value, PolygonPixelRegion):
         return 'poly'
     else:
-        return '-'.join('{0}_{1}'.format(key, value) for key, value in sorted(value.items()))
+        return '-'.join(f'{key}_{value}' for key, value in sorted(value.items()))
 
 # There's a bug in numpy: `numpy.savetxt` doesn't accept unicode
 # on Python 2. Bytes works on Python 2 and 3, so we're using that here.

--- a/regions/shapes/tests/test_masks.py
+++ b/regions/shapes/tests/test_masks.py
@@ -2,8 +2,6 @@
 """
 This file sets up detailed tests for computing masks with reference images.
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import itertools
 import pytest
 

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest

--- a/regions/shapes/tests/test_text.py
+++ b/regions/shapes/tests/test_text.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -49,7 +49,7 @@ class TextPixelRegion(PointPixelRegion):
     _params = ('center', 'text')
 
     def __init__(self, center, text, meta=None, visual=None):
-        super(TextPixelRegion, self).__init__(center, meta, visual)
+        super().__init__(center, meta, visual)
         self.text = text
 
     def to_sky(self, wcs):
@@ -101,7 +101,7 @@ class TextSkyRegion(PointSkyRegion):
     _params = ('center', 'text')
 
     def __init__(self, center, text, meta=None, visual=None):
-        super(TextSkyRegion, self).__init__(center,  meta, visual)
+        super().__init__(center,  meta, visual)
         self.text = text
 
     def to_pixel(self, wcs):

--- a/regions/tests/coveragerc
+++ b/regions/tests/coveragerc
@@ -20,7 +20,3 @@ exclude_lines =
 
    # Don't complain about script hooks
    def main\(.*\):
-
-   # Ignore branches that don't pertain to this version of Python
-   pragma: py{ignore_python_version}
-   six.PY{ignore_python_version}

--- a/regions/tests/helpers.py
+++ b/regions/tests/helpers.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import numpy as np
 
 from astropy.wcs import WCS

--- a/setup.py
+++ b/setup.py
@@ -104,8 +104,8 @@ setup(name=PACKAGENAME,
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,
-      setup_requires=['numpy'],
-      install_requires=['numpy', 'astropy', 'six'],
+      setup_requires=['numpy>=1.16'],
+      install_requires=['numpy>=1.16', 'astropy>=2.0'],
       extras_require=dict(
           plot=[
               'matplotlib',
@@ -124,5 +124,5 @@ setup(name=PACKAGENAME,
       zip_safe=False,
       use_2to3=False,
       entry_points=entry_points,
-      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+      python_requires='>=3.6',
       **package_info)


### PR DESCRIPTION
This PR updates `astropy-regions` to Python 3.6+ and Numpy 1.16+.

To be in line with the Astropy core package (see [here](https://github.com/astropy/astropy/blob/bf4e4de4a6d1ceb1db10f5850a90cce476348903/setup.cfg#L28-L30).

x-ref #241 and #291 