### PR TITLE
Rename BoundingBox to RegionBoundingBox

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,9 @@ API Changes
   set to 'mpl' or None, then the matplotlib defaults will be used, with
   the exception that fill is turned off for Patch and Line2D artists.
 
+- Renamed the ``BoundingBox`` class to ``RegionBoundingBox``. The old
+  name is deprecated. [#427]
+
 
 0.5 (2021-07-20)
 ================

--- a/docs/masks.rst
+++ b/docs/masks.rst
@@ -95,11 +95,11 @@ As we've seen above, the :class:`~regions.RegionMask` object has a
 ``data`` attribute that contains a Numpy array with the mask values.
 However, if you have, for example, a small circluar region with a radius
 of 3 pixels at a pixel position of (1000, 1000), it would be inefficient
-to store a large mask array that has a size to cover this position
-(most of the mask values would be zero). Instead, we store the mask
-using the minimal array that contains the region mask along with a
-``bbox`` attribute that is a :class:`~regions.BoundingBox` object used
-to indicate where the mask should be applied in an image.
+to store a large mask array that has a size to cover this position (most
+of the mask values would be zero). Instead, we store the mask using
+the minimal array that contains the region mask along with a ``bbox``
+attribute that is a :class:`~regions.RegionBoundingBox` object used to
+indicate where the mask should be applied in an image.
 
 
 Defining a region mask within an image
@@ -287,12 +287,12 @@ the selector.
 We first create an :class:`~regions.EllipsePixelRegion` and add an ``as_mpl_selector``
 property linked to the Matplotlib axes. This can be moved around to
 position it on different sources, and resized just like its Rectangle
-counterpart, using the handles of the bounding box. 
+counterpart, using the handles of the bounding box.
 
 The user-defined callback function here generates a mask from this region and overlays
 it on the image as an alpha filter (keeping the areas outside shaded).
 We will use this mask as an aperture as well to calculate integrated
-and averaged flux, which is updated live in the text field of the plot as well. 
+and averaged flux, which is updated live in the text field of the plot as well.
 
 .. plot::
    :context:

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -4,12 +4,13 @@ This module defines a class for a rectangular bounding box.
 """
 
 from astropy.io.fits.util import _is_int
+from astropy.utils.decorators import deprecated
 import numpy as np
 
-__all__ = ['BoundingBox']
+__all__ = ['RegionBoundingBox', 'BoundingBox']
 
 
-class BoundingBox:
+class RegionBoundingBox:
     """
     A rectangular bounding box in integer (not float) pixel indices.
 
@@ -24,20 +25,20 @@ class BoundingBox:
 
     Examples
     --------
-    >>> from regions import BoundingBox
+    >>> from regions import RegionBoundingBox
 
-    >>> # constructing a BoundingBox like this is cryptic:
-    >>> bbox = BoundingBox(1, 10, 2, 20)
+    >>> # constructing a RegionBoundingBox like this is cryptic:
+    >>> bbox = RegionBoundingBox(1, 10, 2, 20)
 
     >>> # it's better to use keyword arguments for readability:
-    >>> bbox = BoundingBox(ixmin=1, ixmax=10, iymin=2, iymax=20)
+    >>> bbox = RegionBoundingBox(ixmin=1, ixmax=10, iymin=2, iymax=20)
     >>> bbox  # nice repr, useful for interactive work
-    BoundingBox(ixmin=1, ixmax=10, iymin=2, iymax=20)
+    RegionBoundingBox(ixmin=1, ixmax=10, iymin=2, iymax=20)
 
     >>> # sometimes it's useful to check if two bounding boxes are the same
-    >>> bbox == BoundingBox(ixmin=1, ixmax=10, iymin=2, iymax=20)
+    >>> bbox == RegionBoundingBox(ixmin=1, ixmax=10, iymin=2, iymax=20)
     True
-    >>> bbox == BoundingBox(ixmin=7, ixmax=10, iymin=2, iymax=20)
+    >>> bbox == RegionBoundingBox(ixmin=7, ixmax=10, iymin=2, iymax=20)
     False
 
     >>> # "center" and "shape" can be useful when working with numpy arrays
@@ -46,7 +47,8 @@ class BoundingBox:
     >>> bbox.shape  # numpy order: (y, x)
     (18, 9)
 
-    >>> # "extent" is useful when plotting the BoundingBox with matplotlib
+    >>> # "extent" is useful when plotting the RegionBoundingBox with
+    >>> # matplotlib
     >>> bbox.extent  # matplotlib order: (x, y)
     (0.5, 9.5, 1.5, 19.5)
     """
@@ -86,9 +88,9 @@ class BoundingBox:
         - pixel 1: from 0.5 to 1.5
         - pixel 2: from 1.5 to 2.5
 
-        In addition, because `BoundingBox` upper limits are exclusive
-        (by definition), 1 is added to the upper pixel edges.  See
-        examples below.
+        In addition, because `RegionBoundingBox` upper limits are
+        exclusive (by definition), 1 is added to the upper pixel edges.
+        See examples below.
 
         Parameters
         ----------
@@ -99,18 +101,20 @@ class BoundingBox:
 
         Returns
         -------
-        bbox : `BoundingBox` object
-            The minimal ``BoundingBox`` object fully containing the
-            input rectangle coordinates.
+        bbox : `RegionBoundingBox` object
+            The minimal ``RegionBoundingBox`` object fully containing
+            the input rectangle coordinates.
 
         Examples
         --------
-        >>> from regions import BoundingBox
-        >>> BoundingBox.from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
-        BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=21)
+        >>> from regions import RegionBoundingBox
+        >>> RegionBoundingBox.from_float(xmin=1.0, xmax=10.0,
+        ...                              ymin=2.0, ymax=20.0)
+        RegionBoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=21)
 
-        >>> BoundingBox.from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
-        BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
+        >>> RegionBoundingBox.from_float(xmin=1.4, xmax=10.4,
+        ...                              ymin=1.6, ymax=10.6)
+        RegionBoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
         """
         ixmin = int(np.floor(xmin + 0.5))
         ixmax = int(np.ceil(xmax + 0.5))
@@ -120,9 +124,9 @@ class BoundingBox:
         return cls(ixmin, ixmax, iymin, iymax)
 
     def __eq__(self, other):
-        if not isinstance(other, BoundingBox):
-            raise TypeError('Can compare BoundingBox only to another '
-                            'BoundingBox.')
+        if not isinstance(other, RegionBoundingBox):
+            raise TypeError('Can compare RegionBoundingBox only to another '
+                            'RegionBoundingBox.')
 
         return ((self.ixmin == other.ixmin)
                 and (self.ixmax == other.ixmax)
@@ -241,8 +245,8 @@ class BoundingBox:
 
             import numpy as np
             import matplotlib.pyplot as plt
-            from regions import BoundingBox
-            bbox = BoundingBox(2, 7, 3, 8)
+            from regions import RegionBoundingBox
+            bbox = RegionBoundingBox(2, 7, 3, 8)
             fig = plt.figure()
             ax = fig.add_subplot(1, 1, 1)
             rng = np.random.default_rng(0)
@@ -270,8 +274,8 @@ class BoundingBox:
 
     def plot(self, origin=(0, 0), ax=None, **kwargs):
         """
-        Plot the `BoundingBox` on a matplotlib `~matplotlib.axes.Axes`
-        instance.
+        Plot the `RegionBoundingBox` on a matplotlib
+        `~matplotlib.axes.Axes` instance.
 
         Parameters
         ----------
@@ -294,50 +298,51 @@ class BoundingBox:
 
     def union(self, other):
         """
-        Return a `BoundingBox` representing the union of this
-        `BoundingBox` with another `BoundingBox`.
+        Return a `RegionBoundingBox` representing the union of this
+        `RegionBoundingBox` with another `RegionBoundingBox`.
 
         Parameters
         ----------
-        other : `~regions.BoundingBox`
-            The `BoundingBox` to join with this one.
+        other : `~regions.RegionBoundingBox`
+            The `RegionBoundingBox` to join with this one.
 
         Returns
         -------
-        result : `~regions.BoundingBox`
-            A `BoundingBox` representing the union of the input
-            `BoundingBox` with this one.
+        result : `~regions.RegionBoundingBox`
+            A `RegionBoundingBox` representing the union of the input
+            `RegionBoundingBox` with this one.
         """
-        if not isinstance(other, BoundingBox):
-            raise TypeError('BoundingBox can be joined only with another '
-                            'BoundingBox.')
+        if not isinstance(other, RegionBoundingBox):
+            raise TypeError('RegionBoundingBox can be joined only with '
+                            'another RegionBoundingBox.')
 
         ixmin = min((self.ixmin, other.ixmin))
         ixmax = max((self.ixmax, other.ixmax))
         iymin = min((self.iymin, other.iymin))
         iymax = max((self.iymax, other.iymax))
 
-        return BoundingBox(ixmin=ixmin, ixmax=ixmax, iymin=iymin, iymax=iymax)
+        return RegionBoundingBox(ixmin=ixmin, ixmax=ixmax, iymin=iymin,
+                                 iymax=iymax)
 
     def intersection(self, other):
         """
-        Return a `BoundingBox` representing the intersection of this
-        `BoundingBox` with another `BoundingBox`.
+        Return a `RegionBoundingBox` representing the intersection of
+        this `RegionBoundingBox` with another `RegionBoundingBox`.
 
         Parameters
         ----------
-        other : `~regions.BoundingBox`
-            The `BoundingBox` to intersect with this one.
+        other : `~regions.RegionBoundingBox`
+            The `RegionBoundingBox` to intersect with this one.
 
         Returns
         -------
-        result : `~regions.BoundingBox`
-            A `BoundingBox` representing the intersection of the input
-            `BoundingBox` with this one.
+        result : `~regions.RegionBoundingBox`
+            A `RegionBoundingBox` representing the intersection of the
+            input `RegionBoundingBox` with this one.
         """
-        if not isinstance(other, BoundingBox):
-            raise TypeError('BoundingBox can be intersected only with '
-                            'another BoundingBox.')
+        if not isinstance(other, RegionBoundingBox):
+            raise TypeError('RegionBoundingBox can be intersected only with '
+                            'another RegionBoundingBox.')
 
         ixmin = max(self.ixmin, other.ixmin)
         ixmax = min(self.ixmax, other.ixmax)
@@ -346,4 +351,24 @@ class BoundingBox:
         if ixmax < ixmin or iymax < iymin:
             return None
 
-        return BoundingBox(ixmin=ixmin, ixmax=ixmax, iymin=iymin, iymax=iymax)
+        return RegionBoundingBox(ixmin=ixmin, ixmax=ixmax, iymin=iymin,
+                                 iymax=iymax)
+
+
+@deprecated('0.6', alternative='`RegionBoundingBox`')
+class BoundingBox(RegionBoundingBox):
+    """
+    A rectangular bounding box in integer (not float) pixel indices.
+
+    Parameters
+    ----------
+    ixmin, ixmax, iymin, iymax : int
+        The bounding box pixel indices.  Note that the upper values
+        (``iymax`` and ``ixmax``) are exclusive as for normal slices in
+        Python.  The lower values (``ixmin`` and ``iymin``) must not be
+        greater than the respective upper values (``ixmax`` and
+        ``iymax``).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)

--- a/regions/core/mask.py
+++ b/regions/core/mask.py
@@ -22,7 +22,7 @@ class RegionMask:
         truncated) array that is the direct output of one of the
         low-level "geometry" functions.
 
