### PR TITLE
Return an empty array for no aperture overlap

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ New Features
 
 - Added ``get_overlap_slices`` method to ``RegionMask``. [#350]
 
-- Added ``get_values`` method to ``RegionMask``. [#351]
+- Added ``get_values`` method to ``RegionMask``. [#351, #353]
 
 Bug Fixes
 ---------

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -241,12 +241,12 @@ class RegionMask:
         result : `~numpy.ndarray`
             A 1D array of mask-weighted pixel values from the input
             ``data``. If there is no overlap of the region with the
-            input ``data``, the result will be a 1-element array of
-            ``numpy.nan``.
+            input ``data``, the result will be an empty array with shape
+            (0,).
         """
         slc_large, slc_small = self.get_overlap_slices(data.shape)
         if slc_large is None:
-            return np.array([np.nan])
+            return np.array([])
         cutout = data[slc_large]
         region_mask = self.data[slc_small]
         pixel_mask = (region_mask > 0)  # good pixels

--- a/regions/core/tests/test_mask.py
+++ b/regions/core/tests/test_mask.py
@@ -181,8 +181,7 @@ def test_mask_get_values_no_overlap():
     aper = CirclePixelRegion(PixCoord(-100, -100), radius=3)
     data = np.ones((51, 51))
     values = aper.to_mask().get_values(data)
-    assert values.size == 1
-    assert np.isnan(values[0])
+    assert values.shape == (0,)
 
 
 def test_mask_get_values_mask():


### PR DESCRIPTION
This PR updates `RegionMask.get_values()` to return an empty array if there is no overlap with the data.