### PR TITLE
Raise error in BoundingBox slices if ixmin or iymin is negative

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,9 @@ Bug Fixes
   ``fill_value`` was non-finite and the input array was integer type.
   [#346]
 
+- A ``ValueError`` is now raised when calling ``BoundingBox.slices``
+  when ``ixmin`` or ``iymin`` is negative. [#347]
+
 
 0.4 (2019-06-17)
 ================

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -156,6 +156,9 @@ class BoundingBox:
         The slice tuple is in numpy axis order (i.e. ``(y, x)``) and
         therefore can be used to slice numpy arrays.
         """
+        if self.iymin < 0 or self.ixmin < 0:
+            raise ValueError('cannot create slices when ixmin or iymin is '
+                             'negative')
         return slice(self.iymin, self.iymax), slice(self.ixmin, self.ixmax)
 
     @property

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -5,7 +5,7 @@ import pytest
 from ..bounding_box import BoundingBox
 
 try:
-    import matplotlib
+    import matplotlib  # noqa
     HAS_MATPLOTLIB = True
 except ImportError:
     HAS_MATPLOTLIB = False
@@ -103,6 +103,7 @@ def test_bounding_box_as_artist():
     assert_allclose(patch.get_width(), 9)
     assert_allclose(patch.get_height(), 18)
 
+
 def test_bounding_box_union():
     bbox1 = BoundingBox(1, 10, 2, 20)
     bbox2 = BoundingBox(5, 21, 7, 32)
@@ -115,6 +116,7 @@ def test_bounding_box_union():
 
     with pytest.raises(TypeError):
         bbox1.union((5, 21, 7, 32))
+
 
 def test_bounding_box_intersect():
     bbox1 = BoundingBox(1, 10, 2, 20)

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -7,7 +7,7 @@ from ..bounding_box import BoundingBox
 try:
     import matplotlib
     HAS_MATPLOTLIB = True
-except:
+except ImportError:
     HAS_MATPLOTLIB = False
 
 

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -78,13 +78,19 @@ def test_bounding_box_shape():
 
 def test_bounding_box_slices():
     bbox = BoundingBox(1, 10, 2, 20)
-
     assert bbox.slices == (slice(2, 20), slice(1, 10))
+
+    with pytest.raises(ValueError):
+        bbox = BoundingBox(-1, 10, 2, 20)
+        bbox.slices
+
+    with pytest.raises(ValueError):
+        bbox = BoundingBox(1, 10, -2, 20)
+        bbox.slices
 
 
 def test_bounding_box_extent():
     bbox = BoundingBox(1, 10, 2, 20)
-
     assert_allclose(bbox.extent, (0.5, 9.5, 1.5, 19.5))
 
 

--- a/regions/core/tests/test_compound.py
+++ b/regions/core/tests/test_compound.py
@@ -103,6 +103,7 @@ class TestCompoundPixel:
         bbox = (self.c1 | self.c2).bounding_box
         assert bbox == BoundingBox(1, 16, 1, 10)
 
+
 def test_compound_sky():
     skycoord1 = SkyCoord(0 * u.deg, 0 * u.deg, frame='galactic')
     c1 = CircleSkyRegion(skycoord1, 1 * u.deg)
@@ -120,15 +121,18 @@ def test_compound_sky():
     assert c2.contains(test_coord1, wcs) and not c1.contains(test_coord1, wcs)
     assert not c2.contains(test_coord2, wcs) and c1.contains(test_coord2, wcs)
     assert c1.contains(test_coord3, wcs) and c2.contains(test_coord3, wcs)
-    assert not c2.contains(test_coord4, wcs) and not c1.contains(test_coord4, wcs)
+    assert (not c2.contains(test_coord4, wcs)
+            and not c1.contains(test_coord4, wcs))
 
-    coords = SkyCoord([test_coord1, test_coord2, test_coord3, test_coord4], frame='galactic')
+    coords = SkyCoord([test_coord1, test_coord2, test_coord3, test_coord4],
+                      frame='galactic')
 
     union = c1 | c2
     assert (union.contains(coords, wcs) == [True, True, True, False]).all()
 
     intersection = c1 & c2
-    assert (intersection.contains(coords, wcs) == [False, False, True, False]).all()
+    assert ((intersection.contains(coords, wcs)
+             == [False, False, True, False]).all())
 
     diff = c1 ^ c2
     assert (diff.contains(coords, wcs) == [True, True, False, False]).all()
@@ -139,7 +143,8 @@ def test_compound_sky():
     assert (union.contains(coords, wcs) == [True, True, True, True]).all()
 
     intersection = c1 & c2 & c3
-    assert (intersection.contains(coords, wcs) == [False, False, False, False]).all()
+    assert ((intersection.contains(coords, wcs)
+             == [False, False, False, False]).all())
 
     diff = c1 ^ c2 ^ c3
     assert (diff.contains(coords, wcs) == [True, True, False, True]).all()

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -163,8 +163,10 @@ def test_pixcoord_to_sky_array_2d(wcs):
 
     s1 = p1.to_sky(wcs=wcs)
     assert s.name == 'galactic'
-    assert_allclose(s1.data.lon.deg, [[0, 0, 0], [349.88094, 349.88094, 349.88094]])
-    assert_allclose(s1.data.lat.deg, [[0, 0, 0], [10.003028, 10.003028, 10.003028]])
+    assert_allclose(s1.data.lon.deg, [[0, 0, 0],
+                                      [349.88094, 349.88094, 349.88094]])
+    assert_allclose(s1.data.lat.deg, [[0, 0, 0],
+                                      [10.003028, 10.003028, 10.003028]])
     assert_allclose(s.data.lon.deg, [[0, 349.88094]])
     assert_allclose(s.data.lat.deg, [[0, 10.003028]])
 


### PR DESCRIPTION
Negative values in the slices wraparound, which is not what is intended for bounding boxes.