### PR TITLE
Fix for Issue 407: CRTF region parsing

### DIFF
--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -482,10 +482,20 @@ class _CRTFCoordinateParser:
             return u.Quantity(string_rep[:-3], u.dimensionless_unscaled)
         if 'h' in string_rep or 'rad' in string_rep:
             return Angle(string_rep)
+
+        # CRTF format apparently implicitly defines
+        # 18:20:30.12
+        # strings as hour units, and
+        # 10.11.54.69
+        # as degrees.
+        # I can't find this definition in documentation anywhere, though.
         if len(string_rep.split('.')) >= 3:
             string_rep = string_rep.replace('.', ':', 2)
+            unit = u.deg
+        elif string_rep.count(":") == 2:
+            unit = u.hour
 
-        return Angle(string_rep, u.deg)
+        return Angle(string_rep, unit)
 
     @staticmethod
     def parse_angular_length_quantity(string_rep):

--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -489,9 +489,9 @@ class _CRTFCoordinateParser:
         # 10.11.54.69
         # as degrees.
         # I can't find this definition in documentation anywhere, though.
+        unit = u.deg
         if len(string_rep.split('.')) >= 3:
             string_rep = string_rep.replace('.', ':', 2)
-            unit = u.deg
         elif string_rep.count(":") == 2:
             unit = u.hour
 

--- a/regions/io/crtf/tests/data/crtf_carta_sexagesimal.crtf
+++ b/regions/io/crtf/tests/data/crtf_carta_sexagesimal.crtf
@@ -1,0 +1,5 @@
+#CRTFv0 CASA Region Text Format version 0
+symbol [[18:47:44.02103, -001.54.58.0916], .] coord=J2000, corr=[I], linewidth=2, linestyle=-, symsize=1, symthick=1, color=2ee6d6, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false
+symbol [[18:47:44.04110, -001.54.56.5869], .] coord=J2000, corr=[I], linewidth=2, linestyle=-, symsize=1, symthick=1, color=2ee6d6, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false
+symbol [[18:47:44.06118, -001.54.55.0070], .] coord=J2000, corr=[I], linewidth=2, linestyle=-, symsize=1, symthick=1, color=2ee6d6, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false
+symbol [[18:47:44.10133, -001.54.53.7280], .] coord=J2000, corr=[I], linewidth=2, linestyle=-, symsize=1, symthick=1, color=2ee6d6, font=Helvetica, fontsize=10, fontstyle=bold, usetex=false

--- a/regions/io/crtf/tests/test_crtf.py
+++ b/regions/io/crtf/tests/test_crtf.py
@@ -6,6 +6,7 @@ Tests for the crtf subpackage.
 from astropy.coordinates import Angle, SkyCoord
 import astropy.units as u
 from astropy.utils.data import get_pkg_data_filename
+from astropy.tests.helper import assert_quantity_allclose
 import pytest
 
 from ....shapes.circle import CircleSkyRegion

--- a/regions/io/crtf/tests/test_crtf.py
+++ b/regions/io/crtf/tests/test_crtf.py
@@ -223,4 +223,4 @@ def test_read_sexagesimal_regression407():
     filename = get_pkg_data_filename(filename)
     regs = Regions.read(filename, errors='warn', format='crtf')
 
-    assert regs[0].center.ra == 281.93342096*u.deg
+    assert_quantity_allclose(regs[0].center.ra, 281.93342096 * u.deg, rtol=1e-9)

--- a/regions/io/crtf/tests/test_crtf.py
+++ b/regions/io/crtf/tests/test_crtf.py
@@ -140,7 +140,7 @@ def test_issue_312_regression():
                            'fk5', '.6f')])
 def test_file_crtf(filename, outname, coordsys, fmt):
     """
-    The "labelcolor" example is e regression test for Issue 405
+    The "labelcolor" example is a regression test for Issue 405
     The others are just a general serialization self-consistency check.
     """
     filename = get_pkg_data_filename(filename)
@@ -216,3 +216,11 @@ def test_angle_serialization():
     expected = ('#CRTFv0\nglobal coord=J2000\ncircle[[10.000009deg, '
                 '20.000002deg], 0.000278deg]\n')
     assert regstr == expected
+
+
+def test_read_sexagesimal_regression407():
+    filename = 'data/crtf_carta_sexagesimal.crtf'
+    filename = get_pkg_data_filename(filename)
+    regs = Regions.read(filename, errors='warn', format='crtf')
+
+    assert regs[0].center.ra == 281.93342096*u.deg


### PR DESCRIPTION
CRTFs appear to interpret :'s as hour-separating, .'s as degree-separating.