### PR TITLE
Fix RegionMask fill_value issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,24 +1,34 @@
 0.5 (unreleased)
 ================
 
+General
+-------
+
 - The infrastructure of the package has been updated in line with the
-  APE 17 guidelines. The main changes are that the ``python setup.py test`` and
-  ``python setup.py build_docs`` commands will no longer work. The easiest way
-  to replicate these commands is to install the tox (https://tox.readthedocs.io)
-  package and run ``tox -e test`` and ``tox -e build_docs``. It is also possible
-  to run pytest and sphinx directly. Other significant changes include switching
-  to setuptools_scm to manage the version number, and adding a
-  ``pyproject.toml`` to opt in to isolated builds as described in PEP 517/518.
-  [#315]
+  APE 17 guidelines. The main changes are that the ``python setup.py
+  test`` and ``python setup.py build_docs`` commands will no longer
+  work. The easiest way to replicate these commands is to install the
+  tox (https://tox.readthedocs.io) package and run ``tox -e test`` and
+  ``tox -e build_docs``. It is also possible to run pytest and sphinx
+  directly. Other significant changes include switching to setuptools_scm
+  to manage the version number, and adding a ``pyproject.toml`` to opt in
+  to isolated builds as described in PEP 517/518. [#315]
+
+- Bump the minimum required version of Astropy to 3.2.
+
+New Features
+------------
 
 - Added a ``as_mpl_selector`` method to the rectangular and ellipse
   pixel-based regions. This method returns an interactive Matplotlib
   selector widget. [#317]
 
-- Add a unified read-write interface for all region formats, inspired by and
-  using the same infrastructure as astropy.table. [#307]
+- Added a unified read-write interface for all region formats, inspired
+  by and using the same infrastructure as astropy.table. [#307]
 
-- Bump the minimum required version of Astropy to 3.2.
+Bug Fixes
+---------
+
 
 0.4 (2019-06-17)
 ================
@@ -41,7 +51,6 @@ Bug Fixes
   to zero. [#278]
 - Fix 'text' renamed to 'label' [#234]
 
-
 Other
 -----
 
@@ -52,9 +61,9 @@ Other
 
 See also: `regions v0.4 merged pull requests list on Github <https://github.com/astropy/regions/pulls?q=is%3Apr+milestone%3A0.4+>`__.
 
+
 0.3 (2018-09-09)
 ================
-
 
 New features
 ------------
@@ -104,12 +113,14 @@ New features
 
 See also: `regions v0.3 merged pull requests list on Github <https://github.com/astropy/regions/pulls?q=is%3Apr+milestone%3A0.3+>`__.
 
+
 0.2 (2017-02-16)
 ================
 
 Changelog wasn't filled.
 
 See also: `regions v0.2 merged pull requests list on Github <https://github.com/astropy/regions/pulls?q=is%3Apr+milestone%3A0.2+>`__.
+
 
 0.1 (2016-07-26)
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,14 @@ New Features
 Bug Fixes
 ---------
 
+- Fixed an issue where ``RegionMask.multiply`` ``fill_value`` was not
+  applied to pixels outside of the mask, but within the region bounding
+  box. [#346]
+
+- Fixed an issue where ``RegionMask.cutout`` would raise an error if
+  ``fill_value`` was non-finite and the input array was integer type.
+  [#346]
+
 
 0.4 (2019-06-17)
 ================

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -247,6 +247,6 @@ class RegionMask:
 
             # needed to zero out non-finite data values outside of the
             # mask but within the bounding box
-            weighted_cutout[self._mask] = 0.0
+            weighted_cutout[self._mask] = fill_value
 
             return weighted_cutout

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -196,8 +196,12 @@ class RegionMask:
             if slices_small is None:
                 return None    # no overlap
 
-            # cutout is a copy
-            cutout = np.zeros(self.shape, dtype=data.dtype)
+            # cutout is always a copy for partial overlap
+            if ~np.isfinite(fill_value):
+                dtype = float
+            else:
+                dtype = data.dtype
+            cutout = np.zeros(self.shape, dtype=dtype)
             cutout[:] = fill_value
             cutout[slices_small] = data[slices_large]
 

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -30,7 +30,7 @@ class RegionMask:
     def __init__(self, data, bbox):
         self.data = np.asanyarray(data)
         if self.data.shape != bbox.shape:
-            raise ValueError('data and bounding box must have the same '
+            raise ValueError('mask data and bounding box must have the same '
                              'shape.')
         self.bbox = bbox
         self._mask = (self.data == 0)
@@ -40,7 +40,6 @@ class RegionMask:
         Array representation of the mask data array (e.g., for
         matplotlib).
         """
-
         return self.data
 
     @property
@@ -48,7 +47,6 @@ class RegionMask:
         """
         The shape of the mask data array.
         """
-
         return self.data.shape
 
     def _overlap_slices(self, shape):
@@ -74,7 +72,6 @@ class RegionMask:
             such that ``small_array[slices_small]`` extracts the region
             of the small array that is inside the large array.
         """
-
         if len(shape) != 2:
             raise ValueError('input shape must have 2 elements.')
 
@@ -102,7 +99,6 @@ class RegionMask:
         Return an image of the mask in a 2D array, where the mask
         is not fully within the image (i.e. partial or no overlap).
         """
-
         # find the overlap of the mask on the output image shape
         slices_large, slices_small = self._overlap_slices(image.shape)
 
@@ -129,7 +125,6 @@ class RegionMask:
         result : `~numpy.ndarray`
             A 2D array of the mask.
         """
-
         if len(shape) != 2:
             raise ValueError('input shape must have 2 elements.')
 
@@ -179,7 +174,6 @@ class RegionMask:
             ``fill_value``.  `None` is returned if there is no overlap
             of the region with the input ``data``.
         """
-
         data = np.asanyarray(data)
         if data.ndim != 2:
             raise ValueError('data must be a 2D array.')
@@ -238,7 +232,6 @@ class RegionMask:
             is returned if there is no overlap of the region with the
             input ``data``.
         """
-
         cutout = self.cutout(data, fill_value=fill_value)
         if cutout is None:
             return None


### PR DESCRIPTION
This PR fixes two issues with `RegionMask` `fill_value`:

* `RegionMask.multiply` `fill_value` was not applied to pixels outside of the mask, but within the region bounding box
* `RegionMask.cutout` would raise an error if `fill_value` was non-finite and the input array was integer type

Fixes #242.