### PR TITLE
Remove build_docs from Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,10 +46,6 @@ jobs:
     - linux32: py36-test-astropy32-cov
     - windows: py36-test-astropy40-cov
 
-    # Documentation builds
-    - linux: build_docs
-    - windows: build_docs
-
 - template: publish.yml@OpenAstronomy
   parameters:
     test_command: pytest -p no:warnings --pyargs regions


### PR DESCRIPTION
I've configured the repo to use RTD for pull requests.