### PR TITLE
Make it possible to initialize and update regions based on interactive Matplotlib widgets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@
   ``pyproject.toml`` to opt in to isolated builds as described in PEP 517/518.
   [#315]
 
+- Added a ``as_mpl_selector`` method to the rectangular and ellipse
+  pixel-based regions. This method returns an interactive Matplotlib
+  selector widget. [#317]
+
 0.4 (2019-06-17)
 ================
 

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -268,7 +268,11 @@ class EllipsePixelRegion(PixelRegion):
             def sync_callback(*args, **kwargs):
                 pass
 
-        self._mpl_selector = EllipseSelector(ax, sync_callback, interactive=True)
+        self._mpl_selector = EllipseSelector(ax, sync_callback, interactive=True,
+                                             rectprops={'edgecolor': self.visual.get('color', 'black'),
+                                                        'facecolor': 'none',
+                                                        'linewidth': self.visual.get('linewidth', 1),
+                                                        'linestyle': self.visual.get('linestyle', 'solid')})
         self._mpl_selector.extents = (self.center.x - self.width / 2,
                                       self.center.x + self.width / 2,
                                       self.center.y - self.height / 2,

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -6,6 +6,8 @@ from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.wcs.utils import pixel_to_skycoord
 
+from matplotlib.widgets import EllipseSelector
+
 from ..core import PixCoord, PixelRegion, SkyRegion, RegionMask, BoundingBox
 from .._geometry import elliptical_overlap_grid
 from .._utils.wcs_helpers import skycoord_to_pixel_scale_angle
@@ -208,6 +210,76 @@ class EllipsePixelRegion(PixelRegion):
 
         return Ellipse(xy=xy, width=width, height=height, angle=angle,
                        **mpl_params)
+
+    def _update_from_mpl_selector(self, *args, **kwargs):
+        xmin, xmax, ymin, ymax = self._mpl_selector.extents
+        self.center = PixCoord(x=0.5 * (xmin + xmax),
+                               y=0.5 * (ymin + ymax))
+        self.width = (xmax - xmin)
+        self.height = (ymax - ymin)
+        self.angle = 0. * u.deg
+        if self._mpl_selector_callback is not None:
+            self._mpl_selector_callback(self)
+
+    def as_mpl_selector(self, ax, active=True, sync=True, callback=None, **kwargs):
+        """
+        Matplotlib editable widget for this region (`matplotlib.widgets.EllipseSelector`)
+
+        Parameters
+        ----------
+        ax : `~matplotlib.axes.Axes`
+            The Matplotlib axes to add the selector to.
+        active : bool, optional
+            Whether the selector should be active by default.
+        sync : bool, optional
+            If `True` (the default), the region will be kept in sync with the
+            selector. Otherwise, the selector will be initialized with the
+            values from the region but the two will then be disconnected.
+        callback : func, optional
+            If specified, this function will be called every time the region is
+            updated. This only has an effect if ``sync`` is `True`. If a
+            callback is set, it is called for the first time once the selector
+            has been created.
+        kwargs
+            Additional keyword arguments are passed to matplotlib.widgets.EllipseSelector`
+
+        Returns
+        -------
+        selector : `matplotlib.widgets.EllipseSelector`
+            The Matplotlib selector.
+
+        Notes
+        -----
+        Once a selector has been created, you will need to keep a reference to
+        it until you no longer need it. In addition, you can enable/disable the
+        selector at any point by calling ``selector.set_active(True)`` or
+        ``selector.set_active(False)``.
+        """
+
+        if hasattr(self, '_mpl_selector'):
+            raise Exception("Cannot attach more than one selector to a region.")
+
+        if self.angle.value != 0:
+            raise NotImplementedError("Cannot create matplotlib selector for rotated rectangle.")
+
+        if sync:
+            sync_callback = self._update_from_mpl_selector
+        else:
+            def sync_callback(*args, **kwargs):
+                pass
+
+        self._mpl_selector = EllipseSelector(ax, sync_callback, interactive=True)
+        self._mpl_selector.extents = (self.center.x - self.width / 2,
+                                      self.center.x + self.width / 2,
+                                      self.center.y - self.height / 2,
+                                      self.center.y + self.height / 2)
+        self._mpl_selector.set_active(active)
+        self._mpl_selector_callback = callback
+
+        if sync and self._mpl_selector_callback is not None:
+            self._mpl_selector_callback(self)
+
+        return self._mpl_selector
 
     def rotate(self, center, angle):
         """Make a rotated region.

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -6,8 +6,6 @@ from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.wcs.utils import pixel_to_skycoord
 
-from matplotlib.widgets import EllipseSelector
-
 from ..core import PixCoord, PixelRegion, SkyRegion, RegionMask, BoundingBox
 from .._geometry import elliptical_overlap_grid
 from .._utils.wcs_helpers import skycoord_to_pixel_scale_angle
@@ -256,11 +254,13 @@ class EllipsePixelRegion(PixelRegion):
         ``selector.set_active(False)``.
         """
 
+        from matplotlib.widgets import EllipseSelector
+
         if hasattr(self, '_mpl_selector'):
             raise Exception("Cannot attach more than one selector to a region.")
 
         if self.angle.value != 0:
-            raise NotImplementedError("Cannot create matplotlib selector for rotated rectangle.")
+            raise NotImplementedError("Cannot create matplotlib selector for rotated ellipse.")
 
         if sync:
             sync_callback = self._update_from_mpl_selector

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -252,7 +252,11 @@ class RectanglePixelRegion(PixelRegion):
             def sync_callback(*args, **kwargs):
                 pass
 
-        self._mpl_selector = RectangleSelector(ax, sync_callback, interactive=True)
+        self._mpl_selector = RectangleSelector(ax, sync_callback, interactive=True,
+                                               rectprops={'edgecolor': self.visual.get('color', 'black'),
+                                                          'facecolor': 'none',
+                                                          'linewidth': self.visual.get('linewidth', 1),
+                                                          'linestyle': self.visual.get('linestyle', 'solid')})
         self._mpl_selector.extents = (self.center.x - self.width / 2,
                                       self.center.x + self.width / 2,
                                       self.center.y - self.height / 2,

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -5,8 +5,6 @@ from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.wcs.utils import pixel_to_skycoord
 
-from matplotlib.widgets import RectangleSelector
-
 from ..core import PixCoord, PixelRegion, SkyRegion, RegionMask, BoundingBox
 from .._geometry import rectangular_overlap_grid
 from .._utils.wcs_helpers import skycoord_to_pixel_scale_angle
@@ -239,6 +237,8 @@ class RectanglePixelRegion(PixelRegion):
         selector at any point by calling ``selector.set_active(True)`` or
         ``selector.set_active(False)``.
         """
+
+        from matplotlib.widgets import RectangleSelector
 
         if hasattr(self, '_mpl_selector'):
             raise Exception("Cannot attach more than one selector to a region.")

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -205,7 +205,7 @@ class RectanglePixelRegion(PixelRegion):
         if self._mpl_selector_callback is not None:
             self._mpl_selector_callback(self)
 
-    def as_mpl_selector(self, ax, sync=True, callback=None, **kwargs):
+    def as_mpl_selector(self, ax, active=True, sync=True, callback=None, **kwargs):
         """
         Matplotlib editable widget for this region (`matplotlib.widgets.RectangleSelector`)
 
@@ -213,6 +213,8 @@ class RectanglePixelRegion(PixelRegion):
         ----------
         ax : `~matplotlib.axes.Axes`
             The Matplotlib axes to add the selector to.
+        active : bool, optional
+            Whether the selector should be active by default.
         sync : bool, optional
             If `True` (the default), the region will be kept in sync with the
             selector. Otherwise, the selector will be initialized with the
@@ -224,6 +226,18 @@ class RectanglePixelRegion(PixelRegion):
             has been created.
         kwargs
             Additional keyword arguments are passed to matplotlib.widgets.RectangleSelector`
+
+        Returns
+        -------
+        selector : `matplotlib.widgets.RectangleSelector`
+            The Matplotlib selector.
+
+        Notes
+        -----
+        Once a selector has been created, you will need to keep a reference to
+        it until you no longer need it. In addition, you can enable/disable the
+        selector at any point by calling ``selector.set_active(True)`` or
+        ``selector.set_active(False)``.
         """
 
         if hasattr(self, '_mpl_selector'):
@@ -243,7 +257,7 @@ class RectanglePixelRegion(PixelRegion):
                                       self.center.x + self.width / 2,
                                       self.center.y - self.height / 2,
                                       self.center.y + self.height / 2)
-        self._mpl_selector.set_active(True)
+        self._mpl_selector.set_active(active)
         self._mpl_selector_callback = callback
 
         if sync and self._mpl_selector_callback is not None:

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 import pytest
 
 import astropy.units as u
@@ -80,7 +80,6 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         assert_allclose(reg.center.xy, (1, 4))
         assert_allclose(reg.angle.to_value("deg"), 95)
 
-
     def test_as_mpl_selector(self):
 
         plt = pytest.importorskip('matplotlib.pyplot')
@@ -91,10 +90,16 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         ax = plt.subplot(1, 1, 1)
         ax.imshow(data)
 
-        def update_mask(region):
-            mask[:] = self.reg.to_mask(mode='subpixels', subpixels=10).to_image(data.shape)
+        def update_mask(reg):
+            mask[:] = reg.to_mask(mode='subpixels', subpixels=10).to_image(data.shape)
 
-        # For now this will only work with unrotated rectangles
+        # For now this will only work with unrotated ellipses. Once this works
+        # with rotated ellipses, the following exception check can be removed
+        # as well as the ``angle=0 * u.deg`` in the call to copy() below.
+        with pytest.raises(NotImplementedError,
+                           match='Cannot create matplotlib selector for rotated ellipse.'):
+            self.reg.as_mpl_selector(ax)
+
         region = self.reg.copy(angle=0 * u.deg)
 
         selector = region.as_mpl_selector(ax, callback=update_mask, sync=True)  # noqa
@@ -113,6 +118,36 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         assert_allclose(region.width, 2)
         assert_allclose(region.height, 1)
         assert_quantity_allclose(region.angle, 0 * u.deg)
+
+        assert_equal(mask, region.to_mask(mode='subpixels', subpixels=10).to_image(data.shape))
+
+        with pytest.raises(Exception, match='Cannot attach more than one selector to a region.'):
+            region.as_mpl_selector(ax)
+
+        # Make sure the region doesn't change if sync=False
+
+        region2 = self.reg.copy(angle=0 * u.deg)
+        mask[:] = 0
+
+        selector = region2.as_mpl_selector(ax, callback=update_mask, sync=False)  # noqa
+
+        x, y = ax.transData.transform([[7.3, 4.4]])[0]
+        ax.figure.canvas.button_press_event(x, y, 1)
+        x, y = ax.transData.transform([[9.3, 5.4]])[0]
+        ax.figure.canvas.motion_notify_event(x, y, 1)
+        x, y = ax.transData.transform([[9.3, 5.4]])[0]
+        ax.figure.canvas.button_release_event(x, y, 1)
+
+        ax.figure.canvas.draw()
+
+        # The region parameters haven't changed and the mask is still empty
+        assert_allclose(region2.center.x, 3)
+        assert_allclose(region2.center.y, 4)
+        assert_allclose(region2.width, 4)
+        assert_allclose(region2.height, 3)
+        assert_quantity_allclose(region2.angle, 0 * u.deg)
+
+        assert_equal(mask, 0)
 
 
 class TestEllipseSkyRegion(BaseTestSkyRegion):

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -105,12 +105,23 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
 
         selector = region.as_mpl_selector(ax, callback=update_mask, sync=sync)  # noqa
 
+        from matplotlib.backend_bases import MouseEvent, MouseButton
+
         x, y = ax.transData.transform([[7.3, 4.4]])[0]
-        ax.figure.canvas.button_press_event(x, y, 1)
+        ax.figure.canvas.callbacks.process('button_press_event',
+                                           MouseEvent('button_press_event',
+                                                      ax.figure.canvas, x, y,
+                                                      button=MouseButton.LEFT))
         x, y = ax.transData.transform([[9.3, 5.4]])[0]
-        ax.figure.canvas.motion_notify_event(x, y, 1)
+        ax.figure.canvas.callbacks.process('motion_notify_event',
+                                           MouseEvent('button_press_event',
+                                                      ax.figure.canvas, x, y,
+                                                      button=MouseButton.LEFT))
         x, y = ax.transData.transform([[9.3, 5.4]])[0]
-        ax.figure.canvas.button_release_event(x, y, 1)
+        ax.figure.canvas.callbacks.process('button_release_event',
+                                           MouseEvent('button_press_event',
+                                                      ax.figure.canvas, x, y,
+                                                      button=MouseButton.LEFT))
 
         ax.figure.canvas.draw()
 

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -81,6 +81,40 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         assert_allclose(reg.angle.to_value("deg"), 95)
 
 
+    def test_as_mpl_selector(self):
+
+        plt = pytest.importorskip('matplotlib.pyplot')
+
+        data = np.random.random((16, 16))
+        mask = np.zeros_like(data)
+
+        ax = plt.subplot(1, 1, 1)
+        ax.imshow(data)
+
+        def update_mask(region):
+            mask[:] = self.reg.to_mask(mode='subpixels', subpixels=10).to_image(data.shape)
+
+        # For now this will only work with unrotated rectangles
+        region = self.reg.copy(angle=0 * u.deg)
+
+        selector = region.as_mpl_selector(ax, callback=update_mask, sync=True)  # noqa
+
+        x, y = ax.transData.transform([[7.3, 4.4]])[0]
+        ax.figure.canvas.button_press_event(x, y, 1)
+        x, y = ax.transData.transform([[9.3, 5.4]])[0]
+        ax.figure.canvas.motion_notify_event(x, y, 1)
+        x, y = ax.transData.transform([[9.3, 5.4]])[0]
+        ax.figure.canvas.button_release_event(x, y, 1)
+
+        ax.figure.canvas.draw()
+
+        assert_allclose(region.center.x, 8.3)
+        assert_allclose(region.center.y, 4.9)
+        assert_allclose(region.width, 2)
+        assert_allclose(region.height, 1)
+        assert_quantity_allclose(region.angle, 0 * u.deg)
+
+
 class TestEllipseSkyRegion(BaseTestSkyRegion):
     reg = EllipseSkyRegion(
         center=SkyCoord(3, 4, unit='deg'),

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -131,11 +131,11 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
 
         selector = region2.as_mpl_selector(ax, callback=update_mask, sync=False)  # noqa
 
-        x, y = ax.transData.transform([[7.3, 4.4]])[0]
+        x, y = ax.transData.transform([[5.3, 4.4]])[0]
         ax.figure.canvas.button_press_event(x, y, 1)
-        x, y = ax.transData.transform([[9.3, 5.4]])[0]
+        x, y = ax.transData.transform([[7.3, 5.4]])[0]
         ax.figure.canvas.motion_notify_event(x, y, 1)
-        x, y = ax.transData.transform([[9.3, 5.4]])[0]
+        x, y = ax.transData.transform([[7.3, 5.4]])[0]
         ax.figure.canvas.button_release_event(x, y, 1)
 
         ax.figure.canvas.draw()

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -80,7 +80,8 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         assert_allclose(reg.center.xy, (1, 4))
         assert_allclose(reg.angle.to_value("deg"), 95)
 
-    def test_as_mpl_selector(self):
+    @pytest.mark.parametrize('sync', (False, True))
+    def test_as_mpl_selector(self, sync):
 
         plt = pytest.importorskip('matplotlib.pyplot')
 
@@ -102,7 +103,7 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
 
         region = self.reg.copy(angle=0 * u.deg)
 
-        selector = region.as_mpl_selector(ax, callback=update_mask, sync=True)  # noqa
+        selector = region.as_mpl_selector(ax, callback=update_mask, sync=sync)  # noqa
 
         x, y = ax.transData.transform([[7.3, 4.4]])[0]
         ax.figure.canvas.button_press_event(x, y, 1)
@@ -113,41 +114,28 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
 
         ax.figure.canvas.draw()
 
-        assert_allclose(region.center.x, 8.3)
-        assert_allclose(region.center.y, 4.9)
-        assert_allclose(region.width, 2)
-        assert_allclose(region.height, 1)
-        assert_quantity_allclose(region.angle, 0 * u.deg)
+        if sync:
 
-        assert_equal(mask, region.to_mask(mode='subpixels', subpixels=10).to_image(data.shape))
+            assert_allclose(region.center.x, 8.3)
+            assert_allclose(region.center.y, 4.9)
+            assert_allclose(region.width, 2)
+            assert_allclose(region.height, 1)
+            assert_quantity_allclose(region.angle, 0 * u.deg)
+
+            assert_equal(mask, region.to_mask(mode='subpixels', subpixels=10).to_image(data.shape))
+
+        else:
+
+            assert_allclose(region.center.x, 3)
+            assert_allclose(region.center.y, 4)
+            assert_allclose(region.width, 4)
+            assert_allclose(region.height, 3)
+            assert_quantity_allclose(region.angle, 0 * u.deg)
+
+            assert_equal(mask, 0)
 
         with pytest.raises(Exception, match='Cannot attach more than one selector to a region.'):
             region.as_mpl_selector(ax)
-
-        # Make sure the region doesn't change if sync=False
-
-        region2 = self.reg.copy(angle=0 * u.deg)
-        mask[:] = 0
-
-        selector = region2.as_mpl_selector(ax, callback=update_mask, sync=False)  # noqa
-
-        x, y = ax.transData.transform([[5.3, 4.4]])[0]
-        ax.figure.canvas.button_press_event(x, y, 1)
-        x, y = ax.transData.transform([[7.3, 5.4]])[0]
-        ax.figure.canvas.motion_notify_event(x, y, 1)
-        x, y = ax.transData.transform([[7.3, 5.4]])[0]
-        ax.figure.canvas.button_release_event(x, y, 1)
-
-        ax.figure.canvas.draw()
-
-        # The region parameters haven't changed and the mask is still empty
-        assert_allclose(region2.center.x, 3)
-        assert_allclose(region2.center.y, 4)
-        assert_allclose(region2.width, 4)
-        assert_allclose(region2.height, 3)
-        assert_quantity_allclose(region2.angle, 0 * u.deg)
-
-        assert_equal(mask, 0)
 
 
 class TestEllipseSkyRegion(BaseTestSkyRegion):

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -130,12 +130,23 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
 
         selector = region.as_mpl_selector(ax, callback=update_mask, sync=sync)  # noqa
 
+        from matplotlib.backend_bases import MouseEvent, MouseButton
+
         x, y = ax.transData.transform([[7.3, 4.4]])[0]
-        ax.figure.canvas.button_press_event(x, y, 1)
+        ax.figure.canvas.callbacks.process('button_press_event',
+                                           MouseEvent('button_press_event',
+                                                      ax.figure.canvas, x, y,
+                                                      button=MouseButton.LEFT))
         x, y = ax.transData.transform([[9.3, 5.4]])[0]
-        ax.figure.canvas.motion_notify_event(x, y, 1)
+        ax.figure.canvas.callbacks.process('motion_notify_event',
+                                           MouseEvent('button_press_event',
+                                                      ax.figure.canvas, x, y,
+                                                      button=MouseButton.LEFT))
         x, y = ax.transData.transform([[9.3, 5.4]])[0]
-        ax.figure.canvas.button_release_event(x, y, 1)
+        ax.figure.canvas.callbacks.process('button_release_event',
+                                           MouseEvent('button_press_event',
+                                                      ax.figure.canvas, x, y,
+                                                      button=MouseButton.LEFT))
 
         ax.figure.canvas.draw()
 


### PR DESCRIPTION
This is a proof of concept of initializing and updating regions based on interactive Matplotlib widgets (which are now a think in ``matplotlib.widgets``). The idea is that regions could have a ``as_mpl_selector``  method that takes the axes and returns a Matplotlib selector. The selector is then active and the region is updated as the selector is moved around and adjusted (provided ``sync`` is set to ``True``, which is the default). Here's an example in action:

```python
import numpy as np
import matplotlib.pyplot as plt
from regions import RectanglePixelRegion, PixCoord

data = np.random.random((16, 16))
mask = np.zeros_like(data)

plt.ion()

ax1 = plt.subplot(1, 2, 1)
ax1.imshow(data)
ax2 = plt.subplot(1, 2, 2)
im_mask = ax2.imshow(mask, vmin=0, vmax=1)


def update_mask(region):
    mask = region.to_mask(mode='subpixels', subpixels=10).to_image(data.shape)
    im_mask.set_data(mask)


region = RectanglePixelRegion(PixCoord(3, 5), 2, 3)
selector = region.as_mpl_selector(ax1, callback=update_mask, sync=True)

plt.show(block=True)
```
![Peek 2020-05-21 13-41](https://user-images.githubusercontent.com/314716/82560196-dd4df800-9b68-11ea-8ff3-08dc2fc4ac14.gif)

The Matplotlib widgets included in Matplotlib don't (yet) have everything we need, in particular they don't have the ability to support rotation. However, I'm going to investigate whether the Matplotlib developers would be happy to have this additional functionality. Also moving regions around is a bit obnoxious as it requires clicking on the center of the region. I'm going to see if I can patch it to allow the whole region to be clicked and dragged. But in any case, we can either improve the widgets in Matplotlib or fork it here if they won't accept improvements upstream (which I doubt).

@keflavich @larrybradley - what do you think about this approach and API?

TODOs if we agree on the approach:

* [x] Use the region's visual properties for the selector
* [x] Changelog entry
* [x] Tests
* [ ] Expand approach to other region types
* [ ] Investigate how to deal with Sky regions and WCSAxes
* [ ] Improve Matplotlib selectors to support e.g. rotation (could potentially be done as part of another PR since we can just raise a NotImplementedError in the mean time)
