### PR TITLE
Fix codestyle errors

### DIFF
--- a/regions/io/crtf/tests/test_casa_mask.py
+++ b/regions/io/crtf/tests/test_casa_mask.py
@@ -12,6 +12,7 @@ from ..write import _write_crtf
 
 try:
     from casatools import image, simulator
+    from casatools import measures as me
     from casatasks import tclean
     HAS_CASATOOLS = True
 except ImportError:

--- a/regions/io/crtf/tests/test_crtf.py
+++ b/regions/io/crtf/tests/test_crtf.py
@@ -198,7 +198,7 @@ def test_angle_serialization():
     Regression test for issue #223 to ensure Angle arcsec inputs are
     correctly converted to degrees.
     """
-    reg = Regions([CircleSkyRegion(SkyCoord(10,20, unit='deg'),
+    reg = Regions([CircleSkyRegion(SkyCoord(10, 20, unit='deg'),
                                    Angle(1, 'arcsec'))])
     regstr = reg.serialize(format='crtf')
     expected = ('#CRTFv0\nglobal coord=J2000\ncircle[[10.000009deg, '

--- a/regions/io/ds9/core.py
+++ b/regions/io/ds9/core.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from astropy.utils.exceptions import AstropyUserWarning
-import numpy as np
 
 try:
     import matplotlib  # noqa
@@ -30,7 +29,7 @@ if not HAS_MATPLOTLIB:
 else:
     import matplotlib.path as mpath
 
-    vertices = [[0., -1.], [0.2652031 , -1.],
+    vertices = [[0., -1.], [0.2652031, -1.],
                 [0.51957987, -0.89463369], [0.70710678, -0.70710678],
                 [0.89463369, -0.51957987], [1., -0.2652031],
                 [1., 0.], [1., 0.2652031], [0.89463369, 0.51957987],

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -22,7 +22,8 @@ __all__ = []
 regex_global = re.compile('^#? *(-?)([a-zA-Z0-9]+)')
 
 # Regular expression to extract meta attributes
-regex_meta = re.compile(r'([a-zA-Z]+)(\s*)(=)(\s*)({.*?}|\'.*?\'|\".*?\"|[0-9\s]+\s?|[^=\s]+\s?[0-9]*)\s?')
+regex_meta = re.compile(r'([a-zA-Z]+)(\s*)(=)(\s*)({.*?}|\'.*?\'|\".*?\"|'
+                        r'[0-9\s]+\s?|[^=\s]+\s?[0-9]*)\s?')
 
 # Regular expression to strip parenthesis
 regex_paren = re.compile('[()]')

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ requires =
 isolated_build = true
 indexserver =
     NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    NRAO = https://casa-pip.nrao.edu/repository/pypi-group/simple
 
 [testenv]
 # Pass through the following environment variables which may be needed
@@ -41,9 +42,9 @@ description =
     numpy119: with numpy 1.19.*
     numpy120: with numpy 1.20.*
     numpy121: with numpy 1.21.*
-
     astropy50: with astropy 5.0.*
     astropylts: with the latest astropy LTS
+    casa: with casatools and casatasks
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -60,9 +61,11 @@ deps =
     devdeps: :NIGHTLY:numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
 
+    casa: :NRAO:casatools
+    casa: :NRAO:casatasks
+
     oldestdeps: numpy==1.18
     oldestdeps: astropy==5.0
-    oldestdeps: scipy==1.6.0
     oldestdeps: matplotlib==3.1
     oldestdeps: pytest-astropy==0.4
 


### PR DESCRIPTION
~~This test requires python 3.6.  Also, I did some digging and this test was *never* running because `casatools` was not installed properly.  In fact, it cannot even pass because the `me` variable is never defined.~~

I've kept the test, adding `from casatools import measures as me`.