### PR TITLE
Use matplotlib artist defaults

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,13 @@ API Changes
 
 - Removed the deprecated ``BoundingBox`` ``slices`` attribute. [#386]
 
+- The default matplotlib keywords that are used when plotting now depend
+  on the value of ``self.visual['default_style']``. This keyword is
+  currently set (to a value of 'ds9') only when reading DS9 region
+  files. If set to 'ds9', DS9 plotting defaults are used. If not set or
+  set to 'mpl' or None, then the matplotlib defaults will be used, with
+  the exception that fill is turned off for Patch and Line2D artists.
+
 
 0.5 (2021-07-20)
 ================

--- a/docs/plotting.rst
+++ b/docs/plotting.rst
@@ -24,6 +24,14 @@ object.
     axes.set_xlim([-0.5, 1])
     axes.set_ylim([-0.5, 1])
 
+The default keyword arguments for the matplotlib artist depend on the
+value of the ``default_style`` keyword in the `~regions.RegionVisual`
+dictionary. This keyword is currently set (to a value of 'ds9') only
+when reading from DS9 region files. If this keyword is not set or set
+to 'mpl' or `None`, then the matplotlib defaults will be used, with the
+exception that fill is turned off for `~matplotlib.patches.Patch` and
+`~matplotlib.lines.Line2D` artists.
+
 The :meth:`regions.PixelRegion.plot` method is a convenience method that
 combines these two steps (creating a matplotlib patch artist and adding
 it to an axis). If no axis is passed then it calls ``plt.gca()``.

--- a/docs/region_io.rst
+++ b/docs/region_io.rst
@@ -116,7 +116,7 @@ parsed for the ``fits`` format::
     >>> print(regions)
     [<CirclePixelRegion(center=PixCoord(x=146.1, y=253.17), radius=3.1)>]
     >>> print(regions[0].visual)
-    {'color': 'green'}
+    {'color': 'green', 'default_style': 'ds9'}
 
 
 Serialize

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -34,6 +34,7 @@ class CompoundPixelRegion(PixelRegion):
     _params = ('region1', 'region2', 'operator')
     region1 = RegionType('region1', PixelRegion)
     region2 = RegionType('region2', PixelRegion)
+    mpl_artist = 'Patch'
 
     def __init__(self, region1, region2, operator, meta=None, visual=None):
         if not callable(operator):
@@ -149,7 +150,7 @@ class CompoundPixelRegion(PixelRegion):
 
             # set mpl_kwargs before as_artist is called on region1 and
             # region2
-            mpl_kwargs = self._define_mpl_kwargs(artist='Patch')
+            mpl_kwargs = self.visual.define_mpl_kwargs(self.mpl_artist)
             mpl_kwargs.update(kwargs)
 
             patch_inner = self.region1.as_artist(origin=origin)

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -318,47 +318,6 @@ class PixelRegion(Region):
         """
         raise NotImplementedError
 
-    def _define_mpl_kwargs(self, artist='Patch'):
-        """
-        Define a dictionary of matplotlib keywords for the input
-        ``artist`` from the region's ``visual`` properties.
-
-        Unset ``visual`` properties are set to default values based on
-        the DS9 convention.
-        """
-        from ..io.ds9.core import valid_symbols_ds9
-
-        if artist not in ('Patch', 'Line2D', 'Text'):
-            raise ValueError(f'artist "{artist}" is not supported')
-
-        kwargs = {}
-        kwargs['color'] = self.visual.get('color', 'green')
-        kwargs['label'] = self.meta.get('label', '')
-
-        if artist == 'Text':
-            kwargs['family'] = self.visual.get('font', 'helvetica')
-            kwargs['style'] = self.visual.get('fontsyle', 'normal')
-            kwargs['weight'] = self.visual.get('fontweight', 'roman')
-            kwargs['size'] = self.visual.get('fontsize', '12')
-            kwargs['rotation'] = self.visual.get('textangle', '0')
-        else:
-            kwargs['linewidth'] = self.visual.get('linewidth', 1)
-            kwargs['linestyle'] = self.visual.get('linstyle', 'solid')
-
-            if artist == 'Line2D':
-                boxcircle = valid_symbols_ds9['boxcircle']
-                kwargs['marker'] = self.visual.get('symbol', boxcircle)
-                kwargs['markersize'] = self.visual.get('symsize', 11)
-                kwargs['markeredgecolor'] = kwargs['color']
-                kwargs['markeredgewidth'] = self.visual.get('width', 1)
-                kwargs['fillstyle'] = self.visual.get('fill', 'none')
-
-            if artist == 'Patch':
-                kwargs['edgecolor'] = kwargs.pop('color')
-                kwargs['fill'] = self.visual.get('fill', False)
-
-        return kwargs
-
     def plot(self, origin=(0, 0), ax=None, **kwargs):
         """
         Plot the region on a matplotlib `~matplotlib.axes.Axes`

--- a/regions/core/metadata.py
+++ b/regions/core/metadata.py
@@ -111,7 +111,7 @@ class RegionVisual(Meta):
 
                 kwargs['marker'] = valid_symbols_ds9['boxcircle']
                 kwargs['markersize'] = 11
-                kwargs['markeredgecolor'] = kwargs['color']
+                kwargs['markeredgecolor'] = kwargs.pop('color')
                 kwargs['fillstyle'] = 'none'
             elif artist == 'Patch':
                 kwargs['edgecolor'] = kwargs.pop('color')

--- a/regions/core/metadata.py
+++ b/regions/core/metadata.py
@@ -121,3 +121,80 @@ class RegionVisual(Meta):
                 raise ValueError('invalid visual["default"] value')
 
         return kwargs
+
+    def _to_mpl_kwargs(self, artist):
+        """
+        Convert the visual metadata to a dictionary of matplotlib
+        keyword arguments for the given artist.
+
+        Parameters
+        ----------
+        artist : {'Text', 'Line2D', 'Patch'}
+            The matplotlib artist type.
+
+        Returns
+        -------
+        result : dict
+            A dictionary of matplotlib keyword arguments.
+        """
+        kwargs = {}
+
+        if artist == 'Text':
+            keymap = {'font': 'family',
+                      'fontstyle': 'style',
+                      'fontweight': 'weight',
+                      'fontsize': 'size',
+                      'textangle': 'rotation'}
+
+        elif artist == 'Line2D':
+            keymap = {'symbol': 'marker',
+                      'symsize': 'markersize',
+                      'color': 'markeredgecolor',
+                      'linewidth': 'markeredgewidth',
+                      'fill': 'fillstyle'}
+
+        elif artist == 'Patch':
+            keymap = {'color': 'edgecolor',
+                      'fill': 'fill'}
+
+        else:
+            raise ValueError('invalid artist type')
+
+        kwargs = {}
+        for name, val in self.items():
+            if name in keymap:
+                # NOTE: this will override existing mpl kwargs
+                kwargs[keymap[name]] = val
+            else:
+                kwargs[name] = val
+
+        default_style = kwargs.pop('default_style', None)
+        if default_style == 'ds9':
+            for key, val in kwargs.items():
+                if val == 'green':
+                    # X11/mpl green is #008000, ds9 uses #00ff00
+                    kwargs[key] = '#00ff00'
+
+        return kwargs
+
+    def define_mpl_kwargs(self, artist):
+        """
+        Define a dictionary of matplotlib keywords for the input
+        ``artist`` from the region's ``visual`` properties.
+
+        Parameters
+        ----------
+        artist : {'Text', 'Line2D', 'Patch'}
+            The matplotlib artist type.
+
+        Returns
+        -------
+        result : dict
+            A dictionary of matplotlib keyword arguments.
+        """
+        if artist not in ('Patch', 'Line2D', 'Text'):
+            raise ValueError(f'artist "{artist}" is not supported')
+
+        kwargs = self._define_default_mpl_kwargs(artist)
+        kwargs.update(self._to_mpl_kwargs(artist))
+        return kwargs

--- a/regions/core/metadata.py
+++ b/regions/core/metadata.py
@@ -72,10 +72,10 @@ class RegionVisual(Meta):
         Define the default matplotlib kwargs for the specified artist.
 
         The kwargs depend on the value of self.visual['default_style'],
-        which can be set when reading region files. If this is not set
-        or set to `mpl' or `None`, then the matplotlib defaults will be
-        used, with the exception that Patch and Line2D fill is turned
-        off.
+        which can be set when reading region files. If this keywords is
+        not set or set to 'mpl' or `None`, then the matplotlib defaults
+        will be used, with the exception fill is turned off for Patch
+        and Line2D objects.
 
         Parameters
         ----------

--- a/regions/core/metadata.py
+++ b/regions/core/metadata.py
@@ -63,6 +63,61 @@ class RegionVisual(Meta):
     valid_keys = ['color', 'dash', 'dashlist', 'fill', 'font', 'fontsize',
                   'fontstyle', 'fontweight', 'labeloff', 'labelpos', 'line',
                   'linestyle', 'linewidth', 'symbol', 'symsize', 'symthick',
-                  'textangle', 'usetex']
+                  'textangle', 'usetex', 'default_style']
 
     key_mapping = {'point': 'symbol', 'width': 'linewidth'}
+
+    def _define_default_mpl_kwargs(self, artist):
+        """
+        Define the default matplotlib kwargs for the specified artist.
+
+        The kwargs depend on the value of self.visual['default_style'],
+        which can be set when reading region files. If this is not set
+        or set to `mpl' or `None`, then the matplotlib defaults will be
+        used, with the exception that Patch and Line2D fill is turned
+        off.
+
+        Parameters
+        ----------
+        artist : {'Text', 'Line2D', 'Patch'}
+            The matplotlib artist type.
+
+        Returns
+        -------
+        result : dict
+            A dictionary of matplotlib keyword arguments.
+        """
+        kwargs = {}
+
+        default_style = self.get('default_style', None)
+        if default_style is None or default_style == 'mpl':
+            # do not fill by default, which is the only change from
+            # matplotlib defaults
+            if artist == 'Patch':
+                kwargs['fill'] = False
+            elif artist == 'Line2D':
+                kwargs['fillstyle'] = 'none'
+                kwargs['marker'] = 'o'
+            return kwargs
+
+        # 'ds9' style is set when reading from ds9 region files
+        elif default_style == 'ds9':
+            kwargs['color'] = '#00ff00'  # green
+            if artist == 'Text':
+                kwargs['ha'] = 'center'  # text horizontal alignment
+                kwargs['va'] = 'center'  # text vertical alignment
+            elif artist == 'Line2D':
+                from ..io.ds9.core import valid_symbols_ds9
+
+                kwargs['marker'] = valid_symbols_ds9['boxcircle']
+                kwargs['markersize'] = 11
+                kwargs['markeredgecolor'] = kwargs['color']
+                kwargs['fillstyle'] = 'none'
+            elif artist == 'Patch':
+                kwargs['edgecolor'] = kwargs.pop('color')
+                kwargs['fill'] = False
+
+            else:
+                raise ValueError('invalid visual["default"] value')
+
+        return kwargs

--- a/regions/io/core.py
+++ b/regions/io/core.py
@@ -669,7 +669,7 @@ class _Shape:
                         'symsize', 'symbol', 'symsize', 'fontsize',
                         'fontstyle', 'usetex', 'labelpos', 'labeloff',
                         'linewidth', 'linestyle', 'point', 'textangle',
-                        'fontweight', 'symthick']
+                        'fontweight', 'symthick', 'default_style']
 
         if isinstance(coords[0], SkyCoord):
             reg = self.shape_to_sky_region[self.region_type](*coords)

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -505,6 +505,7 @@ class _DS9RegionParser:
         self.include = (self.meta.get('include', True)
                         if self.include == '' else self.include != '-')
         self.meta['include'] = self.include
+        self.meta['default_style'] = 'ds9'
 
     def make_shape(self):
         """

--- a/regions/io/ds9/tests/test_ds9.py
+++ b/regions/io/ds9/tests/test_ds9.py
@@ -418,3 +418,53 @@ def test_compound_color():
               'annulus(651.0,301.0,60.0,90.0) # color=red')
     regions = Regions.parse(regstr, format='ds9')
     assert regions[0].as_artist().get_edgecolor() == (1., 0., 0., 1.)
