### PR TITLE
Refactor/cleanup RegionMask

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ New Features
 
 - Added a ``center`` attribute to ``BoundingBox``. [#348]
 
+- Added ``get_overlap_slices`` method to ``RegionMask``. [#350]
+
 Bug Fixes
 ---------
 

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -110,6 +110,34 @@ class RegionMask:
 
         return image
 
+    def get_overlap_slices(self, shape):
+        """
+        Get slices for the overlapping part of the aperture mask and a
+        2D array.
+
+        Parameters
+        ----------
+        shape : 2-tuple of int
+            The shape of the 2D array.
+
+        Returns
+        -------
+        slices_large : tuple of slices or `None`
+            A tuple of slice objects for each axis of the large array,
+            such that ``large_array[slices_large]`` extracts the region
+            of the large array that overlaps with the small array.
+            `None` is returned if there is no overlap of the bounding
+            box with the given image shape.
+
+        slices_small : tuple of slices or `None`
+            A tuple of slice objects for each axis of the aperture mask
+            array such that ``small_array[slices_small]`` extracts the
+            region that is inside the large array. `None` is returned if
+            there is no overlap of the bounding box with the given image
+            shape.
+        """
+        return self.bbox.get_overlap_slices(shape)
+
     def to_image(self, shape):
         """
         Return an image of the mask in a 2D array of the given shape,

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This module defines a class for region masks.
+"""
 import numpy as np
 import astropy.units as u
-
 
 __all__ = ['RegionMask']
 
@@ -13,13 +15,14 @@ class RegionMask:
     Parameters
     ----------
     data : array_like
-        A 2D array of a region mask representing the fractional overlap
-        of the region on the pixel grid.  This should be the full-sized
-        (i.e. not truncated) array that is the direct output of one of
-        the low-level "geometry" functions.
+        A 2D array representing the fractional overlap of a region
+        on the pixel grid. This should be the full-sized (i.e., not
+        truncated) array that is the direct output of one of the
+        low-level "geometry" functions.
 
     bbox : `regions.BoundingBox`
-        The bounding box for the region.
+        The bounding box object defining the region minimal bounding
+        box.
 
     Examples
     --------
@@ -31,7 +34,7 @@ class RegionMask:
         self.data = np.asanyarray(data)
         if self.data.shape != bbox.shape:
             raise ValueError('mask data and bounding box must have the same '
-                             'shape.')
+                             'shape')
         self.bbox = bbox
         self._mask = (self.data == 0)
 
@@ -127,7 +130,7 @@ class RegionMask:
             array will be a view into the input ``data``.  In cases
             where the mask partially overlaps or has no overlap with the
             input ``data``, the returned cutout array will always hold a
-            copy of the input ``data`` (i.e. this keyword has no
+            copy of the input ``data`` (i.e., this keyword has no
             effect).
 
         Returns
@@ -145,7 +148,7 @@ class RegionMask:
             raise ValueError('data must be a 2D array.')
 
         # find the overlap of the mask on the output image shape
-        slices_large, slices_small = self.bbox.get_overlap_slices(data.shape)
+        slices_large, slices_small = self.get_overlap_slices(data.shape)
 
         if slices_small is None:
             return None  # no overlap
@@ -205,8 +208,7 @@ class RegionMask:
         else:
             weighted_cutout = cutout * self.data
 
-            # needed to zero out non-finite data values outside of the
-            # mask but within the bounding box
+            # fill values outside of the mask but within the bounding box
             weighted_cutout[self._mask] = fill_value
 
             return weighted_cutout

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -49,67 +49,6 @@ class RegionMask:
         """
         return self.data.shape
 
-    def _overlap_slices(self, shape):
-        """
-        Calculate the slices for the overlapping part of the bounding
-        box and an array of the given shape.
-
-        Parameters
-        ----------
-        shape : tuple of int
-            The ``(ny, nx)`` shape of array where the slices are to be
-            applied.
-
-        Returns
-        -------
-        slices_large : tuple of slices
-            A tuple of slice objects for each axis of the large array,
-            such that ``large_array[slices_large]`` extracts the region
-            of the large array that overlaps with the small array.
-
-        slices_small : slice
-            A tuple of slice objects for each axis of the small array,
-            such that ``small_array[slices_small]`` extracts the region
-            of the small array that is inside the large array.
-        """
-        if len(shape) != 2:
-            raise ValueError('input shape must have 2 elements.')
-
-        xmin = self.bbox.ixmin
-        xmax = self.bbox.ixmax
-        ymin = self.bbox.iymin
-        ymax = self.bbox.iymax
-
-        if xmin >= shape[1] or ymin >= shape[0] or xmax <= 0 or ymax <= 0:
-            # no overlap of the region with the data
-            return None, None
-
-        slices_large = (slice(max(ymin, 0), min(ymax, shape[0])),
-                        slice(max(xmin, 0), min(xmax, shape[1])))
-
-        slices_small = (slice(max(-ymin, 0),
-                              min(ymax - ymin, shape[0] - ymin)),
-                        slice(max(-xmin, 0),
-                              min(xmax - xmin, shape[1] - xmin)))
-
-        return slices_large, slices_small
-
-    def _to_image_partial_overlap(self, image):
-        """
-        Return an image of the mask in a 2D array, where the mask
-        is not fully within the image (i.e. partial or no overlap).
-        """
-        # find the overlap of the mask on the output image shape
-        slices_large, slices_small = self._overlap_slices(image.shape)
-
-        if slices_small is None:
-            return None    # no overlap
-
-        # insert the mask into the output image
-        image[slices_large] = self.data[slices_small]
-
-        return image
-
     def get_overlap_slices(self, shape):
         """
         Get slices for the overlapping part of the aperture mask and a
@@ -156,16 +95,15 @@ class RegionMask:
         if len(shape) != 2:
             raise ValueError('input shape must have 2 elements.')
 
+        # find the overlap of the mask on the output image shape
+        slices_large, slices_small = self.get_overlap_slices(shape)
+
+        if slices_small is None:
+            return None  # no overlap
+
+        # insert the mask into the output image
         image = np.zeros(shape)
-
-        if self.bbox.ixmin < 0 or self.bbox.iymin < 0:
-            return self._to_image_partial_overlap(image)
-
-        try:
-            image[self.bbox.slices] = self.data
-        except ValueError:    # partial or no overlap
-            image = self._to_image_partial_overlap(image)
-
+        image[slices_large] = self.data[slices_small]
         return image
 
     def cutout(self, data, fill_value=0., copy=False):
@@ -206,35 +144,32 @@ class RegionMask:
         if data.ndim != 2:
             raise ValueError('data must be a 2D array.')
 
-        partial_overlap = False
-        if self.bbox.ixmin < 0 or self.bbox.iymin < 0:
-            partial_overlap = True
+        # find the overlap of the mask on the output image shape
+        slices_large, slices_small = self.bbox.get_overlap_slices(data.shape)
 
-        if not partial_overlap:
-            # try this for speed -- the result may still be a partial
-            # overlap, in which case the next block will be triggered
+        if slices_small is None:
+            return None  # no overlap
+
+        cutout_shape = (slices_small[0].stop - slices_small[0].start,
+                        slices_small[1].stop - slices_small[1].start)
+
+        if cutout_shape == self.shape:
+            cutout = data[slices_large]
             if copy:
-                cutout = np.copy(data[self.bbox.slices])
-            else:
-                cutout = data[self.bbox.slices]
+                cutout = np.copy(cutout)
+            return cutout
 
-        if partial_overlap or (cutout.shape != self.shape):
-            slices_large, slices_small = self._overlap_slices(data.shape)
+        # cutout is always a copy for partial overlap
+        if ~np.isfinite(fill_value):
+            dtype = float
+        else:
+            dtype = data.dtype
+        cutout = np.zeros(self.shape, dtype=dtype)
+        cutout[:] = fill_value
+        cutout[slices_small] = data[slices_large]
 
-            if slices_small is None:
-                return None    # no overlap
-
-            # cutout is always a copy for partial overlap
-            if ~np.isfinite(fill_value):
-                dtype = float
-            else:
-                dtype = data.dtype
-            cutout = np.zeros(self.shape, dtype=dtype)
-            cutout[:] = fill_value
-            cutout[slices_small] = data[slices_large]
-
-            if isinstance(data, u.Quantity):
-                cutout = u.Quantity(cutout, unit=data.unit)
+        if isinstance(data, u.Quantity):
+            cutout <<= data.unit
 
         return cutout
 

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -159,7 +159,9 @@ class RegionMask:
         if cutout_shape == self.shape:
             cutout = data[slices_large]
             if copy:
-                cutout = np.copy(cutout)
+                # NOTE: np.copy() doesn't work with Quantity for
+                # astropy 3.2.3
+                cutout = cutout.copy()
             return cutout
 
         # cutout is always a copy for partial overlap

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -106,13 +106,15 @@ def test_bounding_box_slices():
     with pytest.warns(AstropyDeprecationWarning):
         assert bbox.slices == (slice(2, 20), slice(1, 10))
 
-    with pytest.raises(ValueError):
-        bbox = BoundingBox(-1, 10, 2, 20)
-        _ = bbox.slices
+    with pytest.warns(AstropyDeprecationWarning):
+        with pytest.raises(ValueError):
+            bbox = BoundingBox(-1, 10, 2, 20)
+            _ = bbox.slices
 
-    with pytest.raises(ValueError):
-        bbox = BoundingBox(1, 10, -2, 20)
-        _ = bbox.slices
+    with pytest.warns(AstropyDeprecationWarning):
+        with pytest.raises(ValueError):
+            bbox = BoundingBox(1, 10, -2, 20)
+            _ = bbox.slices
 
 
 def test_bounding_box_extent():

--- a/regions/core/tests/test_mask.py
+++ b/regions/core/tests/test_mask.py
@@ -128,3 +128,11 @@ def test_mask_multiply_fill_value():
     xypos = ((20, 20), (5, 5), (5, 35), (35, 5), (35, 35))
     for x, y in xypos:
         assert np.isnan(cutout[y, x])
+
+
+def test_mask_get_overlap_slices():
+    aper = CirclePixelRegion(PixCoord(5, 5), radius=10.)
+    mask = aper.to_mask()
+    slc = ((slice(0, 16, None), slice(0, 16, None)),
+           (slice(5, 21, None), slice(5, 21, None)))
+    assert mask.get_overlap_slices((25, 25)) == slc

--- a/regions/core/tests/test_mask.py
+++ b/regions/core/tests/test_mask.py
@@ -1,19 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the mask module.
+"""
+
+import astropy.units as u
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_almost_equal
 import pytest
 
 from ..bounding_box import BoundingBox
 from ..mask import RegionMask
 from ..pixcoord import PixCoord
 from ...shapes import CirclePixelRegion, CircleAnnulusPixelRegion
-
-try:
-    import matplotlib    # noqa
-    HAS_MATPLOTLIB = True
-except ImportError:
-    HAS_MATPLOTLIB = False
-
 
 POSITIONS = [(-20, -20), (-20, 20), (20, -20), (60, 60)]
 
@@ -33,6 +31,14 @@ def test_mask_array():
     assert_allclose(data, mask.data)
 
 
+def test_mask_get_overlap_slices():
+    aper = CirclePixelRegion(PixCoord(5, 5), radius=10.)
+    mask = aper.to_mask()
+    slc = ((slice(0, 16, None), slice(0, 16, None)),
+           (slice(5, 21, None), slice(5, 21, None)))
+    assert mask.get_overlap_slices((25, 25)) == slc
+
+
 def test_mask_cutout_shape():
     mask_data = np.ones((10, 10))
     bbox = BoundingBox(5, 15, 5, 15)
@@ -40,9 +46,6 @@ def test_mask_cutout_shape():
 
     with pytest.raises(ValueError):
         mask.cutout(np.arange(10))
-
-    with pytest.raises(ValueError):
-        mask._overlap_slices((10,))
 
     with pytest.raises(ValueError):
         mask.to_image((10,))
@@ -55,6 +58,13 @@ def test_mask_cutout_copy():
     cutout = mask.cutout(data, copy=True)
     data[25, 25] = 100.
     assert cutout[10, 10] == 1.
+
+    # test quantity data
+    data2 = np.ones((50, 50)) * u.adu
+    cutout2 = mask.cutout(data2, copy=True)
+    assert cutout2.unit == data2.unit
+    data2[25, 25] = 100. * u.adu
+    assert cutout2[10, 10].value == 1.
 
 
 @pytest.mark.parametrize('position', POSITIONS)
@@ -89,28 +99,31 @@ def test_mask_cutout_partial_overlap(position):
     assert image.shape == data.shape
 
 
-def test_mask_nan_in_bbox():
-    """
-    Regression test that non-finite data values outside of the mask but
-    within the bounding box are set to zero.
-    """
+def test_mask_multiply():
+    radius = 10.
+    data = np.ones((50, 50))
+    region = CirclePixelRegion(PixCoord(25, 25), radius=radius)
+    mask = region.to_mask(mode='exact')
+    data_weighted = mask.multiply(data)
+    assert_almost_equal(np.sum(data_weighted), np.pi * radius**2)
 
-    data = np.ones((101, 101))
-    data[33, 33] = np.nan
-    data[67, 67] = np.inf
-    data[33, 67] = -np.inf
-    data[22, 22] = np.nan
-    data[22, 23] = np.inf
+    # test that multiply() returns a copy
+    data[25, 25] = 100.
+    assert data_weighted[10, 10] == 1.
 
-    radius = 20.
-    reg1 = CirclePixelRegion(PixCoord(50, 50), radius)
-    reg2 = CirclePixelRegion(PixCoord(5, 5), radius)
 
-    wdata1 = reg1.to_mask(mode='exact').multiply(data)
-    assert_allclose(np.sum(wdata1), np.pi * radius**2)
+def test_mask_multiply_quantity():
+    radius = 10.
+    data = np.ones((50, 50)) * u.adu
+    region = CirclePixelRegion(PixCoord(25, 25), radius=radius)
+    mask = region.to_mask(mode='exact')
+    data_weighted = mask.multiply(data)
+    assert data_weighted.unit == u.adu
+    assert_almost_equal(np.sum(data_weighted.value), np.pi * radius**2)
 
-    wdata2 = reg2.to_mask(mode='exact').multiply(data)
-    assert_allclose(np.sum(wdata2), 561.6040111923013)
+    # test that multiply() returns a copy
+    data[25, 25] = 100. * u.adu
+    assert data_weighted[10, 10].value == 1.
 
 
 @pytest.mark.parametrize('value', (np.nan, np.inf))
@@ -130,9 +143,24 @@ def test_mask_multiply_fill_value():
         assert np.isnan(cutout[y, x])
 
 
-def test_mask_get_overlap_slices():
-    aper = CirclePixelRegion(PixCoord(5, 5), radius=10.)
-    mask = aper.to_mask()
-    slc = ((slice(0, 16, None), slice(0, 16, None)),
-           (slice(5, 21, None), slice(5, 21, None)))
-    assert mask.get_overlap_slices((25, 25)) == slc
+def test_mask_nonfinite_in_bbox():
+    """
+    Regression test that non-finite data values outside of the mask but
+    within the bounding box are set to zero.
+    """
+    data = np.ones((101, 101))
+    data[33, 33] = np.nan
+    data[67, 67] = np.inf
+    data[33, 67] = -np.inf
+    data[22, 22] = np.nan
+    data[22, 23] = np.inf
+
+    radius = 20.
+    reg1 = CirclePixelRegion(PixCoord(50, 50), radius)
+    reg2 = CirclePixelRegion(PixCoord(5, 5), radius)
+
+    wdata1 = reg1.to_mask(mode='exact').multiply(data)
+    assert_allclose(np.sum(wdata1), np.pi * radius**2)
+
+    wdata2 = reg2.to_mask(mode='exact').multiply(data)
+    assert_allclose(np.sum(wdata2), 561.6040111923013)


### PR DESCRIPTION
This PR simplifies `RegionMask` by adding a `get_overlap_slices` method.  Based on improvements originally implemented and tested in `photutils`.