### PR TITLE
Add RegularPolygonPixelRegion class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ New Features
 - Added an ``origin`` keyword to ``PolygonPixelRegion`` to allow
   specifying the vertices relative to an origin pixel. [#397]
 
+- Added a ``RegularPolygonPixelRegion`` class. [#398]
+
 Bug Fixes
 ---------
 

--- a/regions/io/core.py
+++ b/regions/io/core.py
@@ -13,7 +13,8 @@ import numpy as np
 from ..shapes import (CirclePixelRegion, CircleSkyRegion,
                       EllipsePixelRegion, EllipseSkyRegion,
                       RectanglePixelRegion, RectangleSkyRegion,
-                      PolygonPixelRegion, PolygonSkyRegion,
+                      PolygonPixelRegion, RegularPolygonPixelRegion,
+                      PolygonSkyRegion,
                       CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
                       EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
                       RectangleAnnulusPixelRegion, RectangleAnnulusSkyRegion,
@@ -760,6 +761,8 @@ def _to_shape_list(region_list, coordinate_system='fk5'):
         coord = []
         if isinstance(region, SkyRegion):
             reg_type = region.__class__.__name__[:-9].lower()
+        elif isinstance(region, RegularPolygonPixelRegion):
+            reg_type = 'polygon'
         else:
             reg_type = region.__class__.__name__[:-11].lower()
 

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -196,6 +196,47 @@ class PolygonPixelRegion(PixelRegion):
 
 
 class RegularPolygonPixelRegion(PolygonPixelRegion):
+    """
+    A regular polygon in pixel coordinates.
+
+    Parameters
+    ----------
+    center : `~regions.PixCoord`
+        The position of the center of the polygon.
+    nvertices : `~regions.PixCoord`
+        The number of polygon vertices (or sides).
+    radius : float
+        The distance from the center to any vertex. This is also known
+        as the circumradius.
+    angle : `~astropy.units.Quantity`, optional
+        The rotation angle of the polygon, measured anti-clockwise. If
+        set to zero (the default), the polygon will point "up" following
+        the `matplotlib.patches.RegularPolygon` convention.
+    meta : `~regions.RegionMeta`, optional
+        A dictionary that stores the meta attributes of this region.
+    visual : `~regions.RegionVisual`, optional
+        A dictionary that stores the visual meta attributes of this
+        region.
+
+    Attributes
+    ----------
+    side_length : float
+        The side length.
+    inradius : float
+        The radius of the largest circle contained entirely within the
+        polygon. This value is identical to the length of a line segment
+        from the polygon center to the midpoint of one of its sides
+        (known as as the apothem).
+    perimeter : float
+        The polygon perimeter.
+    interior_angle : float
+        The polygon interior angle, which is the angle at each vertex on
+        the inside of the polygon.
+    exterior_angle : float
+        The polygon exterior angle, which is an angle at each vertex on
+        the ouside of the polygon.
+    """
+
     def __init__(self, center, nvertices, radius, angle=0. * u.deg,
                  meta=None, visual=None):
 

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -200,6 +200,13 @@ class RegularPolygonPixelRegion(PolygonPixelRegion):
     """
     A regular polygon in pixel coordinates.
 
+    .. note::
+
+        This class will be serialized as a generic polygon
+        region, thus when read back in it will produce a
+        `~regions.PolygonPixelRegion` object instead of a
+        `~regions.RegularPolygonPixelRegion` object.
+
     Parameters
     ----------
     center : `~regions.PixCoord`

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -235,6 +235,40 @@ class RegularPolygonPixelRegion(PolygonPixelRegion):
     exterior_angle : float
         The polygon exterior angle, which is an angle at each vertex on
         the ouside of the polygon.
+
+    Examples
+    --------
+    .. plot::
+        :include-source:
+
+        import astropy.units as u
+        import matplotlib.pyplot as plt
+        from regions import PixCoord, RegularPolygonPixelRegion
+
+        fig, ax = plt.subplots(1, 1)
+        center = PixCoord(x=50, y=50)
+        reg1 = RegularPolygonPixelRegion(center, 6, 15)
+        reg1.plot(edgecolor='red', lw=2)
+
+        center = PixCoord(x=25, y=25)
+        reg2 = RegularPolygonPixelRegion(center, 3, 15)
+        reg2.plot(edgecolor='green', lw=2)
+
+        center = PixCoord(x=25, y=75)
+        reg3 = RegularPolygonPixelRegion(center, 3, 15, angle=25*u.deg)
+        reg3.plot(edgecolor='orange', lw=2)
+
+        center = PixCoord(x=75, y=75)
+        reg4 = RegularPolygonPixelRegion(center, 8, 15)
+        reg4.plot(edgecolor='blue', lw=2)
+
+        center = PixCoord(x=75, y=25)
+        reg5 = RegularPolygonPixelRegion(center, 5, 15)
+        reg5.plot(edgecolor='magenta', lw=2)
+
+        ax.set_xlim(0, 100)
+        ax.set_ylim(0, 100)
+        ax.set_aspect('equal')
     """
 
     def __init__(self, center, nvertices, radius, angle=0. * u.deg,

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -7,7 +7,8 @@ import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
-from ..core.attributes import OneDPix, OneDSky
+from ..core.attributes import (OneDPix, OneDSky, ScalarPix, ScalarLength,
+                               QuantityLength)
 from ..core.bounding_box import BoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -271,6 +272,12 @@ class RegularPolygonPixelRegion(PolygonPixelRegion):
         ax.set_aspect('equal')
     """
 
+    _params = ('center', 'nvertices', 'radius', 'angle')
+    center = ScalarPix('center')
+    nvertices = ScalarLength('nvertices')
+    radius = ScalarLength('radius')
+    angle = QuantityLength('angle')
+
     def __init__(self, center, nvertices, radius, angle=0. * u.deg,
                  meta=None, visual=None):
 
@@ -280,9 +287,8 @@ class RegularPolygonPixelRegion(PolygonPixelRegion):
         self.nvertices = nvertices
         self.radius = radius
         self.angle = angle
-        self.vertices = self._calc_vertices()
-        self.meta = meta or RegionMeta()
-        self.visual = visual or RegionVisual()
+
+        super().__init__(self._calc_vertices(), meta=meta, visual=visual)
 
         self.side_length = 2. * self.radius * np.sin(np.pi / self.nvertices)
         self.inradius = self.radius * np.cos(np.pi / self.nvertices)

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -305,6 +305,28 @@ class RegularPolygonPixelRegion(PolygonPixelRegion):
         yvert = self.radius * np.sin(theta)
         return self.center + PixCoord(xvert, yvert)
 
+    def rotate(self, center, angle):
+        """
+        Rotate the region.
+
+        Postive ``angle`` corresponds to counter-clockwise rotation.
+
+        Parameters
+        ----------
+        center : `~regions.PixCoord`
+            The rotation center point.
+        angle : `~astropy.coordinates.Angle`
+            The rotation angle.
+
+        Returns
+        -------
+        region : `PolygonPixelRegion`
+            The rotated region (which is an independent copy).
+        """
+        center = self.center.rotate(center, angle)
+        angle = self.angle + angle
+        return self.copy(center=center, angle=angle)
+
 
 class PolygonSkyRegion(SkyRegion):
     """

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -230,7 +230,12 @@ class TestRegionPolygonPixelRegion(BaseTestPixelRegion):
                     [41.54763477, 68.12615574]]
         assert_allclose(patch.xy, expected)
 
-    def zz_test_rotate(self):
-        reg = self.reg.rotate(PixCoord(3, 1), -90 * u.deg)
-        assert_allclose(reg.vertices.x, [3, 3, 6])
-        assert_allclose(reg.vertices.y, [3, 1, 3])
+    def test_rotate(self):
+        reg = self.reg.rotate(self.reg.center, 20 * u.deg)
+        assert reg.angle.value == 45.0
+        x_vert = [35.85786438, 30., 35.85786438, 50., 64.14213562, 70.,
+                  64.14213562, 50.]
+        y_vert = [64.14213562, 50., 35.85786438, 30., 35.85786438, 50.,
+                  64.14213562, 70.]
+        assert_allclose(reg.vertices.x, x_vert)
+        assert_allclose(reg.vertices.y, y_vert)

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from copy import copy
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import pytest
@@ -11,7 +12,8 @@ from astropy.tests.helper import assert_quantity_allclose
 from ...core import PixCoord, BoundingBox
 from ...tests.helpers import make_simple_wcs
 from ..._utils.examples import make_example_dataset
-from ..polygon import PolygonPixelRegion, PolygonSkyRegion
+from ..polygon import (PolygonPixelRegion, RegularPolygonPixelRegion,
+                       PolygonSkyRegion)
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 from .utils import HAS_MATPLOTLIB  # noqa
 
@@ -156,3 +158,79 @@ class TestPolygonSkyRegion(BaseTestSkyRegion):
         # 1,2 is outside, 3.25,3.75 should be inside the triangle...
         assert all(self.reg.contains(position, wcs)
                    == np.array([False, True], dtype='bool'))
+
+
+class TestRegionPolygonPixelRegion(BaseTestPixelRegion):
+
+    reg = RegularPolygonPixelRegion(PixCoord(50, 50), 8, 20, angle=25*u.deg)
+    inside = [(40, 40)]
+    outside = [(20, 20), (80, 90)]
+    expected_area = 1131.37085
+    expected_repr = ('<RegularPolygonPixelRegion(center=PixCoord(x=50, y=50), '
+                     'nvertices=8, radius=20, angle=25.0 deg)>')
+
+    expected_str = ('Region: RegularPolygonPixelRegion\n'
+                    'center: PixCoord(x=50, y=50)\n'
+                    'nvertices: 8\n'
+                    'radius: 20\nangle: 25.0 deg')
+
+    def test_copy(self):
+        reg = self.reg.copy()
+        x_expected = copy(self.reg.vertices.x)
+        y_expected = copy(self.reg.vertices.y)
+        assert_allclose(reg.vertices.x, x_expected)
+        assert_allclose(reg.vertices.y, y_expected)
+        assert reg.visual == {}
+        assert reg.meta == {}
+
+    def test_bounding_box(self):
+        bbox = self.reg.bounding_box
+        assert bbox == BoundingBox(ixmin=31, ixmax=70, iymin=31, iymax=70)
+
+    def test_to_mask(self):
+        # The true area of this polygon is 3
+        # We only do very low-precision asserts below,
+        # because results can be unstable with points
+        # on the edge of the polygon.
+        # Basically we check that mask.data is filled
+        # with something useful at all.
+
+        # Bounding box and output shape is independent of subpixels,
+        # so we only assert on it once here, not in the other cases below
+        mask = self.reg.to_mask(mode='center', subpixels=1)
+        assert 1130 <= np.sum(mask.data) <= 1135
+        assert mask.bbox == BoundingBox(ixmin=31, ixmax=70, iymin=31,
+                                        iymax=70)
+        assert mask.data.shape == (39, 39)
+
+        # Test more cases for to_mask
+        # This example is with the default: subpixels=5
+        mask = self.reg.to_mask(mode='subpixels')
+        assert 1130 <= np.sum(mask.data) <= 1135
+
+        mask = self.reg.to_mask(mode='subpixels', subpixels=8)
+        assert 1130 <= np.sum(mask.data) <= 1135
+
+        mask = self.reg.to_mask(mode='subpixels', subpixels=9)
+        assert 1130 <= np.sum(mask.data) <= 1135
+
+        mask = self.reg.to_mask(mode='subpixels', subpixels=10)
+        assert 1130 <= np.sum(mask.data) <= 1135
+
+        with pytest.raises(NotImplementedError):
+            self.reg.to_mask(mode='exact')
+
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
+    def test_as_artist(self):
+        patch = self.reg.as_artist()
+        expected = [[41.54763477, 68.12615574], [31.20614758, 56.84040287],
+                    [31.87384426, 41.54763477], [43.15959713, 31.20614758],
+                    [58.45236523, 31.87384426], [68.79385242, 43.15959713],
+                    [68.12615574, 58.45236523], [56.84040287, 68.79385242],
+                    [41.54763477, 68.12615574]]
+        assert_allclose(patch.xy, expected)
+
+    def zz_test_rotate(self):
+        reg = self.reg.rotate(PixCoord(3, 1), -90 * u.deg)
+        assert_allclose(reg.vertices.x, [3, 3, 6])
+        assert_allclose(reg.vertices.y, [3, 1, 3])


### PR DESCRIPTION
This PR adds a `RegularPolygonPixelRegion` class defined by a center, number of vertices (sides), radius, and optional angle.

Examples:

![regions-RegularPolygonPixelRegion-1](https://user-images.githubusercontent.com/4992897/128442936-cb1e9864-a49a-4d65-93b3-cb6b6e866573.png)
