### PR TITLE
Fix plotting issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,13 @@ Bug Fixes
 - Fixed the DS9 default point symbol to use 'boxcircle'. [#387]
 
 - Point symbol markers are no longer filled for consistency with DS9.
-  [387]
+  [#387]
+
+- Fixed an issue where plotting elliptical regions were incorrectly
+  filled by default. [#389]
+
+- Fixed an issue where compound region colors were being set correctly.
+  [#389]
 
 API Changes
 -----------

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -147,11 +147,15 @@ class CompoundPixelRegion(PixelRegion):
 
             import matplotlib.patches as mpatches
 
+            # set mpl_kwargs before as_artist is called on region1 and
+            # region2
+            mpl_kwargs = self._define_mpl_kwargs(artist='Patch')
+            mpl_kwargs.update(kwargs)
+
             patch_inner = self.region1.as_artist(origin=origin)
             patch_outer = self.region2.as_artist(origin=origin)
             path = self._make_annulus_path(patch_inner, patch_outer)
-            mpl_kwargs = self._define_mpl_kwargs(artist='Patch')
-            mpl_kwargs.update(kwargs)
+
             patch = mpatches.PathPatch(path, **mpl_kwargs)
             return patch
         else:

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -44,11 +44,11 @@ class CompoundPixelRegion(PixelRegion):
         if meta is None:
             self.meta = region1.meta
         else:
-            self.meta = RegionMeta()
+            self.meta = meta
         if visual is None:
             self.visual = region1.visual
         else:
-            self.visual = RegionVisual()
+            self.visual = visual
         self._operator = operator
 
     @property

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -150,7 +150,9 @@ class CompoundPixelRegion(PixelRegion):
             patch_inner = self.region1.as_artist(origin=origin)
             patch_outer = self.region2.as_artist(origin=origin)
             path = self._make_annulus_path(patch_inner, patch_outer)
-            patch = mpatches.PathPatch(path, **kwargs)
+            mpl_kwargs = self._define_mpl_kwargs(artist='Patch')
+            mpl_kwargs.update(kwargs)
+            patch = mpatches.PathPatch(path, **mpl_kwargs)
             return patch
         else:
             raise NotImplementedError

--- a/regions/io/ds9/tests/test_ds9.py
+++ b/regions/io/ds9/tests/test_ds9.py
@@ -411,6 +411,7 @@ def test_point_boxcircle():
     assert regions[2].as_artist().get_color() == 'green'
 
 
+@pytest.mark.skipif('not HAS_MATPLOTLIB')
 def test_compound_color():
     regstr = ('# Region file format: DS9 astropy/regions\n'
               'image\n'

--- a/regions/io/ds9/tests/test_ds9.py
+++ b/regions/io/ds9/tests/test_ds9.py
@@ -409,3 +409,11 @@ def test_point_boxcircle():
     assert regions[1].as_artist().get_color() == 'blue'
     assert isinstance(regions[2].as_artist().get_marker(), mpath.Path)
     assert regions[2].as_artist().get_color() == 'green'
+
+
+def test_compound_color():
+    regstr = ('# Region file format: DS9 astropy/regions\n'
+              'image\n'
+              'annulus(651.0,301.0,60.0,90.0) # color=red')
+    regions = Regions.parse(regstr, format='ds9')
+    assert regions[0].as_artist().get_edgecolor() == (1., 0., 0., 1.)

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -206,7 +206,7 @@ class EllipsePixelRegion(PixelRegion):
         mpl_kwargs.update(kwargs)
 
         return Ellipse(xy=xy, width=width, height=height, angle=angle,
-                       **kwargs)
+                       **mpl_kwargs)
 
     def _update_from_mpl_selector(self, *args, **kwargs):
         xmin, xmax, ymin, ymax = self._mpl_selector.extents


### PR DESCRIPTION
This PR fixes:

* an issue where plotting elliptical regions were incorrectly filled by default.

* an issue where compound region colors were being set correctly

With this PR (and #387) the comparison plot on the main documentation page matches DS9.