### PR TITLE
Fix crtf parser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,9 @@ Bug Fixes
   width would raise a ``ValueError`` when creating a ``RegionMask``.
   [#363]
 
+- Fixed parsing CRTF regions files that do not have a comma after the
+  region. [#364]
+
 API Changes
 -----------
 

--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -36,7 +36,7 @@ regex_meta = re.compile(r'(?:(\w+)\s*=[\s\'\"]*([^,\[\]]+?)[\'\",]+)|(?:(\w+)\s*
 regex_region = re.compile(r'(?P<include>[+-])?(?P<type>ann(?=\s))?\s*(?P<regiontype>[a-z]*?)\s?\[[^=]*]')
 
 # Line format which checks the validity of the line and segregates the meta attributes from the region format.
-regex_line = re.compile(r'(?P<region>[+-]?(?:ann(?=\s))?\s*[a-z]+?\s?\[[^=]+\])(?:\s*[,]\s*(?P<parameters>.*))?')
+regex_line = re.compile(r'(?P<region>[+-]?(?:ann(?=\s))?\s*[a-z]+?\s?\[[^=]+\])(?:\s*,?\s*(?P<parameters>.*))?')
 
 
 def read_crtf(filename, errors='strict'):

--- a/regions/io/crtf/tests/test_crtf_language.py
+++ b/regions/io/crtf/tests/test_crtf_language.py
@@ -166,3 +166,16 @@ def test_space_after_regname():
     parser = CRTFParser(reg_str)
     reg = parser.shapes.to_regions()[0]
     assert isinstance(reg, CircleSkyRegion)
+
+
+def test_no_comma_after_region():
+    reg_str = 'circle [[42deg, 43deg], 3deg] coord=J2000, color=green'
+    parser = CRTFParser(reg_str)
+    reg = parser.shapes.to_regions()[0]
+    assert isinstance(reg, CircleSkyRegion)
+    assert reg.center.ra.value == 42.0
+    assert reg.center.ra.unit == 'deg'
+    assert reg.center.dec.value == 43.0
+    assert reg.center.dec.unit == 'deg'
+    assert reg.radius.value == 3.0
+    assert reg.radius.unit == 'deg'


### PR DESCRIPTION
This PR fixes the parsing of CRTF region strings that do not have a comma after the region (i.e., before the `coord`).

For example, 
```
reg_str = 'circle [[42deg, 43deg], 3deg] coord=J2000, color=green'
```
and
```
reg_str = 'circle [[42deg, 43deg], 3deg], coord=J2000, color=green'
```

are valid.