### PR TITLE
Fix issue parsing DS9 regions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -88,6 +88,8 @@ Bug Fixes
 - Fixed an issue where a semicolon in the DS9 text field would raise an
   error. [#381]
 
+- Fixed an issue where DS9 regions without metadata would not be parsed
+  correctly. [#382]
 
 API Changes
 -----------

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -447,17 +447,17 @@ class _DS9RegionParser:
         """
         Split line into coordinates and meta string.
         """
-        # coordinate of the # symbol or end of the line (-1) if not found
-        hash_or_end = self.line.find('#')
-        temp = self.line[self.region_end:hash_or_end].strip(' |')
+        # index of the # symbol or end of the line (-1) if not found
+        hash_idx = self.line.find('#')
+        if hash_idx == -1:
+            temp = self.line[self.region_end:].strip(' |')
+            self.meta_str = ''  # no metadata found
+        else:
+            temp = self.line[self.region_end:hash_idx].strip(' |')
+            self.meta_str = self.line[hash_idx:]
+
         # force all coordinate names (circle, etc) to be lower-case
         self.coord_str = regex_paren.sub('', temp).lower()
-
-        # don't want any meta_str if there is no metadata found
-        if hash_or_end >= 0:
-            self.meta_str = self.line[hash_or_end:]
-        else:
-            self.meta_str = ''
 
     def convert_coordinates(self):
         """

--- a/regions/io/ds9/tests/test_ds9.py
+++ b/regions/io/ds9/tests/test_ds9.py
@@ -286,7 +286,7 @@ def test_angle_serialization():
     Regression test for issue #223 to ensure Angle arcsec inputs are
     correctly converted to degrees.
     """
-    reg = Regions([CircleSkyRegion(SkyCoord(10,20, unit='deg'),
+    reg = Regions([CircleSkyRegion(SkyCoord(10, 20, unit='deg'),
                                    Angle(1, 'arcsec'))])
     regstr = reg.serialize(format='ds9')
     expected = ('# Region file format: DS9 astropy/regions\nfk5\n'
@@ -305,3 +305,21 @@ def test_semicolon():
 
     reg = Regions.parse(regstr, format='ds9')
     assert len(reg) == 2
+
+
+def test_parser_no_metadata():
+    """
+    Regression test for issue #259 to ensure regions without metadata
+    are parsed correctly.
+    """
+    regstr1 = 'galactic;circle(42,43,3)'
+    regstr2 = 'galactic;circle 42 43 3'
+    reg1 = Regions.parse(regstr1, format='ds9')[0]
+    reg2 = Regions.parse(regstr2, format='ds9')[0]
+
+    assert isinstance(reg1, CircleSkyRegion)
+    assert isinstance(reg2, CircleSkyRegion)
+    assert reg1.radius.value == 3.0
+    assert reg2.radius.value == 3.0
+    assert reg1.radius.unit == 'deg'
+    assert reg2.radius.unit == 'deg'


### PR DESCRIPTION
This PR fixes an issue where DS9 regions without metadata would not be parsed correctly (e.g., the radius would not be parsed for circle regions).

Fixes #259.