-    bbox : `regions.BoundingBox`
+    bbox : `regions.RegionBoundingBox`
         The bounding box object defining the region minimal bounding
         box.
 

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -6,14 +6,14 @@ Tests for the bounding_box module.
 from numpy.testing import assert_allclose
 import pytest
 
-from ..bounding_box import BoundingBox
+from ..bounding_box import RegionBoundingBox
 from ..pixcoord import PixCoord
 from ...shapes import RectanglePixelRegion
 from ..._utils.optional_deps import HAS_MATPLOTLIB  # noqa
 
 
 def test_bounding_box_init():
-    bbox = BoundingBox(1, 10, 2, 20)
+    bbox = RegionBoundingBox(1, 10, 2, 20)
     assert bbox.ixmin == 1
     assert bbox.ixmax == 10
     assert bbox.iymin == 2
@@ -22,87 +22,90 @@ def test_bounding_box_init():
 
 def test_bounding_box_init_minmax():
     with pytest.raises(ValueError):
-        BoundingBox(100, 1, 1, 100)
+        RegionBoundingBox(100, 1, 1, 100)
     with pytest.raises(ValueError):
-        BoundingBox(1, 100, 100, 1)
+        RegionBoundingBox(1, 100, 100, 1)
 
 
 def test_bounding_box_inputs():
     with pytest.raises(TypeError):
