### PR TITLE
Fix DS9 regex for parsing metadata with spaces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,8 @@ Bug Fixes
 - Fixed an issue where DS9 regions without metadata would not be parsed
   correctly. [#382]
 
+- Fixed an issue parsing spaces in DS9 region metadata. [#384]
+
 API Changes
 -----------
 

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -23,7 +23,7 @@ __all__ = ['read_ds9', 'DS9Parser']
 regex_global = re.compile('^#? *(-?)([a-zA-Z0-9]+)')
 
 # Regular expression to extract meta attributes
-regex_meta = re.compile(r'([a-zA-Z]+)(=)({.*?}|\'.*?\'|\".*?\"|[0-9\s]+\s?|[^=\s]+\s?[0-9]*)\s?')  # noqa
+regex_meta = re.compile(r'([a-zA-Z]+)(\s*)(=)(\s*)({.*?}|\'.*?\'|\".*?\"|[0-9\s]+\s?|[^=\s]+\s?[0-9]*)\s?')
 
 # Regular expression to strip parenthesis
 regex_paren = re.compile('[()]')
@@ -293,7 +293,7 @@ class _DS9Parser:
             A dictionary containing the metadata.
         """
         # keys must be lower-casae, but data can be any case
-        keys_vals = [(x.lower(), y) for x, _, y
+        keys_vals = [(x.lower(), y) for x, _, _, _, y
                      in regex_meta.findall(meta_str.strip())]
         extra_text = regex_meta.split(meta_str.strip())[-1]
         result = {}

--- a/regions/io/ds9/tests/test_ds9.py
+++ b/regions/io/ds9/tests/test_ds9.py
@@ -326,7 +326,7 @@ def test_semicolon():
               'circle(1.5, 2, 2) # text={this_is_text};'
               'text(151.1,51.2) # text={text ; hi ; there;} textangle=45'
               ' color=orange font="helvetica 12 normal roman";'
-              'text(151.1,51.2) # text=  {text ; hi ; there;} textangle=45'
+              'text(151.1,51.2) # text  =  {text ; hi ; there;} textangle=45'
               ' color=orange font="helvetica 12 normal roman";'
               'circle(1.5, 2, 2) # text={text="hi;world";text;"tes\'t};'
               "circle(1.5, 2, 2) # text={text='hi;world';text;\"tes't};")
@@ -351,3 +351,36 @@ def test_parser_no_metadata():
     assert reg2.radius.value == 3.0
     assert reg1.radius.unit == 'deg'
     assert reg2.radius.unit == 'deg'
+
+
+def test_spaces_metadata():
+    """
+    Regression test for spaces before or after "=" in region metadata.
+    """
+    regstr = ('galactic;'
+              'circle(202.4,47.2,10.9) # text={a; test; test; A1} color=red;'
+              'circle(202.4,47.2,10.9) # text ={a; test; test; A1} color= red;'
+              'circle(202.4,47.2,10.9) # text= {a; test; test; A1} color =red;'
+              'circle(202.4,47.2,10.9) # text = {a; test; test; A1}'
+              ' color = red;')
+    reg = Regions.parse(regstr, format='ds9')
+    assert len(reg) == 4
+    for i in range(1, len(reg)):
+        assert reg[0].visual == reg[i].visual
+        assert reg[0].meta == reg[i].meta
+
+    regstr2 = ('galactic;'
+               'text(151.1,51.2) # text={text ; hi ; there;} textangle= 45'
+               ' color=orange font="helvetica 12 normal roman";'
+               'text(151.1,51.2) # text  ={text ; hi ; there;} textangle =45'
+               ' color=orange font="helvetica 12 normal roman";'
+               'text(151.1,51.2) # text=  {text ; hi ; there;} textangle  =45'
+               ' color   =   orange font="helvetica 12 normal roman";'
+               'text(151.1,51.2) # text   =  {text ; hi ; there;} textangle=45'
+               ' color   =orange font="helvetica 12 normal roman";')
+
+    reg = Regions.parse(regstr2, format='ds9')
+    assert len(reg) == 4
+    for i in range(1, len(reg)):
+        assert reg[0].visual == reg[i].visual
+        assert reg[0].meta == reg[i].meta


### PR DESCRIPTION
This fixes an issue where spaces before or after the "=" in DS9 metadata would causing parsing errors.