### PR TITLE
API Cleanup:  Make the FITS I/O API consistent with other region types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,6 +85,12 @@ API Changes
 - The ``RegionMeta`` and ``RegionVisual`` classes have been moved to the
   ``regions.core.metadata`` module. [#371]
 
+- Deprecated the ``read_fits_region`` and ``write_fits_region``
+  functions. Instead, use the ``read_fits`` and ``write_fits``
+  functions. Note that the ``write_fits`` function is called as
+  ``write_fits(regions, filename)`` for consistency with the other
+  functions that write files. [#376]
+
 - The following helper functions were removed from the public API:
   ``to_shape_list``, ``to_crtf_meta``, ``to_ds9_meta``,
   ``CRTFRegionParser``, ``DS9RegionParser``, ``CoordinateParser``,

--- a/docs/fits_region.rst
+++ b/docs/fits_region.rst
@@ -9,10 +9,10 @@ objects to FITS region file. A `FITS Region Binary Table
 <https://fits.gsfc.nasa.gov/registry/region.html>`_ defines a spatial
 region of a two-dimensional image in pixels.
 
-The file can be read in using the `~regions.read_fits_region`
-function. The name of the header must be ``REGION`` for
-the `~regions.read_fits_region` to parse the table. The
-`~regions.read_fits_region` function returns a sky region object.
+The file can be read in using the `~regions.read_fits` function. The
+name of the header must be ``REGION`` for the `~regions.read_fits` to
+parse the table. The `~regions.read_fits` function returns a sky region
+object.
 
 Some FITS regions, such as ``rectangle``, ``rotrectangle``,
 ``pie``, ``sector``, are not supported by this package.
@@ -85,9 +85,9 @@ function::
           1.0 .. 4.0       5.0 .. 8.0 polygon       0.0 .. 0.0       0.0         8
          10.0 .. 0.0       5.5 .. 0.0  ROTBOX      10.0 .. 0.0       0.0         9
 
-The `~regions.write_fits` and `~regions.read_fits_region`
-functions write as well as read from a file in addition to doing the
-region serialisation and parsing:
+The `~regions.write_fits` and `~regions.read_fits` functions write as
+well as read from a file in addition to doing the region serialisation
+and parsing:
 
 .. doctest-skip::
 

--- a/docs/fits_region.rst
+++ b/docs/fits_region.rst
@@ -85,12 +85,12 @@ function::
           1.0 .. 4.0       5.0 .. 8.0 polygon       0.0 .. 0.0       0.0         8
          10.0 .. 0.0       5.5 .. 0.0  ROTBOX      10.0 .. 0.0       0.0         9
 
-The `~regions.write_fits_region` and `~regions.read_fits_region`
+The `~regions.write_fits` and `~regions.read_fits_region`
 functions write as well as read from a file in addition to doing the
 region serialisation and parsing:
 
 .. doctest-skip::
 
-    >>> from regions import CirclePixelRegion, PixCoord, write_fits_region
+    >>> from regions import CirclePixelRegion, PixCoord, write_fits
     >>> reg_pixel = CirclePixelRegion(PixCoord(1, 2), 5)
-    >>> write_fits_region('regions_output.fits', regions=[reg_pixel], overwrite=True)
+    >>> write_fits('regions_output.fits', regions=[reg_pixel], overwrite=True)

--- a/regions/io/fits/connect.py
+++ b/regions/io/fits/connect.py
@@ -4,18 +4,12 @@ from astropy.io import registry
 from astropy.io.fits.connect import is_fits
 
 from ..core import ShapeList
-from .read import read_fits_region
-from .write import write_fits_region
+from .read import read_fits
+from .write import write_fits
 
 __all__ = []
 
 
-# FIXME: write_fits_region has its first two arguments backwards as
-# compared to write_crtf and write_ds9
-def write_fits(regions, filename, *args, **kwargs):
-    return write_fits_region(filename, regions, *args, **kwargs)
-
-
-registry.register_reader('fits', ShapeList, read_fits_region)
+registry.register_reader('fits', ShapeList, read_fits)
 registry.register_writer('fits', ShapeList, write_fits)
 registry.register_identifier('fits', ShapeList, is_fits)

--- a/regions/io/fits/read.py
+++ b/regions/io/fits/read.py
@@ -5,6 +5,7 @@ from warnings import warn
 from astropy.io import fits
 from astropy.table import Table
 import astropy.units as u
+from astropy.utils import deprecated
 from astropy.wcs import WCS
 import numpy as np
 
@@ -12,7 +13,7 @@ from ..core import Shape, ShapeList, reg_mapping
 from .core import (FITSRegionParserError, FITSRegionParserWarning,
                    language_spec)
 
-__all__ = ['FITSRegionParser', 'read_fits_region']
+__all__ = ['FITSRegionParser', 'read_fits']
 
 
 class FITSRegionParser:
@@ -217,7 +218,7 @@ class _FITSRegionRowParser():
             self._raise_error(f'The unit: {unit} is invalid')
 
 
-def read_fits_region(filename, errors='strict'):
+def read_fits(filename, errors='strict'):
     """
     Read a FITS region file, converting a FITS regions table to a list
     of `~regions.Region` objects.
@@ -242,10 +243,10 @@ def read_fits_region(filename, errors='strict'):
     Examples
     --------
     >>> from astropy.utils.data import get_pkg_data_filename
-    >>> from regions import read_fits_region
+    >>> from regions import read_fits
     >>> file_read = get_pkg_data_filename('data/fits_region.fits',
     ...                                   package='regions.io.fits.tests')
-    >>> regions = read_fits_region(file_read)
+    >>> regions = read_fits(file_read)
     """
     regions = []
 
@@ -260,3 +261,29 @@ def read_fits_region(filename, errors='strict'):
                     regions.append(reg.to_sky(wcs))
 
     return regions
+
+
+@deprecated('0.5', alternative='read_fits')
+def read_fits_region(filename, errors='strict'):
+    """
+    Read a FITS region file, converting a FITS regions table to a list
+    of `~regions.Region` objects.
+
+    Parameters
+    ----------
+    filename : str
+        The file path.
+
+    errors : {'strict', 'warn', 'ignore'}, optional
+        The error handling scheme to use for handling parsing
+        errors. The default is 'strict', which will raise a
+        `~regions.FITSRegionParserError`. 'warn' will raise a
+        `~regions.FITSRegionParserWarning`, and 'ignore' will do
+        nothing (i.e., be silent).
+
+    Returns
+    -------
+    regions : list
+        A list of `~regions.Region` objects.
+    """
+    return read_fits(filename, errors=errors)

--- a/regions/io/fits/tests/test_fits_region.py
+++ b/regions/io/fits/tests/test_fits_region.py
@@ -15,7 +15,7 @@ import pytest
 from ....shapes import CircleSkyRegion
 from ...core import _to_shape_list
 from ..core import FITSRegionParserError
-from ..read import FITSRegionParser, read_fits_region
+from ..read import FITSRegionParser, read_fits
 from ..write import fits_region_objects_to_table
 
 implemented_region_types = ('ellipse', 'circle', 'box', 'polygon', 'point',
@@ -61,7 +61,7 @@ def test_file_fits(filename):
 
     # Reading the regions directly from file and converting to sky
     # regions.
-    regs_sky = read_fits_region(filename)
+    regs_sky = read_fits(filename)
     with fits.open(filename) as hdulist:
         header = hdulist[1].header
         wcs = WCS(header, keysel=['image', 'binary', 'pixel'])

--- a/regions/io/fits/write.py
+++ b/regions/io/fits/write.py
@@ -1,10 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy.io import fits
+from astropy.utils import deprecated
 
 from ..core import _to_shape_list, SkyRegion
 
-__all__ = ['write_fits_region', 'fits_region_objects_to_table']
+__all__ = ['write_fits', 'fits_region_objects_to_table']
 
 
 def fits_region_objects_to_table(regions):
@@ -31,6 +32,34 @@ def fits_region_objects_to_table(regions):
     return shape_list.to_fits()
 
 
+def write_fits(regions, filename, header=None, overwrite=False):
+    """
+    Convert a list of `~regions.Region` to a FITS region table and write
+    to a file.
+
+    See :ref:`gs-fits`
+
+    Parameters
+    ----------
+    regions : list
+        A list of `~regions.Region` objects.
+
+    filename : str
+        The filename in which the table is to be written.
+
+    header : `~astropy.io.fits.Header`, optional
+        The FITS header.
+
+    overwrite : bool, optional
+        If True, overwrite the output file if it exists. Raises an
+        `OSError` if False and the output file exists. Default is False.
+    """
+    output = fits_region_objects_to_table(regions)
+    bin_table = fits.BinTableHDU(data=output, header=header)
+    bin_table.writeto(filename, overwrite=overwrite)
+
+
+@deprecated('0.5', alternative='write_fits')
 def write_fits_region(filename, regions, header=None, overwrite=False):
     """
     Convert a list of `~regions.Region` to a FITS region table and write
@@ -53,6 +82,4 @@ def write_fits_region(filename, regions, header=None, overwrite=False):
         If True, overwrite the output file if it exists. Raises an
         `OSError` if False and the output file exists. Default is False.
     """
-    output = fits_region_objects_to_table(regions)
-    bin_table = fits.BinTableHDU(data=output, header=header)
-    bin_table.writeto(filename, overwrite=overwrite)
+    write_fits(regions, filename, header=header, overwrite=overwrite)


### PR DESCRIPTION
This PR deprecates the ``read_fits_region`` and ``write_fits_region`` functions and adds new ``read_fits`` and ``write_fits`` functions.  This makes the FITS read/write function names consistent with the other region types, e.g.,:
  * `read_ds9` / `write_ds9`
  *  `read_crtf` / `write_crtf`
  *  `read_fits` / `write_fits`

Likewise, the new `write_fits` function signature is now consistent with the other region types, with the list of regions as the first argument and the filename as the second argument.