-        BoundingBox([1], [10], [2], [9])
+        RegionBoundingBox([1], [10], [2], [9])
     with pytest.raises(TypeError):
-        BoundingBox([1, 2], 10, 2, 9)
+        RegionBoundingBox([1, 2], 10, 2, 9)
     with pytest.raises(TypeError):
-        BoundingBox(1.0, 10.0, 2.0, 9.0)
+        RegionBoundingBox(1.0, 10.0, 2.0, 9.0)
     with pytest.raises(TypeError):
-        BoundingBox(1.3, 10, 2, 9)
+        RegionBoundingBox(1.3, 10, 2, 9)
     with pytest.raises(TypeError):
-        BoundingBox(1, 10.3, 2, 9)
+        RegionBoundingBox(1, 10.3, 2, 9)
     with pytest.raises(TypeError):
-        BoundingBox(1, 10, 2.3, 9)
+        RegionBoundingBox(1, 10, 2.3, 9)
     with pytest.raises(TypeError):
-        BoundingBox(1, 10, 2, 9.3)
+        RegionBoundingBox(1, 10, 2, 9.3)
 
 
 def test_bounding_box_from_float():
     # This is the example from the method docstring
-    bbox = BoundingBox.from_float(xmin=1.0, xmax=10.0, ymin=2.0, ymax=20.0)
-    assert bbox == BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=21)
+    bbox = RegionBoundingBox.from_float(xmin=1.0, xmax=10.0, ymin=2.0,
+                                        ymax=20.0)
+    assert bbox == RegionBoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=21)
 
