### PR TITLE
Fix SkyRegion serialization for Angle shape parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,6 +82,9 @@ Bug Fixes
 - Fixed an issue where DS9 annulus regions with more than one annulus
   would not be parsed correctly. Such regions are skipped for now. [#371]
 
+- Fixed an issue where ``Angle`` values for ``SkyRegion`` shape
+  parameters could be incorrectly serialized. [#380]
+
 
 API Changes
 -----------

--- a/regions/io/core.py
+++ b/regions/io/core.py
@@ -782,7 +782,11 @@ def _to_shape_list(region_list, coordinate_system='fk5'):
 
         new_coord = []
         for val in coord:
-            if isinstance(val, (Angle, u.Quantity, numbers.Number)):
+            if isinstance(val, Angle):
+                # convert Angle to Quantity; Angle values get units
+                # stripped in serialization, but Quantity gets converted
+                new_coord.append(u.Quantity(val))
+            elif isinstance(val, (u.Quantity, numbers.Number)):
                 new_coord.append(val)
             elif isinstance(val, PixCoord):
                 new_coord.append(u.Quantity(val.x, u.dimensionless_unscaled))

--- a/regions/io/crtf/tests/test_crtf.py
+++ b/regions/io/crtf/tests/test_crtf.py
@@ -3,7 +3,7 @@
 Tests for the crtf subpackage.
 """
 
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import Angle, SkyCoord
 import astropy.units as u
 from astropy.utils.data import get_pkg_data_filename
 import pytest
@@ -191,3 +191,16 @@ def test_casa_file_crtf():
     filename = get_pkg_data_filename('data/CRTF_CARTA.crtf')
     regions = Regions.read(filename, format='crtf')
     assert len(regions) == 2
+
+
+def test_angle_serialization():
+    """
+    Regression test for issue #223 to ensure Angle arcsec inputs are
+    correctly converted to degrees.
+    """
+    reg = Regions([CircleSkyRegion(SkyCoord(10,20, unit='deg'),
+                                   Angle(1, 'arcsec'))])
+    regstr = reg.serialize(format='crtf')
+    expected = ('#CRTFv0\nglobal coord=J2000\ncircle[[10.000009deg, '
+                '20.000002deg], 0.000278deg]\n')
+    assert regstr == expected

--- a/regions/io/ds9/tests/test_ds9.py
+++ b/regions/io/ds9/tests/test_ds9.py
@@ -279,3 +279,16 @@ def test_text_metadata():
     assert regions[0].meta['text'] == 'this_is_text'
     assert regions[0].meta['label'] == 'this_is_text'
     assert regions[0].meta['text'] == 'this_is_text'
+
+
+def test_angle_serialization():
+    """
+    Regression test for issue #223 to ensure Angle arcsec inputs are
+    correctly converted to degrees.
+    """
+    reg = Regions([CircleSkyRegion(SkyCoord(10,20, unit='deg'),
+                                   Angle(1, 'arcsec'))])
+    regstr = reg.serialize(format='ds9')
+    expected = ('# Region file format: DS9 astropy/regions\nfk5\n'
+                'circle(10.000009,20.000002,0.000278)\n')
+    assert regstr == expected


### PR DESCRIPTION
This PR fixes an issue where ``Angle`` values for ``SkyRegion`` shape parameters could be incorrectly serialized, e.g., Angle(1, 'arcsec') would be serialized as 1 degree.

Fixes #223.