### PR TITLE
Add origin keyword to PolygonPixelRegion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ New Features
 
 - Added the ability to add and subtract ``PixCoord`` objects. [#396]
 
+- Added an ``origin`` keyword to ``PolygonPixelRegion`` to allow
+  specifying the vertices relative to an origin pixel. [#397]
+
 Bug Fixes
 ---------
 

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -31,6 +31,10 @@ class PolygonPixelRegion(PixelRegion):
     visual : `~regions.RegionVisual`, optional
         A dictionary that stores the visual meta attributes of this
         region.
+    origin : `~regions.PixCoord`, optional
+        The origin for polynomial vertices. Using this keyword allows
+        ``vertices`` to be specified relative to an origin pixel
+        coordinate.
 
     Examples
     --------
@@ -56,10 +60,13 @@ class PolygonPixelRegion(PixelRegion):
     _params = ('vertices',)
     vertices = OneDPix('vertices')
 
-    def __init__(self, vertices, meta=None, visual=None):
-        self.vertices = vertices
+    def __init__(self, vertices, meta=None, visual=None,
+                 origin=PixCoord(0, 0)):
+        self._vertices = vertices
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
+        self.origin = origin
+        self.vertices = vertices + origin
 
     @property
     def area(self):

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 import pytest
 
 from astropy.coordinates import SkyCoord
@@ -103,6 +103,15 @@ class TestPolygonPixelRegion(BaseTestPixelRegion):
         reg = self.reg.rotate(PixCoord(3, 1), -90 * u.deg)
         assert_allclose(reg.vertices.x, [3, 3, 6])
         assert_allclose(reg.vertices.y, [3, 1, 3])
+
+    def test_origin(self):
+        verts = PixCoord([1, 3, 1], [1, 1, 4])
+        reg1 = PolygonPixelRegion(verts)
+
+        origin = PixCoord(1, 1)
+        relverts = verts - origin
+        reg2 = PolygonPixelRegion(relverts, origin=origin)
+        assert_equal(reg1.vertices, reg2.vertices)
 
 
 class TestPolygonSkyRegion(BaseTestSkyRegion):


### PR DESCRIPTION
This PR adds an `origin` keyword to `PolygonPixelRegion`, which allows `vertices` to be specified relative to an origin pixel coordinate.

Closes #57.