### PR TITLE
Fix annulus regions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,12 @@ Bug Fixes
 - Fixed an issue where sky/pixel conversions did not preserve ``meta``
   and ``visual`` data for some regions. [#420, #424]
 
+- Fixed an issue with elliptical and rectangular annulus regions where
+  the outer width/height could be smaller than the inner width/height.
+  [#425]
+
+- Fixed an issue converting elliptical and rectangular annulus regions
+  between pixel and sky regions. [#425]
 
 API Changes
 -----------

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -216,10 +216,10 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
         The position of the center of the annulus.
     inner_width : float
         The inner width of the annulus (before rotation) in pixels.
-    inner_height : float
-        The inner height of the annulus (before rotation) in pixels.
     outer_width : float
         The outer width of the annulus (before rotation) in pixels.
+    inner_height : float
+        The inner height of the annulus (before rotation) in pixels.
     outer_height : float
         The outer height of the annulus (before rotation) in pixels.
     angle : `~astropy.units.Quantity`, optional
@@ -228,7 +228,7 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
         axis.
     """
 
-    _params = ('center', 'inner_width', 'inner_height', 'outer_width',
+    _params = ('center', 'inner_width', 'outer_width', 'inner_height',
                'outer_height', 'angle')
     center = ScalarPix('center')
     inner_width = ScalarLength('inner_width')
@@ -290,10 +290,10 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
         The position of the center of the annulus.
     inner_width : `~astropy.units.Quantity`
         The inner width of the annulus (before rotation) as an angle.
-    inner_height : `~astropy.units.Quantity`
-        The inner height of the annulus (before rotation) as an angle.
     outer_width : `~astropy.units.Quantity`
         The outer width of the annulus (before rotation) as an angle.
+    inner_height : `~astropy.units.Quantity`
+        The inner height of the annulus (before rotation) as an angle.
     outer_height : `~astropy.units.Quantity`
         The outer height of the annulus (before rotation) as an angle.
     angle : `~astropy.units.Quantity`, optional
@@ -307,7 +307,7 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
         region.
     """
 
-    _params = ('center', 'inner_width', 'inner_height', 'outer_width',
+    _params = ('center', 'inner_width', 'outer_width', 'inner_height',
                'outer_height', 'angle')
 
     center = ScalarSky('center')
@@ -358,11 +358,11 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
     inner_width : float
         The inner width of the elliptical annulus (before rotation) in
         pixels.
-    inner_height : float
-        The inner height of the elliptical annulus (before rotation) in
-        pixels.
     outer_width : float
         The outer width of the elliptical annulus (before rotation) in
+        pixels.
+    inner_height : float
+        The inner height of the elliptical annulus (before rotation) in
         pixels.
     outer_height : float
         The outer height of the elliptical annulus (before rotation) in
@@ -388,8 +388,8 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
 
         x, y = 6, 6
         inner_width = 5.5
-        inner_height = 3.5
         outer_width = 8.5
+        inner_height = 3.5
         outer_height = 6.5
         angle = Angle("45deg")
 
@@ -397,8 +397,8 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
 
         center = PixCoord(x=x, y=y)
         reg = EllipseAnnulusPixelRegion(center=center, inner_width=inner_width,
-                                        inner_height=inner_height,
                                         outer_width=outer_width,
+                                        inner_height=inner_height,
                                         outer_height=outer_height, angle=angle)
         patch = reg.as_artist(facecolor='none', edgecolor='red', lw=2)
         ax.add_patch(patch)
@@ -427,11 +427,11 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
     inner_width : `~astropy.units.Quantity`
         The inner width of the elliptical annulus (before rotation) as
         an angle.
-    inner_height : `~astropy.units.Quantity`
-        The inner height of the elliptical annulus (before rotation) as
-        an angle.
     outer_width : `~astropy.units.Quantity`
         The outer width of the elliptical annulus (before rotation) as
+        an angle.
+    inner_height : `~astropy.units.Quantity`
+        The inner height of the elliptical annulus (before rotation) as
         an angle.
     outer_height : `~astropy.units.Quantity`
         The outer height of the elliptical annulus (before rotation) as
@@ -466,11 +466,11 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
     inner_width : float
         The inner width of the rectangular annulus (before rotation) in
         pixels.
-    inner_height : float
-        The inner height of the rectangular annulus (before rotation) in
-        pixels.
     outer_width : float
         The outer width of the rectangular annulus (before rotation) in
+        pixels.
+    inner_height : float
+        The inner height of the rectangular annulus (before rotation) in
         pixels.
     outer_height : float
         The outer height of the rectangular annulus (before rotation) in
@@ -496,8 +496,8 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
 
         x, y = 6, 6
         inner_width = 5.5
-        inner_height = 3.5
         outer_width = 8.5
+        inner_height = 3.5
         outer_height = 6.5
         angle = Angle("45deg")
 
@@ -506,8 +506,8 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
         center = PixCoord(x=x, y=y)
         reg = RectangleAnnulusPixelRegion(center=center,
                                           inner_width=inner_width,
-                                          inner_height=inner_height,
                                           outer_width=outer_width,
+                                          inner_height=inner_height,
                                           outer_height=outer_height,
                                           angle=angle)
         patch = reg.as_artist(facecolor='none', edgecolor='red', lw=2)
@@ -538,11 +538,11 @@ class RectangleAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
     inner_width : `~astropy.units.Quantity`
         The inner width of the rectangular annulus (before rotation) as
         an angle.
-    inner_height : `~astropy.units.Quantity`
-        The inner height of the rectangular annulus (before rotation) as
-        an angle.
     outer_width : `~astropy.units.Quantity`
         The outer width of the rectangular annulus (before rotation) as
+        an angle.
+    inner_height : `~astropy.units.Quantity`
+        The inner height of the rectangular annulus (before rotation) as
         an angle.
     outer_height : `~astropy.units.Quantity`
         The outer height of the rectangular annulus (before rotation) as

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -269,12 +269,12 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
         center = pixel_to_skycoord(self.center.x, self.center.y, wcs)
         _, pixscale, north_angle = pixel_scale_angle_at_skycoord(center, wcs)
         inner_width = (self.inner_width * u.pix * pixscale).to(u.arcsec)
-        inner_height = (self.inner_height * u.pix * pixscale).to(u.arcsec)
         outer_width = (self.outer_width * u.pix * pixscale).to(u.arcsec)
+        inner_height = (self.inner_height * u.pix * pixscale).to(u.arcsec)
         outer_height = (self.outer_height * u.pix * pixscale).to(u.arcsec)
         angle = self.angle - (north_angle - 90 * u.deg)
 
-        return (center, inner_width, inner_height, outer_width, outer_height,
+        return (center, inner_width, outer_width, inner_height, outer_height,
                 angle)
 
 
@@ -338,12 +338,12 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
             self.center, wcs)
         center = PixCoord(center.x, center.y)
         inner_width = (self.inner_width / pixscale).to(u.pix).value
-        inner_height = (self.inner_height / pixscale).to(u.pix).value
         outer_width = (self.outer_width / pixscale).to(u.pix).value
+        inner_height = (self.inner_height / pixscale).to(u.pix).value
         outer_height = (self.outer_height / pixscale).to(u.pix).value
         angle = self.angle + (north_angle - 90 * u.deg)
 
-        return (center, inner_width, inner_height, outer_width, outer_height,
+        return (center, inner_width, outer_width, inner_height, outer_height,
                 angle)
 
 

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -136,6 +136,9 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
 
+        if inner_radius >= outer_radius:
+            raise ValueError('outer_radius must be greater than inner_radius')
+
     @property
     def _inner_region(self):
         return self._component_class(self.center, self.inner_radius,
@@ -186,6 +189,9 @@ class CircleAnnulusSkyRegion(SkyRegion):
         self.outer_radius = outer_radius
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
+
+        if inner_radius >= outer_radius:
+            raise ValueError('outer_radius must be greater than inner_radius')
 
     def to_pixel(self, wcs):
         center, pixscale, _ = pixel_scale_angle_at_skycoord(self.center, wcs)
@@ -241,6 +247,11 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
         self.angle = angle
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
+
+        if inner_width >= outer_width:
+            raise ValueError('outer_width must be greater than inner_width')
+        if inner_height >= outer_height:
+            raise ValueError('outer_height must be greater than inner_height')
 
     @property
     def _inner_region(self):
@@ -316,6 +327,11 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
         self.angle = angle
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
+
+        if inner_width >= outer_width:
+            raise ValueError('outer_width must be greater than inner_width')
+        if inner_height >= outer_height:
+            raise ValueError('outer_height must be greater than inner_height')
 
     def to_pixel_args(self, wcs):
         center, pixscale, north_angle = pixel_scale_angle_at_skycoord(

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -131,11 +131,11 @@ class TestEllipseAnnulusPixelRegion(BaseTestPixelRegion):
     outside = [(3, 4)]
     expected_area = 7.5 * np.pi
     expected_repr = ('<EllipseAnnulusPixelRegion(center=PixCoord(x=3, y=4), '
-                     'inner_width=2, inner_height=5, outer_width=5, '
+                     'inner_width=2, outer_width=5, inner_height=5, '
                      'outer_height=8, angle=0.0 deg)>')
     expected_str = ('Region: EllipseAnnulusPixelRegion\ncenter: '
-                    'PixCoord(x=3, y=4)\ninner_width: 2\ninner_height: 5\n'
-                    'outer_width: 5\nouter_height: 8\nangle: 0.0 deg')
+                    'PixCoord(x=3, y=4)\ninner_width: 2\nouter_width: 5\n'
+                    'inner_height: 5\nouter_height: 8\nangle: 0.0 deg')
 
     skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='icrs')
     wcs = make_simple_wcs(skycoord, 5 * u.arcsec, 20)
@@ -205,12 +205,13 @@ class TestEllipseAnnulusSkyRegion(BaseTestSkyRegion):
 
     expected_repr = ('<EllipseAnnulusSkyRegion(center=<SkyCoord (ICRS): '
                      '(ra, dec) in deg\n    (3., 4.)>, inner_width=20.0 '
-                     'arcsec, inner_height=50.0 arcsec, outer_width=50.0 '
+                     'arcsec, outer_width=50.0 arcsec, inner_height=50.0 '
                      'arcsec, outer_height=80.0 arcsec, angle=0.0 deg)>')
     expected_str = ('Region: EllipseAnnulusSkyRegion\ncenter: <SkyCoord '
                     '(ICRS): (ra, dec) in deg\n    (3., 4.)>\ninner_width: '
-                    '20.0 arcsec\ninner_height: 50.0 arcsec\nouter_width: '
-                    '50.0 arcsec\nouter_height: 80.0 arcsec\nangle: 0.0 deg')
+                    '20.0 arcsec\nouter_width: 50.0 arcsec\n'
+                    'inner_height: 50.0 arcsec\nouter_height: '
+                    '80.0 arcsec\nangle: 0.0 deg')
 
     def test_init(self):
         assert_quantity_allclose(self.reg.center.ra, self.skycoord.ra)
@@ -254,11 +255,11 @@ class TestRectangleAnnulusPixelRegion(BaseTestPixelRegion):
     outside = [(3, 4)]
     expected_area = 30
     expected_repr = ('<RectangleAnnulusPixelRegion(center=PixCoord(x=3, y=4), '
-                     'inner_width=2, inner_height=5, outer_width=5, '
+                     'inner_width=2, outer_width=5, inner_height=5, '
                      'outer_height=8, angle=0.0 deg)>')
     expected_str = ('Region: RectangleAnnulusPixelRegion\ncenter: '
-                    'PixCoord(x=3, y=4)\ninner_width: 2\ninner_height: 5\n'
-                    'outer_width: 5\nouter_height: 8\nangle: 0.0 deg')
+                    'PixCoord(x=3, y=4)\ninner_width: 2\nouter_width: 5\n'
+                    'inner_height: 5\nouter_height: 8\nangle: 0.0 deg')
 
     skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='icrs')
     wcs = make_simple_wcs(skycoord, 5 * u.arcsec, 20)
@@ -328,12 +329,13 @@ class TestRectangleAnnulusSkyRegion(BaseTestSkyRegion):
 
     expected_repr = ('<RectangleAnnulusSkyRegion(center=<SkyCoord (ICRS): '
                      '(ra, dec) in deg\n    (3., 4.)>, inner_width=20.0 '
-                     'arcsec, inner_height=50.0 arcsec, outer_width=50.0 '
+                     'arcsec, outer_width=50.0 arcsec, inner_height=50.0 '
                      'arcsec, outer_height=80.0 arcsec, angle=0.0 deg)>')
     expected_str = ('Region: RectangleAnnulusSkyRegion\ncenter: <SkyCoord '
                     '(ICRS): (ra, dec) in deg\n    (3., 4.)>\ninner_width: '
-                    '20.0 arcsec\ninner_height: 50.0 arcsec\nouter_width: '
-                    '50.0 arcsec\nouter_height: 80.0 arcsec\nangle: 0.0 deg')
+                    '20.0 arcsec\nouter_width: 50.0 arcsec\n'
+                    'inner_height: 50.0 arcsec\nouter_height: 80.0 arcsec\n'
+                    'angle: 0.0 deg')
 
     def test_init(self):
         assert_quantity_allclose(self.reg.center.ra, self.skycoord.ra)


### PR DESCRIPTION
This PR makes two fixes to ellipse and rectangle annulus regions:

* Fixes an issue with elliptical and rectangular annulus regions where
  the outer width/height could be smaller than the inner width/height.

- Fixes an issue converting elliptical and rectangular annulus regions
  between pixel and sky regions.

It also fixes the order of parameters in the docstrings of these classes to match the class signature.