-    bbox = BoundingBox.from_float(xmin=1.4, xmax=10.4, ymin=1.6, ymax=10.6)
-    assert bbox == BoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
+    bbox = RegionBoundingBox.from_float(xmin=1.4, xmax=10.4, ymin=1.6,
+                                        ymax=10.6)
+    assert bbox == RegionBoundingBox(ixmin=1, ixmax=11, iymin=2, iymax=12)
 
 
 def test_bounding_box_eq():
-    bbox = BoundingBox(1, 10, 2, 20)
-    assert bbox == BoundingBox(1, 10, 2, 20)
-    assert bbox != BoundingBox(9, 10, 2, 20)
-    assert bbox != BoundingBox(1, 99, 2, 20)
-    assert bbox != BoundingBox(1, 10, 9, 20)
-    assert bbox != BoundingBox(1, 10, 2, 99)
+    bbox = RegionBoundingBox(1, 10, 2, 20)
+    assert bbox == RegionBoundingBox(1, 10, 2, 20)
+    assert bbox != RegionBoundingBox(9, 10, 2, 20)
+    assert bbox != RegionBoundingBox(1, 99, 2, 20)
+    assert bbox != RegionBoundingBox(1, 10, 9, 20)
+    assert bbox != RegionBoundingBox(1, 10, 2, 99)
 
     with pytest.raises(TypeError):
         assert bbox == (1, 10, 2, 20)
 
 
 def test_bounding_box_repr():
