### PR TITLE
Add DS9 boxcircle point symbol

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,8 +7,15 @@ General
 New Features
 ------------
 
+- Added the DS9 'boxcircle' point symbol. [#387]
+
 Bug Fixes
 ---------
+
+- Fixed the DS9 default point symbol to use 'boxcircle'. [#387]
+
+- Point symbol markers are no longer filled for consistency with DS9.
+  [387]
 
 API Changes
 -----------

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -326,6 +326,8 @@ class PixelRegion(Region):
         Unset ``visual`` properties are set to default values based on
         the DS9 convention.
         """
+        from ..io.ds9.core import valid_symbols_ds9
+
         if artist not in ('Patch', 'Line2D', 'Text'):
             raise ValueError(f'artist "{artist}" is not supported')
 
@@ -344,7 +346,8 @@ class PixelRegion(Region):
             kwargs['linestyle'] = self.visual.get('linstyle', 'solid')
 
             if artist == 'Line2D':
-                kwargs['marker'] = self.visual.get('symbol', 'o')
+                boxcircle = valid_symbols_ds9['boxcircle']
+                kwargs['marker'] = self.visual.get('symbol', boxcircle)
                 kwargs['markersize'] = self.visual.get('symsize', 11)
                 kwargs['markeredgecolor'] = kwargs['color']
                 kwargs['markeredgewidth'] = self.visual.get('width', 1)

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -348,6 +348,7 @@ class PixelRegion(Region):
                 kwargs['markersize'] = self.visual.get('symsize', 11)
                 kwargs['markeredgecolor'] = kwargs['color']
                 kwargs['markeredgewidth'] = self.visual.get('width', 1)
+                kwargs['fillstyle'] = self.visual.get('fill', 'none')
 
             if artist == 'Patch':
                 kwargs['edgecolor'] = kwargs.pop('color')

--- a/regions/io/ds9/core.py
+++ b/regions/io/ds9/core.py
@@ -1,6 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy.utils.exceptions import AstropyUserWarning
+import numpy as np
+
+try:
+    import matplotlib  # noqa
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
 
 __all__ = ['DS9RegionParserWarning', 'DS9RegionParserError']
 
@@ -17,6 +24,30 @@ class DS9RegionParserError(ValueError):
     """
 
 
+if not HAS_MATPLOTLIB:
+    boxcircle = '8'  # octagon
+else:
+    import matplotlib.path as mpath
+
+    vertices = np.array([[0., -1.], [0.2652031 , -1.],
+                         [0.51957987, -0.89463369], [0.70710678, -0.70710678],
+                         [0.89463369, -0.51957987], [1., -0.2652031],
+                         [1., 0.], [1., 0.2652031], [0.89463369, 0.51957987],
+                         [0.70710678, 0.70710678], [0.51957987, 0.89463369],
+                         [0.2652031, 1.], [0., 1.], [-0.2652031, 1.],
+                         [-0.51957987, 0.89463369], [-0.70710678, 0.70710678],
+                         [-0.89463369, 0.51957987], [-1., 0.2652031],
+                         [-1., 0.], [-1., -0.2652031],
+                         [-0.89463369, -0.51957987],
+                         [-0.70710678, -0.70710678],
+                         [-0.51957987, -0.89463369], [-0.2652031, -1.],
+                         [0., -1.], [0., -1.], [0., -1.], [1., -1.], [1., 1.],
+                         [-1., 1.], [-1., -1.], [0., -1.]])
+    codes = np.array([1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+                      4, 4, 4, 4, 4, 4, 4, 79, 1, 2, 2, 2, 2, 79],
+                     dtype=np.uint8)
+    boxcircle = mpath.Path(vertices, codes)
+
 # mapping to matplotlib marker symbols, also compatible with CRTF.
 valid_symbols_ds9 = {'circle': 'o',
                      'box': 's',
@@ -24,4 +55,4 @@ valid_symbols_ds9 = {'circle': 'o',
                      'x': 'x',
                      'cross': '+',
                      'arrow': '^',
-                     'boxcircle': '*'}
+                     'boxcircle': boxcircle}


### PR DESCRIPTION
This PR also fixes the DS9 default point symbol to use the new 'boxcircle' symbol.

Point symbol markers are also no longer filled for consistency with DS9.