+
+
+@pytest.mark.skipif('not HAS_MATPLOTLIB')
+def test_default_mpl_kwargs():
+    # Patch
+    regstr = ('# Region file format: DS9 astropy/regions\n'
+              'image\n'
+              'circle(101.0,101.0,3.0) # color=red\n'
+              'circle(101.0,301.0,3.0)\n'
+              'point(101.0,101.0) # color=red\n'
+              'point(101.0,301.0)\n'
+              'text(101.0,101.0) # text={Text} color=red\n'
+              'text(101.0,101.0) # text={Text}')
+    regions = Regions.parse(regstr, format='ds9')
+
+    assert regions[0].visual['default_style'] == 'ds9'
+    assert regions[0].as_artist().get_edgecolor() == (1, 0, 0, 1)
+    assert regions[1].as_artist().get_edgecolor() == (0, 1, 0, 1)
+
+    for i in (0, 1):
+        regions[i].visual['default_style'] = None
+    assert regions[0].as_artist().get_edgecolor() == (1, 0, 0, 1)
+    assert regions[1].as_artist().get_edgecolor() == (0, 0, 0, 1)
+
+    # Line2D
+    assert regions[2].visual['default_style'] == 'ds9'
+    assert regions[2].as_artist().get_markeredgecolor() == 'red'
+    assert regions[3].as_artist().get_markeredgecolor() == '#00ff00'
+
+    for i in (2, 3):
+        regions[i].visual['default_style'] = None
+    assert regions[2].as_artist().get_markeredgecolor() == 'red'
+    assert regions[3].as_artist().get_markeredgecolor() == 'C0'
+
+    # Text
+    assert regions[4].visual['default_style'] == 'ds9'
+    assert regions[4].as_artist().get_color() == 'red'
+    assert regions[5].as_artist().get_color() == '#00ff00'
+
+    for i in (4, 5):
+        assert regions[i].as_artist().get_va() == 'center'
+        assert regions[i].as_artist().get_ha() == 'center'
+
+    for i in (4, 5):
+        regions[i].visual['default_style'] = None
+        assert regions[i].as_artist().get_va() == 'baseline'
+        assert regions[i].as_artist().get_ha() == 'left'
+
+    assert regions[4].as_artist().get_color() == 'red'
+    assert regions[5].as_artist().get_color() == 'black'