-    bbox = BoundingBox(1, 10, 2, 20)
-    assert repr(bbox) == 'BoundingBox(ixmin=1, ixmax=10, iymin=2, iymax=20)'
+    bbox = RegionBoundingBox(1, 10, 2, 20)
+    assert repr(bbox) == ('RegionBoundingBox(ixmin=1, ixmax=10, iymin=2, '
+                          'iymax=20)')
 
 
 def test_bounding_box_shape():
-    bbox = BoundingBox(1, 10, 2, 20)
+    bbox = RegionBoundingBox(1, 10, 2, 20)
     assert bbox.shape == (18, 9)
 
 
 def test_bounding_box_center():
-    bbox = BoundingBox(1, 10, 2, 20)
+    bbox = RegionBoundingBox(1, 10, 2, 20)
     assert bbox.center == (10.5, 5)
 
 
 def test_bounding_box_get_overlap_slices():
-    bbox = BoundingBox(1, 10, 2, 20)
+    bbox = RegionBoundingBox(1, 10, 2, 20)
     slc = ((slice(2, 20, None), slice(1, 10, None)),
            (slice(0, 18, None), slice(0, 9, None)))
     assert bbox.get_overlap_slices((50, 50)) == slc
 
-    bbox = BoundingBox(-10, -1, 2, 20)
+    bbox = RegionBoundingBox(-10, -1, 2, 20)
     assert bbox.get_overlap_slices((50, 50)) == (None, None)
 
-    bbox = BoundingBox(-10, 10, -10, 20)
+    bbox = RegionBoundingBox(-10, 10, -10, 20)
     slc = ((slice(0, 20, None), slice(0, 10, None)),
            (slice(10, 30, None), slice(10, 20, None)))
     assert bbox.get_overlap_slices((50, 50)) == slc
 
 
 def test_bounding_box_extent():
-    bbox = BoundingBox(1, 10, 2, 20)
+    bbox = RegionBoundingBox(1, 10, 2, 20)
     assert_allclose(bbox.extent, (0.5, 9.5, 1.5, 19.5))
 
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
 def test_bounding_box_as_artist():
-    bbox = BoundingBox(1, 10, 2, 20)
+    bbox = RegionBoundingBox(1, 10, 2, 20)
     patch = bbox.as_artist()
 
     assert_allclose(patch.get_xy(), (0.5, 1.5))
@@ -112,7 +115,7 @@ def test_bounding_box_as_artist():
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
 def test_bounding_box_to_region():
-    bbox = BoundingBox(1, 10, 2, 20)
+    bbox = RegionBoundingBox(1, 10, 2, 20)
     region = RectanglePixelRegion(PixCoord(5.0, 10.5), width=9., height=18.)
     bbox_region = bbox.to_region()
     assert_allclose(bbox_region.center.xy, region.center.xy)
@@ -124,14 +127,14 @@ def test_bounding_box_to_region():
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
 def test_bounding_box_plot():
     # TODO: check the content of the plot
-    bbox = BoundingBox(1, 10, 2, 20)
+    bbox = RegionBoundingBox(1, 10, 2, 20)
     bbox.plot()
 
 
 def test_bounding_box_union():
