### PR TITLE
Make converted region meta and visual data be copies and not views

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ New Features
 
 - Added the ability to compare ``Region`` objects for equality. [#421]
 
+- Added a ``copy`` method to ``RegionMeta`` and ``RegionVisual``. [#424]
+
 Bug Fixes
 ---------
 
@@ -33,7 +35,8 @@ Bug Fixes
   [#389]
 
 - Fixed an issue where sky/pixel conversions did not preserve ``meta``
-  and ``visual`` data for some regions. [#420]
+  and ``visual`` data for some regions. [#420, #424]
+
 
 API Changes
 -----------

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -92,8 +92,8 @@ class CompoundPixelRegion(PixelRegion):
         skyreg1 = self.region1.to_sky(wcs=wcs)
         skyreg2 = self.region2.to_sky(wcs=wcs)
         return CompoundSkyRegion(region1=skyreg1, operator=self.operator,
-                                 region2=skyreg2, meta=self.meta,
-                                 visual=self.visual)
+                                 region2=skyreg2, meta=self.meta.copy(),
+                                 visual=self.visual.copy())
 
     @staticmethod
     def _make_annulus_path(patch_inner, patch_outer):
@@ -249,8 +249,8 @@ class CompoundSkyRegion(SkyRegion):
         pixreg1 = self.region1.to_pixel(wcs=wcs)
         pixreg2 = self.region2.to_pixel(wcs=wcs)
         return CompoundPixelRegion(region1=pixreg1, operator=self.operator,
-                                   region2=pixreg2, meta=self.meta,
-                                   visual=self.visual)
+                                   region2=pixreg2, meta=self.meta.copy(),
+                                   visual=self.visual.copy())
 
     def as_artist(self, ax, **kwargs):
         raise NotImplementedError

--- a/regions/core/metadata.py
+++ b/regions/core/metadata.py
@@ -2,6 +2,7 @@
 """
 This module proves classes to handle region metadata.
 """
+from copy import deepcopy
 
 __all__ = ['Meta', 'RegionMeta', 'RegionVisual']
 
@@ -39,6 +40,12 @@ class Meta(dict):
     def __getitem__(self, item):
         item = self.key_mapping.get(item, item)
         return super().__getitem__(item)
+
+    def copy(self):
+        """
+        Make a deep copy of this object.
+        """
+        return deepcopy(self)
 
 
 class RegionMeta(Meta):

--- a/regions/core/tests/test_metadata.py
+++ b/regions/core/tests/test_metadata.py
@@ -1,0 +1,64 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Tests for the metadata module.
+"""
+import pytest
+
+from ..metadata import RegionMeta, RegionVisual
+
+
+def test_region_meta():
+    meta_dict = {'text': 'hello world', 'tag': ['Tag1', 'Tag2']}
+    meta = RegionMeta(meta_dict)
+
+    for key, val in meta_dict.items():
+        assert val == meta[key]
+
+    meta2 = meta.copy()
+    assert isinstance(meta2, RegionMeta)
+
+    text = 'new'
+    meta['text'] = text
+    assert meta2['text'] != text
+
+    with pytest.raises(KeyError):
+        RegionMeta({'invalid': 1})
+
+
+def test_region_visual():
+    meta_dict = {'color': 'blue', 'fontsize': 12}
+    meta = RegionVisual(meta_dict)
+
+    for key, val in meta_dict.items():
+        assert val == meta[key]
+
+    meta2 = meta.copy()
+    assert isinstance(meta2, RegionVisual)
+
+    color = 'green'
+    meta['color'] = color
+    assert meta2['color'] != color
+
+    with pytest.raises(KeyError):
+        RegionVisual({'invalid': 1})
+
+
+def test_region_visual_mpl_kwargs():
+    meta_dict = {'color': 'blue'}
+    meta = RegionVisual(meta_dict)
+
+    kwargs = meta.define_mpl_kwargs('Patch')
+    expected = {'edgecolor': 'blue', 'fill': False}
+    assert kwargs == expected
+
+    kwargs = meta.define_mpl_kwargs('Line2D')
+    expected = {'markeredgecolor': 'blue', 'fillstyle': 'none',
+                'marker': 'o'}
+    assert kwargs == expected
+
+    kwargs = meta.define_mpl_kwargs('Text')
+    expected = {'color': 'blue'}
+    assert kwargs == expected
+
+    with pytest.raises(ValueError):
+        meta.define_mpl_kwargs('invalid')

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -152,7 +152,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
         inner_radius = self.inner_radius * u.pix * pixscale
         outer_radius = self.outer_radius * u.pix * pixscale
         return CircleAnnulusSkyRegion(center, inner_radius, outer_radius,
-                                      self.meta, self.visual)
+                                      self.meta.copy(), self.visual.copy())
 
 
 class CircleAnnulusSkyRegion(SkyRegion):
@@ -192,7 +192,8 @@ class CircleAnnulusSkyRegion(SkyRegion):
         inner_radius = (self.inner_radius / pixscale).to(u.pix).value
         outer_radius = (self.outer_radius / pixscale).to(u.pix).value
         return CircleAnnulusPixelRegion(center, inner_radius, outer_radius,
-                                        meta=self.meta, visual=self.visual)
+                                        meta=self.meta.copy(),
+                                        visual=self.visual.copy())
 
 
 class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
@@ -394,8 +395,9 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
     _component_class = EllipsePixelRegion
 
     def to_sky(self, wcs):
-        return EllipseAnnulusSkyRegion(
-            *self.to_sky_args(wcs), meta=self.meta, visual=self.visual)
+        return EllipseAnnulusSkyRegion(*self.to_sky_args(wcs),
+                                       meta=self.meta.copy(),
+                                       visual=self.visual.copy())
 
 
 class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
@@ -432,8 +434,9 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
     _component_class = EllipseSkyRegion
 
     def to_pixel(self, wcs):
-        return EllipseAnnulusPixelRegion(
-            *self.to_pixel_args(wcs), meta=self.meta, visual=self.visual)
+        return EllipseAnnulusPixelRegion(*self.to_pixel_args(wcs),
+                                         meta=self.meta.copy(),
+                                         visual=self.visual.copy())
 
 
 class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
@@ -502,8 +505,9 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
     _component_class = RectanglePixelRegion
 
     def to_sky(self, wcs):
-        return RectangleAnnulusSkyRegion(
-            *self.to_sky_args(wcs), meta=self.meta, visual=self.visual)
+        return RectangleAnnulusSkyRegion(*self.to_sky_args(wcs),
+                                         meta=self.meta.copy(),
+                                         visual=self.visual.copy())
 
 
 class RectangleAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
@@ -541,5 +545,6 @@ class RectangleAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
     _component_class = RectangleSkyRegion
 
     def to_pixel(self, wcs):
-        return RectangleAnnulusPixelRegion(
-            *self.to_pixel_args(wcs), meta=self.meta, visual=self.visual)
+        return RectangleAnnulusPixelRegion(*self.to_pixel_args(wcs),
+                                           meta=self.meta.copy(),
+                                           visual=self.visual.copy())

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -90,8 +90,8 @@ class CirclePixelRegion(PixelRegion):
         center = pixel_to_skycoord(self.center.x, self.center.y, wcs)
         _, pixscale, _ = pixel_scale_angle_at_skycoord(center, wcs)
         radius = Angle(self.radius * u.pix * pixscale, 'arcsec')
-        return CircleSkyRegion(center, radius, meta=self.meta,
-                               visual=self.visual)
+        return CircleSkyRegion(center, radius, meta=self.meta.copy(),
+                               visual=self.visual.copy())
 
     @property
     def bounding_box(self):
@@ -213,5 +213,5 @@ class CircleSkyRegion(SkyRegion):
     def to_pixel(self, wcs):
         center, pixscale, _ = pixel_scale_angle_at_skycoord(self.center, wcs)
         radius = (self.radius / pixscale).to(u.pix).value
-        return CirclePixelRegion(center, radius, meta=self.meta,
-                                 visual=self.visual)
+        return CirclePixelRegion(center, radius, meta=self.meta.copy(),
+                                 visual=self.visual.copy())

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -116,7 +116,8 @@ class EllipsePixelRegion(PixelRegion):
         width = Angle(self.width * u.pix * pixscale, 'arcsec')
         return EllipseSkyRegion(center, width, height,
                                 angle=self.angle - (north_angle - 90 * u.deg),
-                                meta=self.meta, visual=self.visual)
+                                meta=self.meta.copy(),
+                                visual=self.visual.copy())
 
     @property
     def bounding_box(self):
@@ -369,4 +370,5 @@ class EllipseSkyRegion(SkyRegion):
         width = (self.width / pixscale).to(u.pixel).value
         angle = self.angle + (north_angle - 90 * u.deg)
         return EllipsePixelRegion(center, width, height, angle=angle,
-                                  meta=self.meta, visual=self.visual)
+                                  meta=self.meta.copy(),
+                                  visual=self.visual.copy())

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -84,7 +84,8 @@ class LinePixelRegion(PixelRegion):
     def to_sky(self, wcs):
         start = pixel_to_skycoord(self.start.x, self.start.y, wcs)
         end = pixel_to_skycoord(self.end.x, self.end.y, wcs)
-        return LineSkyRegion(start, end, meta=self.meta, visual=self.visual)
+        return LineSkyRegion(start, end, meta=self.meta.copy(),
+                             visual=self.visual.copy())
 
     @property
     def bounding_box(self):
@@ -198,4 +199,5 @@ class LineSkyRegion(SkyRegion):
         start = PixCoord(start_x, start_y)
         end_x, end_y = skycoord_to_pixel(self.end, wcs=wcs)
         end = PixCoord(end_x, end_y)
-        return LinePixelRegion(start, end, meta=self.meta, visual=self.visual)
+        return LinePixelRegion(start, end, meta=self.meta.copy(),
+                               visual=self.visual.copy())

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -87,7 +87,8 @@ class PointPixelRegion(PixelRegion):
 
     def to_sky(self, wcs):
         center = pixel_to_skycoord(self.center.x, self.center.y, wcs=wcs)
-        return PointSkyRegion(center, meta=self.meta, visual=self.visual)
+        return PointSkyRegion(center, meta=self.meta.copy(),
+                              visual=self.visual.copy())
 
     @property
     def bounding_box(self):
@@ -182,4 +183,5 @@ class PointSkyRegion(SkyRegion):
     def to_pixel(self, wcs):
         center_x, center_y = skycoord_to_pixel(self.center, wcs=wcs)
         center = PixCoord(center_x, center_y)
-        return PointPixelRegion(center, meta=self.meta, visual=self.visual)
+        return PointPixelRegion(center, meta=self.meta.copy(),
+                                visual=self.visual.copy())

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -103,8 +103,8 @@ class PolygonPixelRegion(PixelRegion):
 
     def to_sky(self, wcs):
         vertices_sky = pixel_to_skycoord(self.vertices.x, self.vertices.y, wcs)
-        return PolygonSkyRegion(vertices=vertices_sky, meta=self.meta,
-                                visual=self.visual)
+        return PolygonSkyRegion(vertices=vertices_sky, meta=self.meta.copy(),
+                                visual=self.visual.copy())
 
     @property
     def bounding_box(self):
@@ -363,5 +363,5 @@ class PolygonSkyRegion(SkyRegion):
     def to_pixel(self, wcs):
         x, y = skycoord_to_pixel(self.vertices, wcs)
         vertices_pix = PixCoord(x, y)
-        return PolygonPixelRegion(vertices_pix, meta=self.meta,
-                                  visual=self.visual)
+        return PolygonPixelRegion(vertices_pix, meta=self.meta.copy(),
+                                  visual=self.visual.copy())

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -112,7 +112,8 @@ class RectanglePixelRegion(PixelRegion):
         height = Angle(self.height * u.pix * pixscale, 'arcsec')
         angle = self.angle - (north_angle - 90 * u.deg)
         return RectangleSkyRegion(center, width, height, angle=angle,
-                                  meta=self.meta, visual=self.visual)
+                                  meta=self.meta.copy(),
+                                  visual=self.visual.copy())
 
     @property
     def bounding_box(self):
@@ -317,8 +318,8 @@ class RectanglePixelRegion(PixelRegion):
         """
         x, y = self.corners.T
         vertices = PixCoord(x=x, y=y)
-        return PolygonPixelRegion(vertices=vertices, meta=self.meta,
-                                  visual=self.visual)
+        return PolygonPixelRegion(vertices=vertices, meta=self.meta.copy(),
+                                  visual=self.visual.copy())
 
     def _lower_left_xy(self):
         """
@@ -408,4 +409,5 @@ class RectangleSkyRegion(SkyRegion):
         height = (self.height / pixscale).to(u.pix).value
         angle = self.angle + (north_angle - 90 * u.deg)
         return RectanglePixelRegion(center, width, height, angle=angle,
-                                    meta=self.meta, visual=self.visual)
+                                    meta=self.meta.copy(),
+                                    visual=self.visual.copy())

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -55,6 +55,12 @@ class TestCircleAnnulusPixelRegion(BaseTestPixelRegion):
         assert reg_new.meta == self.reg.meta
         assert reg_new.visual == self.reg.visual
 
+        # test that converted region meta and visual are copies and not views
+        reg_new.meta['text'] = 'new'
+        reg_new.visual['color'] = 'green'
+        assert reg_new.meta['text'] != self.reg.meta['text']
+        assert reg_new.visual['color'] != self.reg.visual['color']
+
     def test_transformation(self):
         skyannulus = self.reg.to_sky(wcs=self.wcs)
         assert isinstance(skyannulus, CircleAnnulusSkyRegion)
@@ -165,6 +171,12 @@ class TestEllipseAnnulusPixelRegion(BaseTestPixelRegion):
         assert_quantity_allclose(reg_new.angle, self.reg.angle)
         assert reg_new.meta == self.reg.meta
         assert reg_new.visual == self.reg.visual
+
+        # test that converted region meta and visual are copies and not views
+        reg_new.meta['text'] = 'new'
+        reg_new.visual['color'] = 'green'
+        assert reg_new.meta['text'] != self.reg.meta['text']
+        assert reg_new.visual['color'] != self.reg.visual['color']
 
     def test_transformation(self):
         skyannulus = self.reg.to_sky(wcs=self.wcs)
@@ -282,6 +294,12 @@ class TestRectangleAnnulusPixelRegion(BaseTestPixelRegion):
         assert_quantity_allclose(reg_new.angle, self.reg.angle)
         assert reg_new.meta == self.reg.meta
         assert reg_new.visual == self.reg.visual
+
+        # test that converted region meta and visual are copies and not views
+        reg_new.meta['text'] = 'new'
+        reg_new.visual['color'] = 'green'
+        assert reg_new.meta['text'] != self.reg.meta['text']
+        assert reg_new.visual['color'] != self.reg.visual['color']
 
     def test_transformation(self):
         skyannulus = self.reg.to_sky(wcs=self.wcs)

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -52,6 +52,12 @@ class TestCirclePixelRegion(BaseTestPixelRegion):
         assert reg_new.meta == self.reg.meta
         assert reg_new.visual == self.reg.visual
 
+        # test that converted region meta and visual are copies and not views
+        reg_new.meta['text'] = 'new'
+        reg_new.visual['color'] = 'green'
+        assert reg_new.meta['text'] != self.reg.meta['text']
+        assert reg_new.visual['color'] != self.reg.visual['color']
+
     @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def test_as_artist(self):
         patch = self.reg.as_artist()

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -59,6 +59,12 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         assert reg_new.meta == self.reg.meta
         assert reg_new.visual == self.reg.visual
 
+        # test that converted region meta and visual are copies and not views
+        reg_new.meta['text'] = 'new'
+        reg_new.visual['color'] = 'green'
+        assert reg_new.meta['text'] != self.reg.meta['text']
+        assert reg_new.visual['color'] != self.reg.visual['color']
+
     @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def test_as_artist(self):
         patch = self.reg.as_artist()

--- a/regions/shapes/tests/test_line.py
+++ b/regions/shapes/tests/test_line.py
@@ -56,6 +56,12 @@ class TestLinePixelRegion(BaseTestPixelRegion):
         assert reg_new.meta == self.reg.meta
         assert reg_new.visual == self.reg.visual
 
+        # test that converted region meta and visual are copies and not views
+        reg_new.meta['text'] = 'new'
+        reg_new.visual['color'] = 'green'
+        assert reg_new.meta['text'] != self.reg.meta['text']
+        assert reg_new.visual['color'] != self.reg.visual['color']
+
     @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def test_as_artist(self):
         patch = self.reg.as_artist()

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -49,6 +49,12 @@ class TestPointPixelRegion(BaseTestPixelRegion):
         assert reg_new.meta == self.reg.meta
         assert reg_new.visual == self.reg.visual
 
+        # test that converted region meta and visual are copies and not views
+        reg_new.meta['text'] = 'new'
+        reg_new.visual['color'] = 'green'
+        assert reg_new.meta['text'] != self.reg.meta['text']
+        assert reg_new.visual['color'] != self.reg.visual['color']
+
     @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def test_as_artist(self):
         artist = self.reg.as_artist()

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -63,6 +63,12 @@ class TestPolygonPixelRegion(BaseTestPixelRegion):
         assert reg_new.meta == self.reg.meta
         assert reg_new.visual == self.reg.visual
 
+        # test that converted region meta and visual are copies and not views
+        reg_new.meta['text'] = 'new'
+        reg_new.visual['color'] = 'green'
+        assert reg_new.meta['text'] != self.reg.meta['text']
+        assert reg_new.visual['color'] != self.reg.visual['color']
+
     def test_bounding_box(self):
         bbox = self.reg.bounding_box
         assert bbox == BoundingBox(ixmin=1, ixmax=4, iymin=1, iymax=5)

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -88,6 +88,12 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
         assert reg_new.meta == self.reg.meta
         assert reg_new.visual == self.reg.visual
 
+        # test that converted region meta and visual are copies and not views
+        reg_new.meta['text'] = 'new'
+        reg_new.visual['color'] = 'green'
+        assert reg_new.meta['text'] != self.reg.meta['text']
+        assert reg_new.visual['color'] != self.reg.visual['color']
+
     @pytest.mark.skipif('not HAS_MATPLOTLIB')
     def test_as_artist(self):
         patch = self.reg.as_artist()

--- a/regions/shapes/tests/test_text.py
+++ b/regions/shapes/tests/test_text.py
@@ -51,6 +51,12 @@ class TestTextPixelRegion(BaseTestPixelRegion):
         assert reg_new.meta == self.reg.meta
         assert reg_new.visual == self.reg.visual
 
+        # test that converted region meta and visual are copies and not views
+        reg_new.meta['text'] = 'new'
+        reg_new.visual['color'] = 'green'
+        assert reg_new.meta['text'] != self.reg.meta['text']
+        assert reg_new.visual['color'] != self.reg.visual['color']
+
     def test_rotate(self):
         reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
         assert_allclose(reg.center.xy, (1, 4))

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -59,8 +59,8 @@ class TextPixelRegion(PointPixelRegion):
 
     def to_sky(self, wcs):
         center = pixel_to_skycoord(self.center.x, self.center.y, wcs=wcs)
-        return TextSkyRegion(center, self.text, meta=self.meta,
-                             visual=self.visual)
+        return TextSkyRegion(center, self.text, meta=self.meta.copy(),
+                             visual=self.visual.copy())
 
     def as_artist(self, origin=(0, 0), **kwargs):
         """
@@ -118,5 +118,5 @@ class TextSkyRegion(PointSkyRegion):
     def to_pixel(self, wcs):
         center_x, center_y = skycoord_to_pixel(self.center, wcs=wcs)
         center = PixCoord(center_x, center_y)
-        return TextPixelRegion(center, self.text, meta=self.meta,
-                               visual=self.visual)
+        return TextPixelRegion(center, self.text, meta=self.meta.copy(),
+                               visual=self.visual.copy())


### PR DESCRIPTION
This PR adds a `copy` method to `RegionMeta` and `RegionVisual` and ensures that converted regions have meta and visual data that are copies and not views.  It also adds unit tests for region metadata, which did not previously exist. 
 Followup to #420.
