### PR TITLE
Add the ability to compare Region objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ New Features
 
 - Added a ``RegularPolygonPixelRegion`` class. [#398]
 
+- Added the ability to compare ``Region`` objects for equality. [#421]
+
 Bug Fixes
 ---------
 

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -68,9 +68,14 @@ class Region(abc.ABC):
         # now check the parameter values
         # Note that Quantity comparisons allow for different units
         # if they directly convertible (e.g., 1. * u.deg == 60. * u.arcmin)
-        for param in self_params:
-            if getattr(self, param) != getattr(other, param):
-                return False
+        try:
+            for param in self_params:
+                if getattr(self, param) != getattr(other, param):
+                    return False
+        except TypeError:
+            # TypeError is raised from SkyCoord comparison when they do
+            # not have equivalent frames
+            return False
 
         return True
 

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -46,6 +46,40 @@ class Region(abc.ABC):
                 cls_info.append((param, getattr(self, param)))
         return '\n'.join([f'{key}: {val}' for key, val in cls_info])
 
+    def __eq__(self, other):
+        """
+        Equality operator for Region.
+
+        All Region properties are compared for strict equality except
+        for Quantity parameters, which allow for different units if they
+        are directly convertible.
+        """
+        if not isinstance(other, self.__class__):
+            return False
+
+        meta_params = ['meta', 'visual']
+        self_params = list(self._params) + meta_params
+        other_params = list(other._params) + meta_params
+
+        # check that both have identical parameters
+        if self_params != other_params:
+            return False
+
+        # now check the parameter values
+        # Note that Quantity comparisons allow for different units
+        # if they directly convertible (e.g., 1. * u.deg == 60. * u.arcmin)
+        for param in self_params:
+            if getattr(self, param) != getattr(other, param):
+                return False
+
+        return True
+
+    def __ne__(self, other):
+        """
+        Inequality operator for Region.
+        """
+        return not (self == other)
+
     @abc.abstractmethod
     def intersection(self, other):
         """

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -3,6 +3,8 @@ import abc
 import copy
 import operator
 
+import numpy as np
+
 from .metadata import RegionMeta, RegionVisual
 from .pixcoord import PixCoord
 from .registry import RegionsRegistry
@@ -70,11 +72,13 @@ class Region(abc.ABC):
         # if they directly convertible (e.g., 1. * u.deg == 60. * u.arcmin)
         try:
             for param in self_params:
-                if getattr(self, param) != getattr(other, param):
+                # np.any is used for SkyCoord array comparisons
+                if np.any(getattr(self, param) != getattr(other, param)):
                     return False
         except TypeError:
             # TypeError is raised from SkyCoord comparison when they do
-            # not have equivalent frames
+            # not have equivalent frames. Here return False instead of
+            # the TypeError.
             return False
 
         return True

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -63,6 +63,12 @@ class TestCircleAnnulusPixelRegion(BaseTestPixelRegion):
         reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
         assert_allclose(reg.center.xy, (1, 4))
 
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.inner_radius = 3
+        assert reg != self.reg
+
 
 class TestCircleAnnulusSkyRegion(BaseTestSkyRegion):
     meta = RegionMeta({'text': 'test'})
@@ -101,6 +107,12 @@ class TestCircleAnnulusSkyRegion(BaseTestSkyRegion):
     def test_transformation(self):
         pixannulus = self.reg.to_pixel(wcs=self.wcs)
         assert isinstance(pixannulus, CircleAnnulusPixelRegion)
+
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.inner_radius = 10 * u.arcsec
+        assert reg != self.reg
 
 
 class TestEllipseAnnulusPixelRegion(BaseTestPixelRegion):
@@ -163,6 +175,12 @@ class TestEllipseAnnulusPixelRegion(BaseTestPixelRegion):
         assert_allclose(reg.center.xy, (1, 4))
         assert_allclose(reg.angle.to_value("deg"), 90)
 
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.outer_height = 10
+        assert reg != self.reg
+
 
 class TestEllipseAnnulusSkyRegion(BaseTestSkyRegion):
     meta = RegionMeta({'text': 'test'})
@@ -206,6 +224,12 @@ class TestEllipseAnnulusSkyRegion(BaseTestSkyRegion):
     def test_transformation(self):
         pixannulus = self.reg.to_pixel(wcs=self.wcs)
         assert isinstance(pixannulus, EllipseAnnulusPixelRegion)
+
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.outer_height = 85 * u.arcsec
+        assert reg != self.reg
 
 
 class TestRectangleAnnulusPixelRegion(BaseTestPixelRegion):
@@ -268,6 +292,12 @@ class TestRectangleAnnulusPixelRegion(BaseTestPixelRegion):
         assert_allclose(reg.center.xy, (1, 4))
         assert_allclose(reg.angle.to_value("deg"), 90)
 
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.outer_height = 10
+        assert reg != self.reg
+
 
 class TestRectangleAnnulusSkyRegion(BaseTestSkyRegion):
     meta = RegionMeta({'text': 'test'})
@@ -311,3 +341,9 @@ class TestRectangleAnnulusSkyRegion(BaseTestSkyRegion):
     def test_transformation(self):
         pixannulus = self.reg.to_pixel(wcs=self.wcs)
         assert isinstance(pixannulus, RectangleAnnulusPixelRegion)
+
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.outer_height = 85 * u.arcsec
+        assert reg != self.reg

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -62,6 +62,12 @@ class TestCirclePixelRegion(BaseTestPixelRegion):
         reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
         assert_allclose(reg.center.xy, (1, 4))
 
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.radius = 3
+        assert reg != self.reg
+
 
 class TestCircleSkyRegion(BaseTestSkyRegion):
     meta = RegionMeta({'text': 'test'})
@@ -113,3 +119,9 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
         # 1,2 is outside, 3,4 is the center and is inside
         assert all(self.reg.contains(position, wcs)
                    == np.array([False, True], dtype='bool'))
+
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.radius = 3 * u.arcsec
+        assert reg != self.reg

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -67,6 +67,17 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         assert_allclose(patch.height, 3)
         assert_allclose(patch.angle, 5)
 
+    def test_rotate(self):
+        reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
+        assert_allclose(reg.center.xy, (1, 4))
+        assert_allclose(reg.angle.to_value("deg"), 95)
+
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.width = 3
+        assert reg != self.reg
+
     def test_region_bbox(self):
         a = 7
         b = 3
@@ -94,11 +105,6 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         reg = EllipsePixelRegion(PixCoord(50, 50), width=0, height=10,
                                  angle=0. * u.deg)
         assert reg.bounding_box.shape == (11, 1)
-
-    def test_rotate(self):
-        reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
-        assert_allclose(reg.center.xy, (1, 4))
-        assert_allclose(reg.angle.to_value("deg"), 95)
 
     @pytest.mark.skipif(MPL_VERSION < 33, reason='requires `do_event`')
     @pytest.mark.parametrize('sync', (False, True))
@@ -296,3 +302,9 @@ class TestEllipseSkyRegion(BaseTestSkyRegion):
         # 1,2 is outside, 3,4 is the center and is inside
         assert all(self.reg.contains(position, wcs)
                    == np.array([False, True], dtype='bool'))
+
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.width = 3 * u.deg
+        assert reg != self.reg

--- a/regions/shapes/tests/test_line.py
+++ b/regions/shapes/tests/test_line.py
@@ -66,6 +66,12 @@ class TestLinePixelRegion(BaseTestPixelRegion):
         assert_allclose(reg.start.xy, (1, 4))
         assert_allclose(reg.end.xy, (1, 5))
 
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.start = PixCoord(1, 2)
+        assert reg != self.reg
+
 
 class TestLineSkyRegion(BaseTestSkyRegion):
     meta = RegionMeta({'text': 'test'})
@@ -110,3 +116,11 @@ class TestLineSkyRegion(BaseTestSkyRegion):
         # lines do not contain things
         assert all(self.reg.contains(position, wcs)
                    == np.array([False, False], dtype='bool'))
+
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.start = SkyCoord(1 * u.deg, 2 * u.deg, frame='galactic')
+        assert reg != self.reg
+        reg.start = SkyCoord(3 * u.deg, 4 * u.deg, frame='icrs')
+        assert reg != self.reg

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -63,6 +63,12 @@ class TestPointPixelRegion(BaseTestPixelRegion):
         reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
         assert_allclose(reg.center.xy, (1, 4))
 
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.center = PixCoord(1, 2)
+        assert reg != self.reg
+
 
 class TestPointSkyRegion(BaseTestSkyRegion):
     meta = RegionMeta({'text': 'test'})
@@ -85,3 +91,9 @@ class TestPointSkyRegion(BaseTestSkyRegion):
         # points do not contain things
         assert all(self.reg.contains(position, wcs)
                    == np.array([False, False], dtype='bool'))
+
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.center = SkyCoord(1, 2, unit='deg')
+        assert reg != self.reg

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -119,6 +119,12 @@ class TestPolygonPixelRegion(BaseTestPixelRegion):
         reg2 = PolygonPixelRegion(relverts, origin=origin)
         assert_equal(reg1.vertices, reg2.vertices)
 
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.vertices = PixCoord([1, 3, 1], [1, 1, 6])
+        assert reg != self.reg
+
 
 class TestPolygonSkyRegion(BaseTestSkyRegion):
     meta = RegionMeta({'text': 'test'})
@@ -164,6 +170,12 @@ class TestPolygonSkyRegion(BaseTestSkyRegion):
         # 1,2 is outside, 3.25,3.75 should be inside the triangle...
         assert all(self.reg.contains(position, wcs)
                    == np.array([False, True], dtype='bool'))
+
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.vertices = SkyCoord([3, 4, 3], [3, 4, 6], unit='deg')
+        assert reg != self.reg
 
 
 class TestRegionPolygonPixelRegion(BaseTestPixelRegion):
@@ -247,3 +259,9 @@ class TestRegionPolygonPixelRegion(BaseTestPixelRegion):
                   64.14213562, 70.]
         assert_allclose(reg.vertices.x, x_vert)
         assert_allclose(reg.vertices.y, y_vert)
+
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.radius = 25.
+        assert reg != self.reg

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -103,6 +103,12 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
         assert_allclose(reg.center.xy, (1, 4))
         assert_allclose(reg.angle.to_value('deg'), 95)
 
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.angle = 35 * u.deg
+        assert reg != self.reg
+
     @pytest.mark.skipif(MPL_VERSION < 33, reason='requires `do_event`')
     @pytest.mark.parametrize('sync', (False, True))
     def test_as_mpl_selector(self, sync):
@@ -318,3 +324,9 @@ class TestRectangleSkyRegion(BaseTestSkyRegion):
         # 1,2 is outside, 3,4 is the center and is inside
         assert all(self.reg.contains(position, wcs)
                    == np.array([False, True], dtype='bool'))
+
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.angle = 10 * u.deg
+        assert reg != self.reg

--- a/regions/shapes/tests/test_text.py
+++ b/regions/shapes/tests/test_text.py
@@ -55,6 +55,12 @@ class TestTextPixelRegion(BaseTestPixelRegion):
         reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
         assert_allclose(reg.center.xy, (1, 4))
 
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.text = 'Hello World!'
+        assert reg != self.reg
+
 
 class TestTextSkyRegion(BaseTestSkyRegion):
     meta = RegionMeta({'text': 'test'})
@@ -78,3 +84,9 @@ class TestTextSkyRegion(BaseTestSkyRegion):
         # Nothing is in a text region
         assert all(self.reg.contains(position, wcs)
                    == np.array([False, False], dtype='bool'))
+
+    def test_eq(self):
+        reg = self.reg.copy()
+        assert reg == self.reg
+        reg.text = 'Hello World!'
+        assert reg != self.reg


### PR DESCRIPTION
This PR adds the ability to compare `Region` objects for equality (or inequality).  This is especially useful for testing.