### PR TITLE
Add ability to add and subtract PixCoord objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ New Features
 
 - Added the DS9 'boxcircle' point symbol. [#387]
 
+- Added the ability to add and subtract ``PixCoord`` objects. [#396]
+
 Bug Fixes
 ---------
 

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -121,16 +121,25 @@ class PixCoord:
         y = self.y[key]
         return PixCoord(x=x, y=y)
 
+    def __add__(self, other):
+        if not isinstance(other, self.__class__):
+            raise TypeError('Can add only to another PixCoord')
+        return self.__class__(self.x + other.x, self.y + other.y)
+
+    def __sub__(self, other):
+        if not isinstance(other, self.__class__):
+            raise TypeError('Can subtract only from another PixCoord')
+        return self.__class__(self.x - other.x, self.y - other.y)
+
     def __eq__(self, other):
         """
         Checks whether ``other`` is `PixCoord` object and whether
         their abscissa and ordinate values are equal using
         `np.testing.assert_allclose` with its default tolerance values.
         """
-        if isinstance(other, PixCoord):
+        if isinstance(other, self.__class__):
             return np.allclose([self.x, self.y], [other.x, other.y])
-        else:
-            return False
+        return False
 
     def to_sky(self, wcs, origin=_DEFAULT_WCS_ORIGIN, mode=_DEFAULT_WCS_MODE):
         """

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -238,3 +238,51 @@ def test_pixcoord_rotate_array():
     center = PixCoord(2, 3)
     point = point.rotate(center, 90 * u.deg)
     assert_allclose(point.xy, ([1, 1], [4, 4]))
+
+
+def test_pixcoord_addition():
+    point1 = PixCoord([3, 3], [4, 4])
+    point2 = PixCoord([5, 7], [6, 1])
+    center = PixCoord(2, 3)
+
+    p1 = point1 + point2
+    p2 = point2 + point1
+    assert p1 == p2
+    assert_equal(p1.x, (8, 10))
+    assert_equal(p1.y, (10, 5))
+
+    p3 = point1 + center
+    p4 = center + point1
+    assert p3 == p4
+    assert_equal(p3.x, (5, 5))
+    assert_equal(p3.y, (7, 7))
+
+    p5 = point1 + point1 + point1
+    assert_equal(p5.x, point1.x * 3)
+    assert_equal(p5.y, point1.y * 3)
+
+    with pytest.raises(TypeError):
+        point1 + 10
+
+    with pytest.raises(ValueError):
+        point1 + PixCoord([1, 1, 1], [2, 2, 2])
+
+
+def test_pixcoord_subtraction():
+    point1 = PixCoord([3, 3], [4, 4])
+    point2 = PixCoord([5, 7], [6, 1])
+    center = PixCoord(2, 3)
+
+    p1 = point2 - point1
+    assert_equal(p1.x, (2, 4))
+    assert_equal(p1.y, (2, -3))
+
+    p2 = point1 - center
+    assert_equal(p2.x, (1, 1))
+    assert_equal(p2.y, (1, 1))
+
+    with pytest.raises(TypeError):
+        point1 - 10
+
+    with pytest.raises(ValueError):
+        point1 - PixCoord([1, 1, 1], [2, 2, 2])


### PR DESCRIPTION
Examples:
```python
>>> p1 = PixCoord([3, 3], [4, 4])
>>> p2 = PixCoord([5, 7], [6, 1])
>>> p1 + p2
PixCoord(x=[ 8 10], y=[10  5])

>>> p1 - p2
PixCoord(x=[-2 -4], y=[-2  3])

>>> PixCoord([3, 3], [4, 4]) + PixCoord(10, 10)
PixCoord(x=[13 13], y=[14 14])
```