--- a/regions/io/ds9/tests/test_ds9.py
+++ b/regions/io/ds9/tests/test_ds9.py
@@ -404,11 +404,11 @@ def test_point_boxcircle():
     regions = Regions.parse(regstr, format='ds9')
 
     assert isinstance(regions[0].as_artist().get_marker(), mpath.Path)
-    assert regions[0].as_artist().get_color() == 'red'
+    assert regions[0].as_artist().get_markeredgecolor() == 'red'
     assert isinstance(regions[1].visual['symbol'], mpath.Path)
-    assert regions[1].as_artist().get_color() == 'blue'
+    assert regions[1].as_artist().get_markeredgecolor() == 'blue'
     assert isinstance(regions[2].as_artist().get_marker(), mpath.Path)
-    assert regions[2].as_artist().get_color() == 'green'
+    assert regions[2].as_artist().get_markeredgecolor() == '#00ff00'
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -65,6 +65,7 @@ class CirclePixelRegion(PixelRegion):
     _params = ('center', 'radius')
     center = ScalarPix('center')
     radius = ScalarLength('radius')
+    mpl_artist = 'Patch'
 
     def __init__(self, center, radius, meta=None, visual=None):
         self.center = center
@@ -154,8 +155,7 @@ class CirclePixelRegion(PixelRegion):
 
         xy = self.center.x - origin[0], self.center.y - origin[1]
         radius = self.radius
