### PR TITLE
Combine compound region descriptor classes

### DIFF
--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -10,7 +10,6 @@ from astropy.coordinates import SkyCoord
 from astropy.units import Quantity
 import numpy as np
 
-from .core import PixelRegion, SkyRegion
 from .pixcoord import PixCoord
 
 __all__ = []
@@ -117,23 +116,16 @@ class QuantityLength(RegionAttr):
                              'Quantity object')
 
 
-class CompoundRegionPix(RegionAttr):
+class RegionType(RegionAttr):
     """
-    Descriptor class for `~regions.CompoundPixelRegion`, which takes a
-    `~regions.PixelRegion` object.
+    Descriptor class for compound pixel and sky regions.
     """
+
+    def __init__(self, name, regionclass):
+        self.name = name
+        self.regionclass = regionclass
 
     def _validate(self, value):
-        if not isinstance(value, PixelRegion):
-            raise ValueError(f'The {self.name} must be a PixelRegion object')
-
-
-class CompoundRegionSky(RegionAttr):
-    """
-    Descriptor class for `~regions.CompoundSkyRegion`, which takes a
-    `~regions.SkyRegion` object.
-    """
-
-    def _validate(self, value):
-        if not isinstance(value, SkyRegion):
-            raise ValueError(f'The {self.name} must be a SkyRegion object')
+        if not isinstance(value, self.regionclass):
+            raise ValueError(f'The {self.name} must be a '
+                             f'{self.regionclass.__name__} object')

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -3,7 +3,7 @@ import operator as op
 
 import numpy as np
 
-from .attributes import CompoundRegionPix, CompoundRegionSky
+from .attributes import RegionType
 from .core import PixelRegion, SkyRegion
 from .mask import RegionMask
 from .metadata import RegionMeta, RegionVisual
@@ -32,8 +32,8 @@ class CompoundPixelRegion(PixelRegion):
     """
 
     _params = ('region1', 'region2', 'operator')
-    region1 = CompoundRegionPix('region1')
-    region2 = CompoundRegionPix('region2')
+    region1 = RegionType('region1', PixelRegion)
+    region2 = RegionType('region2', PixelRegion)
 
     def __init__(self, region1, region2, operator, meta=None, visual=None):
         if not callable(operator):
@@ -207,8 +207,8 @@ class CompoundSkyRegion(SkyRegion):
     """
 
     _params = ('region1', 'region2', 'operator')
-    region1 = CompoundRegionSky('region1')
-    region2 = CompoundRegionSky('region2')
+    region1 = RegionType('region1', SkyRegion)
+    region2 = RegionType('region2', SkyRegion)
 
     def __init__(self, region1, region2, operator, meta=None, visual=None):
         if not callable(operator):


### PR DESCRIPTION
This PR replaces the awkwardly-named  (as mentioned in #83) `CompoundRegionPix` and `CompoundRegionSky` descriptor with a single descriptor called `RegionType`.

Closes #83.