### PR TITLE
Account for a zero-height or width ellipse

### DIFF
--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -130,7 +130,10 @@ class EllipsePixelRegion(PixelRegion):
         if dx1 > dx2:
             dx1, dx2 = dx2, dx1
 
-        t1 = np.arctan(self.height / tan_angle / self.width)
+        if 0 in (self.height, tan_angle, self.width):
+            t1 = 0
+        else:
+            t1 = np.arctan(self.height / tan_angle / self.width)
         t2 = t1 + np.pi * u.rad
 
         dy1 = 0.5 * self.height * cos_angle * np.sin(t1) + 0.5 * self.width * sin_angle * np.cos(t1)


### PR DESCRIPTION
Corner case: trying to create a mask from a size-zero ellipse results in:
```
  File "/Users/adam/repos/astropy-regions/regions/shapes/ellipse.py", line 160, in to_mask
    bbox = self.bounding_box
  File "/Users/adam/repos/astropy-regions/regions/shapes/ellipse.py", line 147, in bounding_box
    return BoundingBox.from_float(xmin, xmax, ymin, ymax)
  File "/Users/adam/repos/astropy-regions/regions/core/bounding_box.py", line 118, in from_float
    iymin = int(np.floor(ymin + 0.5))
  File "/Users/adam/repos/astropy/astropy/units/quantity.py", line 1084, in __int__
    return int(self.to_value(dimensionless_unscaled))
ValueError: cannot convert float NaN to integer
```

This PR provides a workaround, but not a great one.

Really, this highlights that this package would benefit from hypothesis-like testing.

Don't merge this without a regression test...