### PR TITLE
MNT: Stop using deprecated astropy.tests stuff

### DIFF
--- a/regions/conftest.py
+++ b/regions/conftest.py
@@ -44,15 +44,3 @@ def pytest_configure(config):
         from . import __version__
         packagename = os.path.basename(os.path.dirname(__file__))
         TESTED_VERSIONS[packagename] = __version__
-
-# Uncomment the last two lines in this block to treat all
-# DeprecationWarnings as exceptions.
-# To ignore some packages that produce deprecation warnings on import
-# (in addition to 'compiler', 'scipy', 'pygments', 'ipykernel', and
-# 'setuptools'), add:
-#     modules_to_ignore_on_import=['module_1', 'module_2']
-# To ignore some specific deprecation warning messages for Python
-# version MAJOR.MINOR or later, add:
-#     warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
-from astropy.tests.helper import enable_deprecations_as_exceptions  # noqa
-enable_deprecations_as_exceptions()

--- a/regions/io/ds9/tests/test_ds9.py
+++ b/regions/io/ds9/tests/test_ds9.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 from astropy.coordinates import Angle, SkyCoord
-from astropy.tests.helper import catch_warnings, assert_quantity_allclose
+from astropy.tests.helper import assert_quantity_allclose
 import astropy.units as u
 from astropy.utils.data import get_pkg_data_filename, get_pkg_data_filenames
 from astropy.utils.exceptions import AstropyUserWarning
@@ -30,7 +30,7 @@ def test_read():
     # Check that all test files including reference files are readable
     files = get_pkg_data_filenames('data')
     # DS9RegionParserWarning from non-supported panda, [b/e]panda regions
-    with catch_warnings(DS9RegionParserWarning):
+    with pytest.warns(DS9RegionParserWarning):
         for file in files:
             with open(file) as fh:
                 _DS9Parser(fh.read(), errors='warn')
@@ -52,7 +52,7 @@ def test_file(filename):
     filename = get_pkg_data_filename(filename)
 
     # DS9RegionParserWarnings from skipped multi-annulus regions
-    with catch_warnings(DS9RegionParserWarning):
+    with pytest.warns(DS9RegionParserWarning):
         regs = Regions.read(filename, errors='warn', format='ds9')
 
     coordsys = os.path.basename(filename).split(".")[1]
@@ -141,14 +141,12 @@ def test_missing_region_warns():
 
     # this will warn on both the commented first line and the
     # not_a_region line
-    with catch_warnings(AstropyUserWarning) as ASWarn:
-        regions = Regions.parse(ds9_str, format='ds9', errors='warn')
-
-    assert len(regions) == 1
-    assert len(ASWarn) == 1
     estr = ('Region type "notaregiontype" was found, but it is not one '
             'of the supported region types.')
-    assert estr in str(ASWarn[0].message)
+    with pytest.warns(AstropyUserWarning, match=estr) as ASWarn:
+        regions = Regions.parse(ds9_str, format='ds9', errors='warn')
+    assert len(regions) == 1
+    assert len(ASWarn) == 1
 
 
 def test_global_parser():

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -96,6 +96,9 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         assert_allclose(reg.center.xy, (1, 4))
         assert_allclose(reg.angle.to_value("deg"), 95)
 
+    # TODO: Is this MatplotlibDeprecationWarning something to worry about?
+    @pytest.mark.filterwarnings(r"ignore:The 'rectprops' parameter of "
+                                r"__init__\(\) has been renamed 'props'")
     @pytest.mark.parametrize('sync', (False, True))
     def test_as_mpl_selector(self, sync):
 

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -100,6 +100,9 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
         assert_allclose(reg.center.xy, (1, 4))
         assert_allclose(reg.angle.to_value('deg'), 95)
 
+    # TODO: Is this MatplotlibDeprecationWarning something to worry about?
+    @pytest.mark.filterwarnings(r"ignore:The 'rectprops' parameter of "
+                                r"__init__\(\) has been renamed 'props'")
     @pytest.mark.parametrize('sync', (False, True))
     def test_as_mpl_selector(self, sync):
         plt = pytest.importorskip('matplotlib.pyplot')

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ filterwarnings =
     ignore:numpy\.ufunc size changed:RuntimeWarning
     ignore:numpy\.ndarray size changed:RuntimeWarning
     ignore:unclosed file:ResourceWarning
+    ignore:distutils Version classes are deprecated:DeprecationWarning
 markers =
     array_compare
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,9 @@ doctest_norecursedirs =
 doctest_subpackage_requires =
     docs/plot_*.py = matplotlib
 filterwarnings =
-    ignore:numpy.ufunc size changed:RuntimeWarning
+    error
+    ignore:numpy\.ufunc size changed:RuntimeWarning
+    ignore:numpy\.ndarray size changed:RuntimeWarning
     ignore:unclosed file:ResourceWarning
 markers =
     array_compare


### PR DESCRIPTION
This pull request is to remove soon to be deprecated code; also see astropy/astropy#12633 .

* MNT: Stop using deprecated astropy.tests stuff
* TST: Turn unhandled pytest warnings into exceptions