### PR TITLE
Fix relative import error

### DIFF
--- a/regions/io/crtf/new_casa_tests/casa_mask_test.py
+++ b/regions/io/crtf/new_casa_tests/casa_mask_test.py
@@ -4,9 +4,9 @@ import pytest
 
 from astropy import coordinates, units as u
 
-from ..write import write_crtf
+from regions.io.crtf.write import write_crtf
 
-from ....shapes.ellipse import EllipseSkyRegion
+from regions.shapes.ellipse import EllipseSkyRegion
 
 try:
     from casatools import image, simulator

--- a/regions/io/crtf/new_casa_tests/casa_mask_test.py
+++ b/regions/io/crtf/new_casa_tests/casa_mask_test.py
@@ -4,9 +4,9 @@ import pytest
 
 from astropy import coordinates, units as u
 
-from regions.io.crtf.write import write_crtf
+from ..write import write_crtf
 
-from regions.shapes.ellipse import EllipseSkyRegion
+from ....shapes.ellipse import EllipseSkyRegion
 
 try:
     from casatools import image, simulator


### PR DESCRIPTION
Fixes #327 

This prevents `pytest` from failing and completes successfully without any errors.

@keflavich or @larrybradley or @astrofrog Could you please review this small change?

Thanks!