### PR TITLE
API Cleanup:  Make helper classes/functions private

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,6 +85,11 @@ API Changes
 - The ``RegionMeta`` and ``RegionVisual`` classes have been moved to the
   ``regions.core.metadata`` module. [#371]
 
+- The following helper functions were removed from the public API:
+  ``to_shape_list``, ``to_crtf_meta``, ``to_ds9_meta``,
+  ``CRTFRegionParser``, ``DS9RegionParser``, ``CoordinateParser``,
+  ``FITSRegionRowParser``. [#375]
+
 
 0.4 (2019-06-17)
 ================

--- a/regions/io/core.py
+++ b/regions/io/core.py
@@ -27,7 +27,7 @@ from .connect import ShapeListRead, ShapeListWrite
 from .ds9.core import DS9RegionParserWarning, valid_symbols_ds9
 from .crtf.core import CRTFRegionParserWarning
 
-__all__ = ['ShapeList', 'Shape', 'to_shape_list']
+__all__ = ['ShapeList', 'Shape']
 
 regions_attributes = dict(circle=['center', 'radius'],
                           ellipse=['center', 'width', 'height', 'angle'],
@@ -741,7 +741,7 @@ class Shape:
                              'reference frame')
 
 
-def to_shape_list(region_list, coordinate_system='fk5'):
+def _to_shape_list(region_list, coordinate_system='fk5'):
     """
     Convert a list of regions into a `~regions.ShapeList` object.
 

--- a/regions/io/core.py
+++ b/regions/io/core.py
@@ -27,9 +27,7 @@ from .connect import ShapeListRead, ShapeListWrite
 from .ds9.core import DS9RegionParserWarning, valid_symbols_ds9
 from .crtf.core import CRTFRegionParserWarning
 
-__all__ = ['ShapeList', 'Shape', 'to_shape_list', 'to_crtf_meta',
-           'to_ds9_meta']
-
+__all__ = ['ShapeList', 'Shape', 'to_shape_list']
 
 regions_attributes = dict(circle=['center', 'radius'],
                           ellipse=['center', 'width', 'height', 'angle'],
@@ -194,7 +192,7 @@ class ShapeList(list):
 
         for shape in self:
             shape.check_crtf()
-            shape.meta = to_crtf_meta(shape.meta)
+            shape.meta = _to_crtf_meta(shape.meta)
 
             # if unspecified, include is True. Despite the
             # specification, CASA does *not* support a preceding "+". If
@@ -347,7 +345,7 @@ class ShapeList(list):
 
         for shape in self:
             shape.check_ds9()
-            shape.meta = to_ds9_meta(shape.meta)
+            shape.meta = _to_ds9_meta(shape.meta)
 
             # if unspecified, include is True.
             include = ''
@@ -812,7 +810,7 @@ def to_shape_list(region_list, coordinate_system='fk5'):
     return shape_list
 
 
-def to_ds9_meta(shape_meta):
+def _to_ds9_meta(shape_meta):
     """
     Make the metadata DS9 compatible by filtering and mapping the valid
     keys.
@@ -849,7 +847,7 @@ def to_ds9_meta(shape_meta):
     return meta
 
 
-def to_crtf_meta(shape_meta):
+def _to_crtf_meta(shape_meta):
     """
     Make the metadata CRTF compatible by filtering and mapping the valid
     keys.

--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -371,9 +371,9 @@ class _CRTFRegionParser:
             if attr_spec == 'c':
                 if len(val_str) == 2 and val_str[1] != '':
                     coord_list.append(
-                        CoordinateParser.parse_coordinate(val_str[0]))
+                        _CRTFCoordinateParser.parse_coordinate(val_str[0]))
                     coord_list.append(
-                        CoordinateParser.parse_coordinate(val_str[1]))
+                        _CRTFCoordinateParser.parse_coordinate(val_str[1]))
                 else:
                     self._raise_error(f'Not in proper format: {val_str} '
                                       'should be a coordinate')
@@ -381,10 +381,10 @@ class _CRTFRegionParser:
             if attr_spec == 'pl':
                 if len(val_str) == 2 and val_str[1] != '':
                     coord_list.append(
-                        CoordinateParser.parse_angular_length_quantity(
+                        _CRTFCoordinateParser.parse_angular_length_quantity(
                             val_str[0]))
                     coord_list.append(
-                        CoordinateParser.parse_angular_length_quantity(
+                        _CRTFCoordinateParser.parse_angular_length_quantity(
                             val_str[1]))
                 else:
                     self._raise_error(f'Not in proper format: {val_str} '
@@ -393,7 +393,7 @@ class _CRTFRegionParser:
             if attr_spec == 'l':
                 if isinstance(val_str, str):
                     coord_list.append(
-                        CoordinateParser.parse_angular_length_quantity(
+                        _CRTFCoordinateParser.parse_angular_length_quantity(
                             val_str))
                 else:
                     self._raise_error(f'Not in proper format: {val_str} '
@@ -472,7 +472,7 @@ class _CRTFRegionParser:
                            include=self.include)
 
 
-class CoordinateParser:
+class _CRTFCoordinateParser:
     """
     Helper class to structure coordinate parser.
     """

--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -13,7 +13,7 @@ from ..core import Shape, ShapeList, reg_mapping
 from .core import (CRTFRegionParserError, CRTFRegionParserWarning,
                    valid_symbols)
 
-__all__ = ['read_crtf', 'CRTFParser', 'CRTFRegionParser']
+__all__ = ['read_crtf', 'CRTFParser']
 
 # All CASA files start with '#CRTF' . It may also include the version
 # number like '#CRTFv0' .
@@ -93,13 +93,6 @@ class CRTFParser:
     `~regions.io.core.ShapeList`. The result is stored in the ``shapes``
     attribute.
 
-    Each line is tested for either containing a region with meta
-    attributes or global parameters. If meta attributes or global
-    parameters are found, they are stored in the ``global_meta``
-    attribute. If a region is found, the `~regions.CRTFRegionParser`
-    is invoked to transform the line into a `~regions.io.core.Shape`
-    object, which is stored in the ``shapes`` attribute.
-
     Parameters
     ----------
     region_string : str
@@ -120,6 +113,13 @@ class CRTFParser:
     >>> print(regs[0].visual)
     {'color': 'blue'}
     """
+
+    # Each line is tested for either containing a region with meta
+    # attributes or global parameters. If meta attributes or global
+    # parameters are found, they are stored in the ``global_meta``
+    # attribute. If a region is found, then ``_CRTFRegionParser``
+    # is invoked to transform the line into a `~regions.io.core.Shape`
+    # object, which is stored in the ``shapes`` attribute.
 
     # valid definition (region or annotation) types
     valid_definition = ('box', 'centerbox', 'rotbox', 'poly', 'circle',
@@ -180,7 +180,7 @@ class CRTFParser:
             include = region.group('include') or '+'
             region_type = region.group('regiontype').lower()
             if region_type in self.valid_definition:
-                helper = CRTFRegionParser(
+                helper = _CRTFRegionParser(
                     self.global_meta, include, type_, region_type,
                     *crtf_line.group('region', 'parameters'))
 
@@ -236,7 +236,7 @@ class CRTFParser:
                                       'key')
 
 
-class CRTFRegionParser:
+class _CRTFRegionParser:
     """
     Parse a CRTF region string.
 

--- a/regions/io/crtf/write.py
+++ b/regions/io/crtf/write.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ..core import to_shape_list
+from ..core import _to_shape_list
 
 __all__ = ['write_crtf', 'crtf_objects_to_string']
 
@@ -41,7 +41,7 @@ def crtf_objects_to_string(regions, coordsys='fk5', fmt='.6f', radunit='deg'):
     global coord=J2000
     circle[[1.000007deg, 2.000002deg], 5.000000deg]
     """
-    shapelist = to_shape_list(regions, coordsys)
+    shapelist = _to_shape_list(regions, coordsys)
     return shapelist.to_crtf(coordsys, fmt, radunit)
 
 

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -14,7 +14,7 @@ from ..core import Shape, ShapeList, reg_mapping
 from .core import (DS9RegionParserError, DS9RegionParserWarning,
                    valid_symbols_ds9)
 
-__all__ = ['read_ds9', 'DS9Parser', 'CoordinateParser']
+__all__ = ['read_ds9', 'DS9Parser']
 
 # Regular expression to extract region type or coodinate system
 regex_global = re.compile('^#? *(-?)([a-zA-Z0-9]+)')
@@ -68,7 +68,7 @@ def read_ds9(filename, errors='strict'):
     return parser.shapes.to_regions()
 
 
-class CoordinateParser:
+class _DS9CoordinateParser:
     """
     Helper class to structure coordinate parser.
     """
@@ -341,11 +341,11 @@ class DS9Parser:
 
 
 # Global definitions to improve readability
-radius = CoordinateParser.parse_angular_length_quantity
-width = CoordinateParser.parse_angular_length_quantity
-height = CoordinateParser.parse_angular_length_quantity
-angle = CoordinateParser.parse_angular_length_quantity
-coordinate = CoordinateParser.parse_coordinate
+radius = _DS9CoordinateParser.parse_angular_length_quantity
+width = _DS9CoordinateParser.parse_angular_length_quantity
+height = _DS9CoordinateParser.parse_angular_length_quantity
+angle = _DS9CoordinateParser.parse_angular_length_quantity
+coordinate = _DS9CoordinateParser.parse_coordinate
 
 
 class _DS9RegionParser:
@@ -405,8 +405,7 @@ class _DS9RegionParser:
                      'polygon': itertools.cycle((coordinate,)),
                      'line': (coordinate, coordinate, coordinate, coordinate),
                      'annulus': itertools.chain((coordinate, coordinate),
-                                                itertools.cycle((radius,))),
-                     }
+                                                itertools.cycle((radius,)))}
 
     def __init__(self, coordsys, include, region_type, region_end,
                  global_meta, line):