-    bbox1 = BoundingBox(1, 10, 2, 20)
-    bbox2 = BoundingBox(5, 21, 7, 32)
-    bbox_union_expected = BoundingBox(1, 21, 2, 32)
+    bbox1 = RegionBoundingBox(1, 10, 2, 20)
+    bbox2 = RegionBoundingBox(5, 21, 7, 32)
+    bbox_union_expected = RegionBoundingBox(1, 21, 2, 32)
     bbox_union1 = bbox1 | bbox2
     bbox_union2 = bbox1.union(bbox2)
 
@@ -143,9 +146,9 @@ def test_bounding_box_union():
 
 
 def test_bounding_box_intersect():
-    bbox1 = BoundingBox(1, 10, 2, 20)
-    bbox2 = BoundingBox(5, 21, 7, 32)
-    bbox_intersect_expected = BoundingBox(5, 10, 7, 20)
+    bbox1 = RegionBoundingBox(1, 10, 2, 20)
+    bbox2 = RegionBoundingBox(5, 21, 7, 32)
+    bbox_intersect_expected = RegionBoundingBox(5, 10, 7, 20)
     bbox_intersect1 = bbox1 & bbox2
     bbox_intersect2 = bbox1.intersection(bbox2)
 
@@ -155,4 +158,4 @@ def test_bounding_box_intersect():
     with pytest.raises(TypeError):
         bbox1.intersection((5, 21, 7, 32))
 
-    assert bbox1.intersection(BoundingBox(30, 40, 50, 60)) is None
+    assert bbox1.intersection(RegionBoundingBox(30, 40, 50, 60)) is None

--- a/regions/core/tests/test_compound.py
+++ b/regions/core/tests/test_compound.py
@@ -11,7 +11,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 
 from ...shapes import CircleSkyRegion, CirclePixelRegion
-from ...core import PixCoord, BoundingBox, CompoundPixelRegion
+from ...core import PixCoord, RegionBoundingBox, CompoundPixelRegion
 from ...tests.helpers import make_simple_wcs
 
 
@@ -108,7 +108,7 @@ class TestCompoundPixel:
 
     def test_bounding_box(self):
         bbox = (self.c1 | self.c2).bounding_box
-        assert bbox == BoundingBox(1, 16, 1, 10)
+        assert bbox == RegionBoundingBox(1, 16, 1, 10)
 
 
 def test_compound_sky():

--- a/regions/core/tests/test_mask.py
+++ b/regions/core/tests/test_mask.py
@@ -8,7 +8,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
 import pytest
 
-from ..bounding_box import BoundingBox
+from ..bounding_box import RegionBoundingBox
 from ..mask import RegionMask
 from ..pixcoord import PixCoord
 from ...shapes import CirclePixelRegion, CircleAnnulusPixelRegion
@@ -19,13 +19,13 @@ POSITIONS = [(-20, -20), (-20, 20), (20, -20), (60, 60)]
 def test_mask_input_shapes():
     with pytest.raises(ValueError):
         mask_data = np.ones((10, 10))
-        bbox = BoundingBox(5, 10, 5, 10)
+        bbox = RegionBoundingBox(5, 10, 5, 10)
         RegionMask(mask_data, bbox)
 
 
 def test_mask_array():
     mask_data = np.ones((10, 10))
-    bbox = BoundingBox(5, 15, 5, 15)
+    bbox = RegionBoundingBox(5, 15, 5, 15)
     mask = RegionMask(mask_data, bbox)
     data = np.array(mask)
     assert_allclose(data, mask.data)
@@ -41,7 +41,7 @@ def test_mask_get_overlap_slices():
 
 def test_mask_cutout_shape():
     mask_data = np.ones((10, 10))
-    bbox = BoundingBox(5, 15, 5, 15)
+    bbox = RegionBoundingBox(5, 15, 5, 15)
     mask = RegionMask(mask_data, bbox)
 
     with pytest.raises(ValueError):

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from ..core.attributes import (ScalarPix, ScalarLength, QuantityLength,
                                ScalarSky)
