### PR TITLE
Skip doctests that write files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,3 @@ pip-wheel-metadata
 
 # Mac OSX
 .DS_Store
-
-# Generated in doctests
-docs/*.reg
-docs/*.crtf
-docs/*.fits

--- a/docs/crtf.rst
+++ b/docs/crtf.rst
@@ -53,6 +53,7 @@ There's also `~regions.write_crtf` and `~regions.read_crtf` which write to and
 read from a file in addition to doing the region serialisation and parsing.
 
 .. code-block:: python
+.. doctest-skip::
 
     >>> from regions import read_crtf, write_crtf
     >>> filename = 'region.crtf'

--- a/docs/ds9.rst
+++ b/docs/ds9.rst
@@ -40,6 +40,7 @@ There's also `~regions.write_ds9` and `~regions.read_ds9` which write to and
 read from a file in addition to doing the region serialisation and parsing.
 
 .. code-block:: python
+.. doctest-skip::
 
     >>> from regions import read_ds9, write_ds9
     >>> filename = 'ds9.reg'
@@ -52,6 +53,7 @@ read from a file in addition to doing the region serialisation and parsing.
 The ``visual`` metadata includes items used for display, e.g.:
 
 .. code-block:: python
+.. doctest-skip::
 
     >>> print(regions[0].visual)
     {'color': 'green'}

--- a/docs/fits_region.rst
+++ b/docs/fits_region.rst
@@ -84,6 +84,7 @@ write as well as read from a file in addition to doing the region serialisation
 and parsing.
 
 .. code-block:: python
+.. doctest-skip::
 
     >>> from regions import CirclePixelRegion, PixCoord, write_fits_region
     >>> reg_pixel = CirclePixelRegion(PixCoord(1, 2), 5)

--- a/docs/unified.rst
+++ b/docs/unified.rst
@@ -22,4 +22,10 @@ region file.
     center: <SkyCoord (ICRS): (ra, dec) in deg
         (211.06231757, 54.49779926)>
     radius: 0.05220229834 deg
+
+Now write to a DS9 region file:
+
+.. code-block:: python
+.. doctest-skip::
+
     >>> regions.write('regions.reg')


### PR DESCRIPTION
This prevents the annoying creation of untracked files when doctests are run locally and prevents them from accidentally being committed to the repo.