-
-        mpl_kwargs = self._define_mpl_kwargs(artist='Patch')
+        mpl_kwargs = self.visual.define_mpl_kwargs(self.mpl_artist)
         mpl_kwargs.update(kwargs)
 
         return Circle(xy=xy, radius=radius, **mpl_kwargs)

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -78,6 +78,7 @@ class EllipsePixelRegion(PixelRegion):
     width = ScalarLength('width')
     height = ScalarLength('height')
     angle = QuantityLength('angle')
+    mpl_artist = 'Patch'
 
     def __init__(self, center, width, height, angle=0. * u.deg, meta=None,
                  visual=None):
@@ -202,7 +203,7 @@ class EllipsePixelRegion(PixelRegion):
         # matplotlib expects rotation in degrees (anti-clockwise)
         angle = self.angle.to('deg').value
 
-        mpl_kwargs = self._define_mpl_kwargs(artist='Patch')
+        mpl_kwargs = self.visual.define_mpl_kwargs(self.mpl_artist)
         mpl_kwargs.update(kwargs)
 
         return Ellipse(xy=xy, width=width, height=height, angle=angle,

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -58,6 +58,7 @@ class LinePixelRegion(PixelRegion):
     _params = ('start', 'end')
     start = ScalarPix('start')
     end = ScalarPix('end')
+    mpl_artist = 'Patch'
 
     def __init__(self, start, end, meta=None, visual=None):
         self.start = start
@@ -130,7 +131,7 @@ class LinePixelRegion(PixelRegion):
         dy = self.end.y - self.start.y
         kwargs.setdefault("width", 0.1)
 
-        mpl_kwargs = self._define_mpl_kwargs(artist='Patch')
+        mpl_kwargs = self.visual.define_mpl_kwargs(self.mpl_artist)
         mpl_kwargs.update(kwargs)
 
         return Arrow(x, y, dx, dy, **mpl_kwargs)

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -62,6 +62,7 @@ class PointPixelRegion(PixelRegion):
 
     _params = ('center',)
     center = ScalarPix('center')
+    mpl_artist = 'Line2D'
 
     def __init__(self, center, meta=None, visual=None):
         self.center = center
@@ -120,7 +121,7 @@ class PointPixelRegion(PixelRegion):
         """
         from matplotlib.lines import Line2D
 
-        mpl_kwargs = self._define_mpl_kwargs(artist='Line2D')
+        mpl_kwargs = self.visual.define_mpl_kwargs(self.mpl_artist)
         mpl_kwargs.update(kwargs)
 
         return Line2D([self.center.x - origin[0]],

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -62,6 +62,7 @@ class PolygonPixelRegion(PixelRegion):
 
     _params = ('vertices',)
     vertices = OneDPix('vertices')
+    mpl_artist = 'Patch'
 
     def __init__(self, vertices, meta=None, visual=None,
                  origin=PixCoord(0, 0)):
@@ -169,7 +170,7 @@ class PolygonPixelRegion(PixelRegion):
         xy = np.vstack([self.vertices.x - origin[0],
                         self.vertices.y - origin[1]]).transpose()
 
-        mpl_kwargs = self._define_mpl_kwargs(artist='Patch')
+        mpl_kwargs = self.visual.define_mpl_kwargs(self.mpl_artist)
         mpl_kwargs.update(kwargs)
 
         return Polygon(xy=xy, **mpl_kwargs)

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -76,6 +76,7 @@ class RectanglePixelRegion(PixelRegion):
     width = ScalarLength('width')
     height = ScalarLength('height')
     angle = QuantityLength('angle')
+    mpl_artist = 'Patch'
 
     def __init__(self, center, width, height, angle=0 * u.deg, meta=None,
                  visual=None):
@@ -195,7 +196,7 @@ class RectanglePixelRegion(PixelRegion):
         # matplotlib expects rotation in degrees (anti-clockwise)
         angle = self.angle.to('deg').value
 
-        mpl_kwargs = self._define_mpl_kwargs(artist='Patch')
+        mpl_kwargs = self.visual.define_mpl_kwargs(self.mpl_artist)
         mpl_kwargs.update(kwargs)
 
         return Rectangle(xy=xy, width=width, height=height,

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -51,6 +51,7 @@ class TextPixelRegion(PointPixelRegion):
     """
 
     _params = ('center', 'text')
+    mpl_artist = 'Text'
 
     def __init__(self, center, text, meta=None, visual=None):
         super().__init__(center, meta, visual)
@@ -83,7 +84,7 @@ class TextPixelRegion(PointPixelRegion):
         """
         from matplotlib.text import Text
 
-        mpl_kwargs = self._define_mpl_kwargs(artist='Text')
+        mpl_kwargs = self.visual.define_mpl_kwargs(self.mpl_artist)
         mpl_kwargs.update(kwargs)
 
         return Text(self.center.x - origin[0], self.center.y - origin[1],


### PR DESCRIPTION
The default matplotlib keywords that are used when plotting now depend on the value of ``self.visual['default_style']``. This keyword is currently set (to a value of 'ds9') only when reading DS9 region files. If set to 'ds9', DS9 plotting defaults are used.  I think users expect that plotting regions defined by reading in a DS9 region file would look like DS9 plots.  If this is not desired, then DS9 defaults can be turned off simply by deleting ``self.visual['default_style']`` or setting it to 'mpl' or None.

If this keyword is not set or set to 'mpl' or None, then the matplotlib defaults will be used, with the exception that fill is turned off for Patch and Line2D artists. This is effectively the new plotting default except for the case where regions are defined by reading in DS9 region files.

CRTF regions already use matplotlib defaults.  FITS regions do not have style defaults.

Closes #316