### PR TITLE
Add get_values method to RegionMask

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@ New Features
 
 - Added ``get_overlap_slices`` method to ``RegionMask``. [#350]
 
+- Added ``get_values`` method to ``RegionMask``. [#351]
+
 Bug Fixes
 ---------
 

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -2,6 +2,8 @@
 """
 This module defines a class for region masks.
 """
+import warnings
+
 import numpy as np
 import astropy.units as u
 

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -56,7 +56,7 @@ class RegionMask:
 
     def get_overlap_slices(self, shape):
         """
-        Get slices for the overlapping part of the aperture mask and a
+        Get slices for the overlapping part of the region mask and a
         2D array.
 
         Parameters
@@ -74,7 +74,7 @@ class RegionMask:
             box with the given image shape.
 
         slices_small : tuple of slices or `None`
-            A tuple of slice objects for each axis of the aperture mask
+            A tuple of slice objects for each axis of the region mask
             array such that ``small_array[slices_small]`` extracts the
             region that is inside the large array. `None` is returned if
             there is no overlap of the bounding box with the given image
@@ -221,9 +221,10 @@ class RegionMask:
         """
         Get the mask-weighted pixel values from the data as a 1D array.
 
-        If the ``ApertureMask`` was created with ``method='center'``,
-        (where the mask weights are only 1 or 0), then the returned
-        values will simply be pixel values extracted from the data.
+        If the `~regions.core.RegionMask` was created with
+        ``mode='center'``, (where the mask weights are only 1 or 0),
+        then the returned values will simply be pixel values extracted
+        from the data.
 
         Parameters
         ----------
@@ -239,7 +240,7 @@ class RegionMask:
         -------
         result : `~numpy.ndarray`
             A 1D array of mask-weighted pixel values from the input
-            ``data``. If there is no overlap of the aperture with the
+            ``data``. If there is no overlap of the region with the
             input ``data``, the result will be a 1-element array of
             ``numpy.nan``.
         """
@@ -247,8 +248,8 @@ class RegionMask:
         if slc_large is None:
             return np.array([np.nan])
         cutout = data[slc_large]
-        apermask = self.data[slc_small]
-        pixel_mask = (apermask > 0)  # good pixels
+        region_mask = self.data[slc_small]
+        pixel_mask = (region_mask > 0)  # good pixels
 
         if mask is not None:
             if mask.shape != data.shape:
@@ -258,4 +259,4 @@ class RegionMask:
         # ignore multiplication with inf data values
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', RuntimeWarning)
-            return (cutout * apermask)[pixel_mask]
+            return (cutout * region_mask)[pixel_mask]

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -214,3 +214,46 @@ class RegionMask:
             weighted_cutout[self._mask] = fill_value
 
             return weighted_cutout
+
+    def get_values(self, data, mask=None):
+        """
+        Get the mask-weighted pixel values from the data as a 1D array.
+
+        If the ``ApertureMask`` was created with ``method='center'``,
+        (where the mask weights are only 1 or 0), then the returned
+        values will simply be pixel values extracted from the data.
+
+        Parameters
+        ----------
+        data : array_like or `~astropy.units.Quantity`
+            The 2D array from which to get mask-weighted values.
+
+        mask : array_like (bool), optional
+            A boolean mask with the same shape as ``data`` where a
+            `True` value indicates the corresponding element of ``data``
+            is not returned in the result.
+
+        Returns
+        -------
+        result : `~numpy.ndarray`
+            A 1D array of mask-weighted pixel values from the input
+            ``data``. If there is no overlap of the aperture with the
+            input ``data``, the result will be a 1-element array of
+            ``numpy.nan``.
+        """
+        slc_large, slc_small = self.get_overlap_slices(data.shape)
+        if slc_large is None:
+            return np.array([np.nan])
+        cutout = data[slc_large]
+        apermask = self.data[slc_small]
+        pixel_mask = (apermask > 0)  # good pixels
+
+        if mask is not None:
+            if mask.shape != data.shape:
+                raise ValueError('mask and data must have the same shape')
+            pixel_mask &= ~mask[slc_large]
+
+        # ignore multiplication with inf data values
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            return (cutout * apermask)[pixel_mask]

--- a/regions/core/tests/test_mask.py
+++ b/regions/core/tests/test_mask.py
@@ -166,21 +166,15 @@ def test_mask_nonfinite_in_bbox():
     assert_allclose(np.sum(wdata2), 561.6040111923013)
 
 
-def test_mask_get_values():
-    x = (0, 50, 100)
-    y = (0, 50, 100)
+@pytest.mark.parametrize('x, y, exp_shape',
+                         [(0, 0, 245), (50, 50, 940), (100, 100, 245)])
+def test_mask_get_values(x, y, exp_shape):
     aper = CircleAnnulusPixelRegion(PixCoord(x, y), inner_radius=10,
                                     outer_radius=20)
     data = np.ones((101, 101))
-    values = [mask.get_values(data) for mask in
-              aper.to_mask(mode='exact')]
-    shapes = [val.shape for val in values]
-    sums = [np.sum(val) for val in values]
-    assert shapes[0] == (278,)
-    assert shapes[1] == (1068,)
-    assert shapes[2] == (278,)
-    sums_expected = (245.621534, 942.477796, 245.621534)
-    assert_allclose(sums, sums_expected)
+    values = aper.to_mask(mode='center').get_values(data)
+    assert values.shape == (exp_shape,)
+    assert_allclose(np.sum(values), exp_shape)
 
 
 def test_mask_get_values_no_overlap():


### PR DESCRIPTION
This PR adds a `get_values` method to `RegionMask` that returns mask-weighted pixel values as a 1D array.  If the `RegionMask` was created with `mode='center'` (i.e., where the weights are 0 or 1), then the returned values will simply be the pixel values from the data.  This has been an oft-requested feature.