### PR TITLE
Fix repr/str for Text Regions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,10 @@ Bug Fixes
 - Fixed an issue converting elliptical and rectangular annulus regions
   between pixel and sky regions. [#425]
 
+- Fixed the string representations of ``TextPixelRegion`` and
+  ``TextSkyRegion`` to include quotes around the text parameter value.
+  [#429]
+
 API Changes
 -----------
 

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -37,7 +37,12 @@ class Region(abc.ABC):
         cls_info = []
         if self._params is not None:
             for param in self._params:
-                cls_info.append(f'{param}={getattr(self, param)}')
+                if param == 'text':
+                    # place quotes around text value
+                    keyval = f'{param}={getattr(self, param)!r}'
+                else:
+                    keyval = f'{param}={getattr(self, param)}'
+                cls_info.append(keyval)
         cls_info = ', '.join(cls_info)
         return f'<{prefix}({cls_info})>'
 
@@ -45,7 +50,13 @@ class Region(abc.ABC):
         cls_info = [('Region', self.__class__.__name__)]
         if self._params is not None:
             for param in self._params:
-                cls_info.append((param, getattr(self, param)))
+                if param == 'text':
+                    # place quotes around text value
+                    keyval = (param, repr(getattr(self, param)))
+                else:
+                    keyval = (param, getattr(self, param))
+                cls_info.append(keyval)
+
         return '\n'.join([f'{key}: {val}' for key, val in cls_info])
 
     def __eq__(self, other):

--- a/regions/shapes/tests/test_text.py
+++ b/regions/shapes/tests/test_text.py
@@ -31,10 +31,10 @@ class TestTextPixelRegion(BaseTestPixelRegion):
     inside = []
     outside = [(3.1, 4.2), (5, 4)]
     expected_area = 0
-    expected_repr = ('<TextPixelRegion(center=PixCoord(x=3, y=4), '
-                     'text=Sample Text)>')
-    expected_str = ('Region: TextPixelRegion\ncenter: PixCoord(x=3, y=4)\n'
-                    'text: Sample Text')
+    expected_repr = ("<TextPixelRegion(center=PixCoord(x=3, y=4), "
+                     "text='Sample Text')>")
+    expected_str = ("Region: TextPixelRegion\ncenter: PixCoord(x=3, y=4)\n"
+                    "text: 'Sample Text'")
 
     def test_copy(self):
         reg = self.reg.copy()
@@ -73,10 +73,10 @@ class TestTextSkyRegion(BaseTestSkyRegion):
     visual = RegionVisual({'color': 'blue'})
     reg = TextSkyRegion(SkyCoord(3, 4, unit='deg'), "Sample Text",
                         meta=meta, visual=visual)
-    expected_repr = ('<TextSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in '
-                     'deg\n    (3., 4.)>, text=Sample Text)>')
-    expected_str = ('Region: TextSkyRegion\ncenter: <SkyCoord (ICRS): '
-                    '(ra, dec) in deg\n    (3., 4.)>\ntext: Sample Text')
+    expected_repr = ("<TextSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in "
+                     "deg\n    (3., 4.)>, text='Sample Text')>")
+    expected_str = ("Region: TextSkyRegion\ncenter: <SkyCoord (ICRS): "
+                    "(ra, dec) in deg\n    (3., 4.)>\ntext: 'Sample Text'")
 
     def test_copy(self):
         reg = self.reg.copy()


### PR DESCRIPTION
Currently the text value is not quoted in the repr/str output:

```python
>>> from regions import PixCoord, TextPixelRegion
>>> reg = TextPixelRegion(PixCoord(10, 10), 'this is a test')
>>> reg
<TextPixelRegion(center=PixCoord(x=10, y=10), text=this is a test)>
```

This PR fixes the output:
```python
>>> from regions import PixCoord, TextPixelRegion
>>> reg = TextPixelRegion(PixCoord(10, 10), 'this is a test')
>>> reg
<TextPixelRegion(center=PixCoord(x=10, y=10), text='this is a test')>
```