-from ..core.bounding_box import BoundingBox
+from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
 from ..core.metadata import RegionMeta, RegionVisual
@@ -95,13 +95,13 @@ class CirclePixelRegion(PixelRegion):
 
     @property
     def bounding_box(self):
-        """Bounding box (`~regions.BoundingBox`)."""
+        """Bounding box (`~regions.RegionBoundingBox`)."""
         xmin = self.center.x - self.radius
         xmax = self.center.x + self.radius
         ymin = self.center.y - self.radius
         ymax = self.center.y + self.radius
 
-        return BoundingBox.from_float(xmin, xmax, ymin, ymax)
+        return RegionBoundingBox.from_float(xmin, xmax, ymin, ymax)
 
     def to_mask(self, mode='center', subpixels=1):
         self._validate_mode(mode, subpixels)

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from ..core.attributes import (ScalarPix, ScalarLength, QuantityLength,
                                ScalarSky)
-from ..core.bounding_box import BoundingBox
+from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
 from ..core.metadata import RegionMeta, RegionVisual
@@ -122,8 +122,8 @@ class EllipsePixelRegion(PixelRegion):
     @property
     def bounding_box(self):
         """
-        The minimal bounding box (`~regions.BoundingBox`) enclosing the
-        exact elliptical region.
+        The minimal bounding box (`~regions.RegionBoundingBox`)
+        enclosing the exact elliptical region.
         """
         # We use the solution described in
         # https://stackoverflow.com/a/14163413
@@ -141,7 +141,7 @@ class EllipsePixelRegion(PixelRegion):
         ymin = self.center.y - dy
         ymax = self.center.y + dy
 
-        return BoundingBox.from_float(xmin, xmax, ymin, ymax)
+        return RegionBoundingBox.from_float(xmin, xmax, ymin, ymax)
 
     def to_mask(self, mode='center', subpixels=5):
         # NOTE: assumes this class represents a single circle

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -7,7 +7,7 @@ from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
 from ..core.attributes import ScalarPix, ScalarSky
-from ..core.bounding_box import BoundingBox
+from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual
 from ..core.pixcoord import PixCoord
@@ -94,7 +94,7 @@ class LinePixelRegion(PixelRegion):
         ymin = min(self.start.y, self.end.y)
         ymax = max(self.start.y, self.end.y)
 
-        return BoundingBox.from_float(xmin, xmax, ymin, ymax)
+        return RegionBoundingBox.from_float(xmin, xmax, ymin, ymax)
 
     def to_mask(self, mode='center', subpixels=5):
         # TODO: needs to be implemented

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -7,7 +7,7 @@ from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
 from ..core.attributes import ScalarPix, ScalarSky
-from ..core.bounding_box import BoundingBox
+from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual
 from ..core.pixcoord import PixCoord
@@ -92,8 +92,8 @@ class PointPixelRegion(PixelRegion):
 
     @property
     def bounding_box(self):
-        return BoundingBox.from_float(self.center.x, self.center.x,
-                                      self.center.y, self.center.y)
+        return RegionBoundingBox.from_float(self.center.x, self.center.x,
+                                            self.center.y, self.center.y)
 
     def to_mask(self, mode='center', subpixels=5):
         # TODO: needs to be implemented

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from ..core.attributes import (OneDPix, OneDSky, ScalarPix, ScalarLength,
                                QuantityLength)
-from ..core.bounding_box import BoundingBox
+from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
 from ..core.metadata import RegionMeta, RegionVisual
@@ -112,7 +112,7 @@ class PolygonPixelRegion(PixelRegion):
         xmax = self.vertices.x.max()
         ymin = self.vertices.y.min()
         ymax = self.vertices.y.max()
