### PR TITLE
Add get_overlap_slices method to BoundingBox

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,10 @@ New Features
 - Added a unified read-write interface for all region formats, inspired
   by and using the same infrastructure as astropy.table. [#307]
 
+- Added a ``get_overlap_slices`` method to ``BoundingBox``. [#348]
+
+- Added a ``center`` attribute to ``BoundingBox``. [#348]
+
 Bug Fixes
 ---------
 
@@ -39,6 +43,11 @@ Bug Fixes
 
 - A ``ValueError`` is now raised when calling ``BoundingBox.slices``
   when ``ixmin`` or ``iymin`` is negative. [#347]
+
+API Changes
+-----------
+
+- Deprecated the ``BoundingBox`` ``slices`` attribute. [#348]
 
 
 0.4 (2019-06-17)

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -1,7 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import numpy as np
+"""
+This module defines a class for a rectangular bounding box.
+"""
+
 from astropy.io.fits.util import _is_int
 from astropy.utils import deprecated
+import numpy as np
 
 __all__ = ['BoundingBox']
 
@@ -119,12 +123,10 @@ class BoundingBox:
             raise TypeError('Can compare BoundingBox only to another '
                             'BoundingBox.')
 
-        return (
-            (self.ixmin == other.ixmin) and
-            (self.ixmax == other.ixmax) and
-            (self.iymin == other.iymin) and
-            (self.iymax == other.iymax)
-        )
+        return ((self.ixmin == other.ixmin)
+                and (self.ixmax == other.ixmax)
+                and (self.iymin == other.iymin)
+                and (self.iymax == other.iymax))
 
     def __or__(self, other):
         return self.union(other)
@@ -152,7 +154,7 @@ class BoundingBox:
         """
         The bounding box as a tuple of `slice` objects.
 
-        The slice tuple is in numpy axis order (i.e. ``(y, x)``) and
+        The slice tuple is in numpy axis order (i.e., ``(y, x)``) and
         therefore can be used to slice numpy arrays.
         """
         if self.iymin < 0 or self.ixmin < 0:
@@ -213,16 +215,12 @@ class BoundingBox:
         pixel.
 
         The upper edges here are the actual pixel positions of the
-        edges, i.e. they are not "exclusive" indices used for python
-        indexing.  This is useful for plotting the bounding box using
+        edges, i.e., they are not "exclusive" indices used for python
+        indexing. This is useful for plotting the bounding box using
         Matplotlib.
         """
-        return (
-            self.ixmin - 0.5,
-            self.ixmax - 0.5,
-            self.iymin - 0.5,
-            self.iymax - 0.5,
-        )
+        return (self.ixmin - 0.5, self.ixmax - 0.5,
+                self.iymin - 0.5, self.iymax - 0.5)
 
     def as_artist(self, **kwargs):
         """
@@ -231,7 +229,7 @@ class BoundingBox:
 
         Parameters
         ----------
-        kwargs : `dict`
+        **kwargs : `dict`
             Any keyword arguments accepted by
             `matplotlib.patches.Patch`.
 
@@ -254,7 +252,6 @@ class BoundingBox:
             ax.imshow(np.random.random((10, 10)), interpolation='nearest', cmap='viridis')
             ax.add_patch(bbox.as_artist(facecolor='none', edgecolor='white', lw=2.))
         """
-
         from matplotlib.patches import Rectangle
 
         return Rectangle(xy=(self.extent[0], self.extent[2]),
@@ -265,7 +262,6 @@ class BoundingBox:
         Return a `~regions.RectanglePixelRegion` that
         represents the bounding box.
         """
-
         from ..shapes import RectanglePixelRegion
         from .pixcoord import PixCoord
 
@@ -289,7 +285,7 @@ class BoundingBox:
         ax : `matplotlib.axes.Axes` instance, optional
             If `None`, then the current `~matplotlib.axes.Axes` instance
             is used.
-        kwargs : `dict`
+        **kwargs : `dict`
             Any keyword arguments accepted by `matplotlib.patches.Patch`.
 
         Returns
@@ -297,7 +293,6 @@ class BoundingBox:
         ax : `~matplotlib.axes.Axes`
             Axes on which the patch is added.
         """
-
         reg = self.to_region()
         return reg.plot(origin=origin, ax=ax, **kwargs)
 

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -161,6 +161,50 @@ class BoundingBox:
                              'negative')
         return slice(self.iymin, self.iymax), slice(self.ixmin, self.ixmax)
 
+    def get_overlap_slices(self, shape):
+        """
+        Get slices for the overlapping part of the bounding box and an
+        2D array.
+
+        Parameters
+        ----------
+        shape : 2-tuple of int
+            The shape of the 2D array.
+
+        Returns
+        -------
+        slices_large : tuple of slices or `None`
+            A tuple of slice objects for each axis of the large array,
+            such that ``large_array[slices_large]`` extracts the region
+            of the large array that overlaps with the small array.
+            `None` is returned if there is no overlap of the bounding
+            box with the given image shape.
+        slices_small : tuple of slices or `None`
+            A tuple of slice objects for each axis of an array enclosed
+            by the bounding box such that ``small_array[slices_small]``
+            extracts the region that is inside the large array. `None`
+            is returned if there is no overlap of the bounding box with
+            the given image shape.
+        """
+        if len(shape) != 2:
+            raise ValueError('input shape must have 2 elements.')
+
+        xmin = self.ixmin
+        xmax = self.ixmax
+        ymin = self.iymin
+        ymax = self.iymax
+        if xmin >= shape[1] or ymin >= shape[0] or xmax <= 0 or ymax <= 0:
+            # no overlap of the bounding box with the input shape
+            return None, None
+
+        slices_large = (slice(max(ymin, 0), min(ymax, shape[0])),
+                        slice(max(xmin, 0), min(xmax, shape[1])))
+        slices_small = (slice(max(-ymin, 0),
+                              min(ymax - ymin, shape[0] - ymin)),
+                        slice(max(-xmin, 0),
+                              min(xmax - xmin, shape[1] - xmin)))
+        return slices_large, slices_small
+
     @property
     def extent(self):
         """

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 from astropy.io.fits.util import _is_int
-
+from astropy.utils import deprecated
 
 __all__ = ['BoundingBox']
 
@@ -37,11 +37,9 @@ class BoundingBox:
     >>> bbox == BoundingBox(ixmin=7, ixmax=10, iymin=2, iymax=20)
     False
 
-    >>> # "shape" and "slices" can be useful when working with numpy arrays
+    >>> # "shape" can be useful when working with numpy arrays
     >>> bbox.shape  # numpy order: (y, x)
     (18, 9)
-    >>> bbox.slices  # numpy order: (y, x)
-    (slice(2, 20, None), slice(1, 10, None))
 
     >>> # "extent" is useful when plotting the BoundingBox with matplotlib
     >>> bbox.extent  # matplotlib order: (x, y)
@@ -149,6 +147,7 @@ class BoundingBox:
         return self.iymax - self.iymin, self.ixmax - self.ixmin
 
     @property
+    @deprecated('0.5', alternative='get_overlap_slices')
     def slices(self):
         """
         The bounding box as a tuple of `slice` objects.

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -41,7 +41,9 @@ class BoundingBox:
     >>> bbox == BoundingBox(ixmin=7, ixmax=10, iymin=2, iymax=20)
     False
 
-    >>> # "shape" can be useful when working with numpy arrays
+    >>> # "center" and "shape" can be useful when working with numpy arrays
+    >>> bbox.center  # numpy order: (y, x)
+    (10.5, 5.0)
     >>> bbox.shape  # numpy order: (y, x)
     (18, 9)
 
@@ -142,6 +144,14 @@ class BoundingBox:
         return fmt.format(**data)
 
     @property
+    def center(self):
+        """
+        The ``(y, x)`` center of the bounding box.
+        """
+        return (0.5 * (self.iymax - 1 + self.iymin),
+                0.5 * (self.ixmax - 1 + self.ixmin))
+
+    @property
     def shape(self):
         """
         The ``(ny, nx)`` shape of the bounding box.
@@ -180,6 +190,7 @@ class BoundingBox:
             of the large array that overlaps with the small array.
             `None` is returned if there is no overlap of the bounding
             box with the given image shape.
+
         slices_small : tuple of slices or `None`
             A tuple of slice objects for each axis of an array enclosed
             by the bounding box such that ``small_array[slices_small]``
@@ -194,6 +205,7 @@ class BoundingBox:
         xmax = self.ixmax
         ymin = self.iymin
         ymax = self.iymax
+
         if xmin >= shape[1] or ymin >= shape[0] or xmax <= 0 or ymax <= 0:
             # no overlap of the bounding box with the input shape
             return None, None
@@ -204,6 +216,7 @@ class BoundingBox:
                               min(ymax - ymin, shape[0] - ymin)),
                         slice(max(-xmin, 0),
                               min(xmax - xmin, shape[1] - xmin)))
+
         return slices_large, slices_small
 
     @property
@@ -265,12 +278,9 @@ class BoundingBox:
         from ..shapes import RectanglePixelRegion
         from .pixcoord import PixCoord
 
-        xpos = (self.extent[1] + self.extent[0]) / 2.
-        ypos = (self.extent[3] + self.extent[2]) / 2.
-        xypos = PixCoord(xpos, ypos)
-        h, w = self.shape
-
-        return RectanglePixelRegion(center=xypos, width=w, height=h)
+        xypos = PixCoord(*self.center[::-1])
+        height, width = self.shape
+        return RectanglePixelRegion(center=xypos, width=width, height=height)
 
     def plot(self, origin=(0, 0), ax=None, **kwargs):
         """

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -261,9 +261,11 @@ class BoundingBox:
             bbox = BoundingBox(2, 7, 3, 8)
             fig = plt.figure()
             ax = fig.add_subplot(1, 1, 1)
-            np.random.seed(12345)
-            ax.imshow(np.random.random((10, 10)), interpolation='nearest', cmap='viridis')
-            ax.add_patch(bbox.as_artist(facecolor='none', edgecolor='white', lw=2.))
+            rng = np.random.default_rng(0)
+            ax.imshow(rng.random((10, 10)), interpolation='nearest',
+                      cmap='viridis')
+            ax.add_patch(bbox.as_artist(facecolor='none', edgecolor='white',
+                         lw=2.))
         """
         from matplotlib.patches import Rectangle
 

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -77,6 +77,11 @@ def test_bounding_box_shape():
     assert bbox.shape == (18, 9)
 
 
+def test_bounding_box_center():
+    bbox = BoundingBox(1, 10, 2, 20)
+    assert bbox.center == (10.5, 5)
+
+
 def test_bounding_box_get_overlap_slices():
     bbox = BoundingBox(1, 10, 2, 20)
     slc = ((slice(2, 20, None), slice(1, 10, None)),

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose
 import pytest
 
@@ -93,7 +94,8 @@ def test_bounding_box_get_overlap_slices():
 
 def test_bounding_box_slices():
     bbox = BoundingBox(1, 10, 2, 20)
-    assert bbox.slices == (slice(2, 20), slice(1, 10))
+    with pytest.warns(AstropyDeprecationWarning):
+        assert bbox.slices == (slice(2, 20), slice(1, 10))
 
     with pytest.raises(ValueError):
         bbox = BoundingBox(-1, 10, 2, 20)

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -1,9 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the bounding_box module.
+"""
+
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from numpy.testing import assert_allclose
 import pytest
 
 from ..bounding_box import BoundingBox
+from ..pixcoord import PixCoord
+from ...shapes import RectanglePixelRegion
 
 try:
     import matplotlib  # noqa
@@ -14,7 +20,6 @@ except ImportError:
 
 def test_bounding_box_init():
     bbox = BoundingBox(1, 10, 2, 20)
-
     assert bbox.ixmin == 1
     assert bbox.ixmax == 10
     assert bbox.iymin == 2
@@ -56,24 +61,23 @@ def test_bounding_box_from_float():
 
 def test_bounding_box_eq():
     bbox = BoundingBox(1, 10, 2, 20)
-    assert bbox == bbox
-
+    assert bbox == BoundingBox(1, 10, 2, 20)
     assert bbox != BoundingBox(9, 10, 2, 20)
     assert bbox != BoundingBox(1, 99, 2, 20)
     assert bbox != BoundingBox(1, 10, 9, 20)
     assert bbox != BoundingBox(1, 10, 2, 99)
 
+    with pytest.raises(TypeError):
+        assert bbox == (1, 10, 2, 20)
+
 
 def test_bounding_box_repr():
     bbox = BoundingBox(1, 10, 2, 20)
-
     assert repr(bbox) == 'BoundingBox(ixmin=1, ixmax=10, iymin=2, iymax=20)'
-    assert eval(repr(bbox)) == bbox
 
 
 def test_bounding_box_shape():
     bbox = BoundingBox(1, 10, 2, 20)
-
     assert bbox.shape == (18, 9)
 
 
@@ -104,11 +108,11 @@ def test_bounding_box_slices():
 
     with pytest.raises(ValueError):
         bbox = BoundingBox(-1, 10, 2, 20)
-        bbox.slices
+        _ = bbox.slices
 
     with pytest.raises(ValueError):
         bbox = BoundingBox(1, 10, -2, 20)
-        bbox.slices
+        _ = bbox.slices
 
 
 def test_bounding_box_extent():
@@ -119,11 +123,29 @@ def test_bounding_box_extent():
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
 def test_bounding_box_as_artist():
     bbox = BoundingBox(1, 10, 2, 20)
-
     patch = bbox.as_artist()
+
     assert_allclose(patch.get_xy(), (0.5, 1.5))
     assert_allclose(patch.get_width(), 9)
     assert_allclose(patch.get_height(), 18)
+
+
+@pytest.mark.skipif('not HAS_MATPLOTLIB')
+def test_bounding_box_to_region():
+    bbox = BoundingBox(1, 10, 2, 20)
+    region = RectanglePixelRegion(PixCoord(5.0, 10.5), width=9., height=18.)
+    bbox_region = bbox.to_region()
+    assert_allclose(bbox_region.center.xy, region.center.xy)
+    assert bbox_region.width == region.width
+    assert bbox_region.height == region.height
+    assert bbox_region.angle == region.angle
+
+
+@pytest.mark.skipif('not HAS_MATPLOTLIB')
+def test_bounding_box_plot():
+    # TODO: check the content of the plot
+    bbox = BoundingBox(1, 10, 2, 20)
+    bbox.plot()
 
 
 def test_bounding_box_union():

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -76,6 +76,21 @@ def test_bounding_box_shape():
     assert bbox.shape == (18, 9)
 
 
+def test_bounding_box_get_overlap_slices():
+    bbox = BoundingBox(1, 10, 2, 20)
+    slc = ((slice(2, 20, None), slice(1, 10, None)),
+           (slice(0, 18, None), slice(0, 9, None)))
+    assert bbox.get_overlap_slices((50, 50)) == slc
+
+    bbox = BoundingBox(-10, -1, 2, 20)
+    assert bbox.get_overlap_slices((50, 50)) == (None, None)
+
+    bbox = BoundingBox(-10, 10, -10, 20)
+    slc = ((slice(0, 20, None), slice(0, 10, None)),
+           (slice(10, 30, None), slice(10, 20, None)))
+    assert bbox.get_overlap_slices((50, 50)) == slc
+
+
 def test_bounding_box_slices():
     bbox = BoundingBox(1, 10, 2, 20)
     assert bbox.slices == (slice(2, 20), slice(1, 10))


### PR DESCRIPTION
This PR adds to `BoundingBox`:

* A `get_overlap_slices` method
* A `center` attribute 

This functionality is already in `photutils` `BoundingBox`.

EDIT:  This PR also deprecates the flawed `slices` attribute.