### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ show-response = 1
 [tool:pytest]
 minversion = 3.1
 norecursedirs = build docs/_build astropy_helpers dist
-addopts = --arraydiff -p no:warnings
+addopts = --arraydiff -p no:warnings --doctest-ignore-import-errors
 doctest_plus = enabled
 
 [ah_bootstrap]


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to future-proof test collection behavior `pytest-doctestplus` - feel free to close if it doesn't look good or isn't relevant! You can report issues to @pllim.