-        return BoundingBox.from_float(xmin, xmax, ymin, ymax)
+        return RegionBoundingBox.from_float(xmin, xmax, ymin, ymax)
 
     def to_mask(self, mode='center', subpixels=5):
         self._validate_mode(mode, subpixels)

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from ..core.attributes import (ScalarPix, ScalarLength, QuantityLength,
                                ScalarSky)
-from ..core.bounding_box import BoundingBox
+from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
 from ..core.metadata import RegionMeta, RegionVisual
@@ -133,7 +133,7 @@ class RectanglePixelRegion(PixelRegion):
         ymin = self.center.y - dy
         ymax = self.center.y + dy
 
-        return BoundingBox.from_float(xmin, xmax, ymin, ymax)
+        return RegionBoundingBox.from_float(xmin, xmax, ymin, ymax)
 
     def to_mask(self, mode='center', subpixels=5):
         # NOTE: assumes this class represents a single rectangle

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -9,7 +9,7 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
 
-from ...core import PixCoord, RegionMeta, RegionVisual, BoundingBox
+from ...core import PixCoord, RegionMeta, RegionVisual, RegionBoundingBox
 from ...tests.helpers import make_simple_wcs
 from ..._utils.examples import make_example_dataset
 from ..._utils.optional_deps import HAS_MATPLOTLIB  # noqa
@@ -71,7 +71,7 @@ class TestPolygonPixelRegion(BaseTestPixelRegion):
 
     def test_bounding_box(self):
         bbox = self.reg.bounding_box
-        assert bbox == BoundingBox(ixmin=1, ixmax=4, iymin=1, iymax=5)
+        assert bbox == RegionBoundingBox(ixmin=1, ixmax=4, iymin=1, iymax=5)
 
     def test_to_mask(self):
         # The true area of this polygon is 3
@@ -85,7 +85,8 @@ class TestPolygonPixelRegion(BaseTestPixelRegion):
         # so we only assert on it once here, not in the other cases below
         mask = self.reg.to_mask(mode='center', subpixels=1)
         assert 2 <= np.sum(mask.data) <= 6
-        assert mask.bbox == BoundingBox(ixmin=1, ixmax=4, iymin=1, iymax=5)
+        assert mask.bbox == RegionBoundingBox(ixmin=1, ixmax=4, iymin=1,
+                                              iymax=5)
         assert mask.data.shape == (4, 3)
 
         # Test more cases for to_mask
@@ -211,7 +212,8 @@ class TestRegionPolygonPixelRegion(BaseTestPixelRegion):
 
     def test_bounding_box(self):
         bbox = self.reg.bounding_box
-        assert bbox == BoundingBox(ixmin=31, ixmax=70, iymin=31, iymax=70)
+        assert bbox == RegionBoundingBox(ixmin=31, ixmax=70, iymin=31,
+                                         iymax=70)
 
     def test_to_mask(self):
         # The true area of this polygon is 3
@@ -225,8 +227,8 @@ class TestRegionPolygonPixelRegion(BaseTestPixelRegion):
         # so we only assert on it once here, not in the other cases below
         mask = self.reg.to_mask(mode='center', subpixels=1)
         assert 1130 <= np.sum(mask.data) <= 1135
-        assert mask.bbox == BoundingBox(ixmin=31, ixmax=70, iymin=31,
-                                        iymax=70)
+        assert mask.bbox == RegionBoundingBox(ixmin=31, ixmax=70, iymin=31,
+                                              iymax=70)
         assert mask.data.shape == (39, 39)
 
         # Test more cases for to_mask


### PR DESCRIPTION
This PR renames the `BoundingBox` class to `RegionBoundingBox` and deprecates the old name.  The reason for this change is that https://github.com/astropy/astropy/pull/11930 introduced a very different `BoundingBox` class for models, whose name would conflict with the regions `BoundingBox` class when regions is merged into astropy core.  To prevent a name conflict, we agreed to rename these as `ModelBoundingBox` (https://github.com/astropy/astropy/pull/12342) and `RegionBoundingBox`. 