@@ -489,7 +488,7 @@ class _DS9RegionParser:
                 coord_list.append(element_parser(element))
 
         if self.region_type in ['ellipse', 'box'] and len(coord_list) % 2 == 1:
-            coord_list[-1] = CoordinateParser.parse_angular_length_quantity(
+            coord_list[-1] = _DS9CoordinateParser.parse_angular_length_quantity(
                 elements[len(coord_list) - 1])
 
         # Reset iterator for ellipse and annulus

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -14,7 +14,7 @@ from ..core import Shape, ShapeList, reg_mapping
 from .core import (DS9RegionParserError, DS9RegionParserWarning,
                    valid_symbols_ds9)
 
-__all__ = ['read_ds9', 'DS9Parser', 'DS9RegionParser', 'CoordinateParser']
+__all__ = ['read_ds9', 'DS9Parser', 'CoordinateParser']
 
 # Regular expression to extract region type or coodinate system
 regex_global = re.compile('^#? *(-?)([a-zA-Z0-9]+)')
@@ -145,12 +145,6 @@ class DS9Parser:
     `~regions.io.core.ShapeList`. The result is stored as ``shapes``
     attribute.
 
-    Each line is tested for either containing a region type or a
-    coordinate system. If a coordinate system is found the global
-    coordsys state of the parser is modified. If a region type is found
-    the `~regions.DS9RegionParser` is invokes to transform the line into
-    a `~regions.Shape` object.
-
     Parameters
     ----------
     region_string : str
@@ -173,6 +167,12 @@ class DS9Parser:
     center: PixCoord(x=330.0, y=1090.0)
     radius: 40.0
     """
+
+    # Each line is tested for either containing a region type or a
+    # coordinate system. If a coordinate system is found the global
+    # coordsys state of the parser is modified. If a region type is
+    # found the ``_DS9RegionParser`` is invokes to transform the line
+    # into a `~regions.Shape` object.
 
     # List of valid coordinate system (all lowercase)
     coordinate_systems = ['fk5', 'fk4', 'icrs', 'galactic', 'wcs',
@@ -264,7 +264,7 @@ class DS9Parser:
             # Found coord system definition
             self.set_coordsys(region_type)
             return
-        if region_type not in DS9RegionParser.language_spec:
+        if region_type not in _DS9RegionParser.language_spec:
             self._raise_error(f'Region type "{region_type}" was found, but '
                               'it is not one of the supported region types.')
             return
@@ -332,10 +332,10 @@ class DS9Parser:
             raise DS9RegionParserError('No coordinate system specified and a '
                                        'region has been found.')
 
-        helper = DS9RegionParser(coordsys=self.coordsys, include=include,
-                                 region_type=region_type,
-                                 region_end=region_end,
-                                 global_meta=self.global_meta, line=line)
+        helper = _DS9RegionParser(coordsys=self.coordsys, include=include,
+                                  region_type=region_type,
+                                  region_end=region_end,
+                                  global_meta=self.global_meta, line=line)
         helper.parse()
         self.shapes.append(helper.shape)
 
@@ -348,7 +348,7 @@ angle = CoordinateParser.parse_angular_length_quantity
 coordinate = CoordinateParser.parse_coordinate
 
 
-class DS9RegionParser:
+class _DS9RegionParser:
     """
     Parse a DS9 region string.
 

--- a/regions/io/ds9/write.py
+++ b/regions/io/ds9/write.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ..core import to_shape_list
+from ..core import _to_shape_list
 
 __all__ = ['write_ds9', 'ds9_objects_to_string']
 
@@ -32,7 +32,7 @@ def ds9_objects_to_string(regions, coordsys='fk5', fmt='.6f', radunit='deg'):
     region_string : str
         A DS9 region string.
     """
-    shapelist = to_shape_list(regions, coordsys)
+    shapelist = _to_shape_list(regions, coordsys)
     return shapelist.to_ds9(coordsys, fmt, radunit)
 
 

--- a/regions/io/fits/read.py
+++ b/regions/io/fits/read.py
@@ -12,7 +12,7 @@ from ..core import Shape, ShapeList, reg_mapping
 from .core import (FITSRegionParserError, FITSRegionParserWarning,
                    language_spec)
 
-__all__ = ['FITSRegionParser', 'read_fits_region', 'FITSRegionRowParser']
+__all__ = ['FITSRegionParser', 'read_fits_region']
 
 
 class FITSRegionParser:
@@ -88,7 +88,7 @@ class FITSRegionParser:
             self.table['COMPONENT'] = np.ones([1, len(self.table)])
 
         for row in self.table:
-            reg = FITSRegionRowParser(row, self.unit, self.errors)
+            reg = _FITSRegionRowParser(row, self.unit, self.errors)
             component, shape = reg.parse()
             if component in self.shapes:
                 self._shapes[component].append(shape)
@@ -96,7 +96,7 @@ class FITSRegionParser:
                 self._shapes[component] = [shape]
 
 
-class FITSRegionRowParser():
+class _FITSRegionRowParser():
     """
     Parse a single row of a FITS region table.
 

--- a/regions/io/fits/tests/test_fits_region.py
+++ b/regions/io/fits/tests/test_fits_region.py
@@ -13,7 +13,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from ....shapes import CircleSkyRegion
-from ...core import to_shape_list
+from ...core import _to_shape_list
 from ..core import FITSRegionParserError
 from ..read import FITSRegionParser, read_fits_region
 from ..write import fits_region_objects_to_table
@@ -66,7 +66,7 @@ def test_file_fits(filename):
         header = hdulist[1].header
         wcs = WCS(header, keysel=['image', 'binary', 'pixel'])
         regs_pix = [reg.to_pixel(wcs) for reg in regs_sky]
-        shapes_roundtrip = to_shape_list(regs_pix, 'image')
+        shapes_roundtrip = _to_shape_list(regs_pix, 'image')
 
     for i, shape in enumerate(shapes):
         assert shape.region_type == shapes_roundtrip[i].region_type

--- a/regions/io/fits/write.py
+++ b/regions/io/fits/write.py
@@ -2,7 +2,7 @@
 
 from astropy.io import fits
 
-from ..core import to_shape_list, SkyRegion
+from ..core import _to_shape_list, SkyRegion
 
 __all__ = ['write_fits_region', 'fits_region_objects_to_table']
 
@@ -27,7 +27,7 @@ def fits_region_objects_to_table(regions):
         if isinstance(reg, SkyRegion):
             raise TypeError('Every region must be a pixel region')
 
-    shape_list = to_shape_list(regions, coordinate_system='image')
+    shape_list = _to_shape_list(regions, coordinate_system='image')
     return shape_list.to_fits()
 
 

--- a/regions/io/tests/test_core.py
+++ b/regions/io/tests/test_core.py
@@ -4,7 +4,9 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy.units.quantity import Quantity
 import pytest
 
-from .. import DS9Parser, CRTFParser, to_shape_list
+from ..core import _to_shape_list
+from ..crtf.read import CRTFParser
+from ..ds9.read import DS9Parser
 
 
 def test_shape_ds9():
@@ -13,7 +15,7 @@ def test_shape_ds9():
     parser = DS9Parser(reg_str)
     shape1 = parser.shapes[0]
     region = parser.shapes.to_regions()
-    shape2 = to_shape_list(region, 'galactic')[0]
+    shape2 = _to_shape_list(region, 'galactic')[0]
 
     assert shape1.coordsys == shape2.coordsys
     assert shape1.region_type == shape2.region_type
@@ -41,7 +43,7 @@ def test_shape_crtf():
     parser = CRTFParser(reg_str)
     shape1 = parser.shapes[0]
     region = parser.shapes.to_regions()
-    shape2 = to_shape_list(region, 'fk5')[0]
+    shape2 = _to_shape_list(region, 'fk5')[0]
 
     assert shape1.coordsys == shape2.coordsys
     assert shape1.region_type == shape2.region_type


### PR DESCRIPTION
This PR is the first in a series to clean up the API.  This PR makes private several intermediate "helper" classes and functions that should never have been public.  I'm just simply removing them from the API (without deprecation).  I could not find any usage of these functions via a GitHub global search.

The removed tools are:
  * ``to_shape_list``
  * ``to_crtf_meta``
  * ``to_ds9_meta``
  * ``CRTFRegionParser``
  * ``DS9RegionParser``
  * ``CoordinateParser``
  * ``FITSRegionRowParser``

I've discussed this offline with @keflavich.