### PR TITLE
Require radius, width, and height parameters to be strictly positive (> 0)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,9 @@ API Changes
 - Renamed the ``BoundingBox`` class to ``RegionBoundingBox``. The old
   name is deprecated. [#427]
 
+- A ``ValueError`` is raised if the radius, width, or height region
+  parameters are not strictly positive (> 0). [#430]
+
 
 0.5 (2021-07-20)
 ================

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -57,7 +57,7 @@ class ScalarPixCoord(RegionAttribute):
 
     def _validate(self, value):
         if not (isinstance(value, PixCoord) and value.isscalar):
-            raise ValueError(f'The {self.name} must be a scalar PixCoord')
+            raise ValueError(f'{self.name!r} must be a scalar PixCoord')
 
 
 class OneDPixCoord(RegionAttribute):
@@ -68,7 +68,7 @@ class OneDPixCoord(RegionAttribute):
     def _validate(self, value):
         if not (isinstance(value, PixCoord) and not value.isscalar
                 and value.x.ndim == 1):
-            raise ValueError(f'The {self.name} must be a 1D PixCoord')
+            raise ValueError(f'{self.name!r} must be a 1D PixCoord')
 
 
 class PositiveScalar(RegionAttribute):
@@ -79,7 +79,7 @@ class PositiveScalar(RegionAttribute):
 
     def _validate(self, value):
         if not np.isscalar(value) or value <= 0:
-            raise ValueError(f'{self.name} must be a positive scalar')
+            raise ValueError(f'{self.name!r} must be a positive scalar')
 
 
 class ScalarSkyCoord(RegionAttribute):
@@ -90,7 +90,7 @@ class ScalarSkyCoord(RegionAttribute):
 
     def _validate(self, value):
         if not (isinstance(value, SkyCoord) and value.isscalar):
-            raise ValueError(f'The {self.name} must be a scalar SkyCoord')
+            raise ValueError(f'{self.name!r} must be a scalar SkyCoord')
 
 
 class OneDSkyCoord(RegionAttribute):
@@ -101,7 +101,7 @@ class OneDSkyCoord(RegionAttribute):
 
     def _validate(self, value):
         if not (isinstance(value, SkyCoord) and value.ndim == 1):
-            raise ValueError(f'The {self.name} must be a 1D SkyCoord')
+            raise ValueError(f'{self.name!r} must be a 1D SkyCoord')
 
 
 class ScalarAngle(RegionAttribute):
@@ -113,12 +113,12 @@ class ScalarAngle(RegionAttribute):
     def _validate(self, value):
         if isinstance(value, Quantity):
             if not value.isscalar:
-                raise ValueError(f'{self.name} must be a scalar')
+                raise ValueError(f'{self.name!r} must be a scalar')
 
             if not value.unit.physical_type == 'angle':
-                raise ValueError(f'{self.name} must have angular units')
+                raise ValueError(f'{self.name!r} must have angular units')
         else:
-            raise ValueError(f'{self.name} must be a scalar angle')
+            raise ValueError(f'{self.name!r} must be a scalar angle')
 
 
 class PositiveScalarAngle(RegionAttribute):
@@ -130,15 +130,15 @@ class PositiveScalarAngle(RegionAttribute):
     def _validate(self, value):
         if isinstance(value, Quantity):
             if not value.isscalar:
-                raise ValueError(f'{self.name} must be a scalar')
+                raise ValueError(f'{self.name!r} must be a scalar')
 
             if not value.unit.physical_type == 'angle':
-                raise ValueError(f'{self.name} must have angular units')
+                raise ValueError(f'{self.name!r} must have angular units')
 
             if not value > 0:
-                raise ValueError(f'{self.name} must be strictly positive')
+                raise ValueError(f'{self.name!r} must be strictly positive')
         else:
-            raise ValueError(f'{self.name} must be a positive scalar angle')
+            raise ValueError(f'{self.name!r} must be a positive scalar angle')
 
 
 class RegionType(RegionAttribute):
@@ -152,5 +152,5 @@ class RegionType(RegionAttribute):
 
     def _validate(self, value):
         if not isinstance(value, self.regionclass):
-            raise ValueError(f'The {self.name} must be a '
+            raise ValueError(f'{self.name!r} must be a '
                              f'{self.regionclass.__name__} object')

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -103,16 +103,41 @@ class OneDSky(RegionAttribute):
             raise ValueError(f'The {self.name} must be a 1D SkyCoord object')
 
 
-class QuantityLength(RegionAttribute):
+class ScalarAngle(RegionAttribute):
     """
-    Descriptor class for `~regions.SkyRegion`, which takes a scalar
-    `~astropy.units.Quantity` object.
+    Descriptor class to check that value is a scalar angle, either an
+    astropy Angle or Quantity with angular units.
     """
 
     def _validate(self, value):
-        if not (isinstance(value, Quantity) and value.isscalar):
-            raise ValueError(f'The {self.name} must be a scalar astropy '
-                             'Quantity object')
+        if isinstance(value, Quantity):
+            if not value.isscalar:
+                raise ValueError(f'{self.name} must be a scalar')
+
+            if not value.unit.physical_type == 'angle':
+                raise ValueError(f'{self.name} must have angular units')
+        else:
+            raise ValueError(f'{self.name} must be a scalar angle')
+
+
+class PositiveScalarAngle(RegionAttribute):
+    """
+    Descriptor class to check that value is a strictly positive scalar
+    angle, either an astropy Angle or Quantity with angular units.
+    """
+
+    def _validate(self, value):
+        if isinstance(value, Quantity):
+            if not value.isscalar:
+                raise ValueError(f'{self.name} must be a scalar')
+
+            if not value.unit.physical_type == 'angle':
+                raise ValueError(f'{self.name} must have angular units')
+
+            if not value > 0:
+                raise ValueError(f'{self.name} must be strictly positive')
+        else:
+            raise ValueError(f'{self.name} must be a positive scalar angle')
 
 
 class RegionType(RegionAttribute):

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -18,6 +18,11 @@ __all__ = []
 class RegionAttribute(abc.ABC):
     """
     Base descriptor class for region attribute validation.
+
+    Parameters
+    ----------
+    name : str
+        The name of the attribute.
     """
 
     def __init__(self, name):
@@ -42,31 +47,28 @@ class RegionAttribute(abc.ABC):
 
         An exception is raised if the value is invalid.
         """
-        pass
+        raise NotImplementedError
 
 
-class ScalarPix(RegionAttribute):
+class ScalarPixCoord(RegionAttribute):
     """
-    Descriptor class for `~regions.PixelRegion`, which takes a scalar
-    `~regions.PixCoord` object.
+    Descriptor class to check that value is a scalar `~regions.PixCoord`.
     """
 
     def _validate(self, value):
         if not (isinstance(value, PixCoord) and value.isscalar):
-            raise ValueError(f'The {self.name} must be a scalar PixCoord '
-                             'object')
+            raise ValueError(f'The {self.name} must be a scalar PixCoord')
 
 
-class OneDPix(RegionAttribute):
+class OneDPixCoord(RegionAttribute):
     """
-    Descriptor class for `~regions.PixelRegion`, which takes a
-    one-dimensional `regions.PixCoord` object.
+    Descriptor class to check that value is a 1D `~regions.PixCoord`.
     """
 
     def _validate(self, value):
         if not (isinstance(value, PixCoord) and not value.isscalar
                 and value.x.ndim == 1):
-            raise ValueError(f'The {self.name} must be a 1D PixCoord object')
+            raise ValueError(f'The {self.name} must be a 1D PixCoord')
 
 
 class PositiveScalar(RegionAttribute):
@@ -142,11 +144,11 @@ class PositiveScalarAngle(RegionAttribute):
 
 class RegionType(RegionAttribute):
     """
-    Descriptor class for compound pixel and sky regions.
+    Descriptor class to check the region type of value.
     """
 
     def __init__(self, name, regionclass):
-        self.name = name
+        super().__init__(name)
         self.regionclass = regionclass
 
     def _validate(self, value):

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -30,7 +30,7 @@ class RegionAttribute(abc.ABC):
 
     def __get__(self, instance, owner):
         if instance is None:
-            return self
+            return self  # pragma: no cover
         return instance.__dict__[self.name]
 
     def __set__(self, instance, value):
@@ -38,7 +38,7 @@ class RegionAttribute(abc.ABC):
         instance.__dict__[self.name] = value
 
     def __delete__(self, instance):
-        del instance.__dict__[self.name]
+        del instance.__dict__[self.name]  # pragma: no cover
 
     @abc.abstractmethod
     def _validate(self, value):
@@ -47,7 +47,7 @@ class RegionAttribute(abc.ABC):
 
         An exception is raised if the value is invalid.
         """
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 class ScalarPixCoord(RegionAttribute):

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -15,7 +15,7 @@ from .pixcoord import PixCoord
 __all__ = []
 
 
-class RegionAttr(abc.ABC):
+class RegionAttribute(abc.ABC):
     """
     Base descriptor class for region attribute validation.
     """
@@ -45,7 +45,7 @@ class RegionAttr(abc.ABC):
         pass
 
 
-class ScalarPix(RegionAttr):
+class ScalarPix(RegionAttribute):
     """
     Descriptor class for `~regions.PixelRegion`, which takes a scalar
     `~regions.PixCoord` object.
@@ -57,7 +57,7 @@ class ScalarPix(RegionAttr):
                              'object')
 
 
-class OneDPix(RegionAttr):
+class OneDPix(RegionAttribute):
     """
     Descriptor class for `~regions.PixelRegion`, which takes a
     one-dimensional `regions.PixCoord` object.
@@ -69,19 +69,18 @@ class OneDPix(RegionAttr):
             raise ValueError(f'The {self.name} must be a 1D PixCoord object')
 
 
-class ScalarLength(RegionAttr):
+class PositiveScalar(RegionAttribute):
     """
-    Descriptor class for `~regions.PixelRegion`, which takes a scalar
-    python/numpy number.
+    Descriptor class to check that value is a strictly positive (> 0)
+    scalar.
     """
 
     def _validate(self, value):
-        if not np.isscalar(value):
-            raise ValueError(
-                f'The {self.name} must be a scalar numpy/python number')
+        if not np.isscalar(value) or value <= 0:
+            raise ValueError(f'{self.name} must be a positive scalar')
 
 
-class ScalarSky(RegionAttr):
+class ScalarSky(RegionAttribute):
     """
     Descriptor class for `~regions.SkyRegion`, which takes a scalar
     `~astropy.coordinates.SkyCoord` object.
@@ -93,7 +92,7 @@ class ScalarSky(RegionAttr):
                              'object')
 
 
-class OneDSky(RegionAttr):
+class OneDSky(RegionAttribute):
     """
     Descriptor class for `~regions.SkyRegion`, which takes a
     one-dimensional `~astropy.coordinates.SkyCoord` object.
@@ -104,7 +103,7 @@ class OneDSky(RegionAttr):
             raise ValueError(f'The {self.name} must be a 1D SkyCoord object')
 
 
-class QuantityLength(RegionAttr):
+class QuantityLength(RegionAttribute):
     """
     Descriptor class for `~regions.SkyRegion`, which takes a scalar
     `~astropy.units.Quantity` object.
@@ -116,7 +115,7 @@ class QuantityLength(RegionAttr):
                              'Quantity object')
 
 
-class RegionType(RegionAttr):
+class RegionType(RegionAttribute):
     """
     Descriptor class for compound pixel and sky regions.
     """

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -82,27 +82,26 @@ class PositiveScalar(RegionAttribute):
             raise ValueError(f'{self.name} must be a positive scalar')
 
 
-class ScalarSky(RegionAttribute):
+class ScalarSkyCoord(RegionAttribute):
     """
-    Descriptor class for `~regions.SkyRegion`, which takes a scalar
-    `~astropy.coordinates.SkyCoord` object.
+    Descriptor class to check that value is a scalar
+    `~astropy.coordinates.SkyCoord`.
     """
 
     def _validate(self, value):
         if not (isinstance(value, SkyCoord) and value.isscalar):
-            raise ValueError(f'The {self.name} must be a scalar SkyCoord '
-                             'object')
+            raise ValueError(f'The {self.name} must be a scalar SkyCoord')
 
 
-class OneDSky(RegionAttribute):
+class OneDSkyCoord(RegionAttribute):
     """
-    Descriptor class for `~regions.SkyRegion`, which takes a
-    one-dimensional `~astropy.coordinates.SkyCoord` object.
+    Descriptor class to check that value is a 1D
+    `~astropy.coordinates.SkyCoord`.
     """
 
     def _validate(self, value):
         if not (isinstance(value, SkyCoord) and value.ndim == 1):
-            raise ValueError(f'The {self.name} must be a 1D SkyCoord object')
+            raise ValueError(f'The {self.name} must be a 1D SkyCoord')
 
 
 class ScalarAngle(RegionAttribute):

--- a/regions/core/tests/test_compound.py
+++ b/regions/core/tests/test_compound.py
@@ -4,6 +4,7 @@ Tests for the compound module.
 """
 
 import operator
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
@@ -109,6 +110,12 @@ class TestCompoundPixel:
     def test_bounding_box(self):
         bbox = (self.c1 | self.c2).bounding_box
         assert bbox == RegionBoundingBox(1, 16, 1, 10)
+
+    def test_invalid(self):
+        with pytest.raises(ValueError):
+            self.c1 | 1.0
+        with pytest.raises(ValueError):
+            self.c1 | PixCoord(1.0, 2.0)
 
 
 def test_compound_sky():

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -9,8 +9,8 @@ import operator
 import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 
-from ..core.attributes import (ScalarPix, PositiveScalar, PositiveScalarAngle,
-                               ScalarAngle, ScalarSky)
+from ..core.attributes import (ScalarPixCoord, PositiveScalar,
+                               PositiveScalarAngle, ScalarAngle, ScalarSky)
 from ..core.compound import CompoundPixelRegion
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual
@@ -124,7 +124,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
 
     _component_class = CirclePixelRegion
     _params = ('center', 'inner_radius', 'outer_radius')
-    center = ScalarPix('center')
+    center = ScalarPixCoord('center')
     inner_radius = PositiveScalar('inner_radius')
     outer_radius = PositiveScalar('outer_radius')
 
@@ -230,7 +230,7 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
 
     _params = ('center', 'inner_width', 'outer_width', 'inner_height',
                'outer_height', 'angle')
-    center = ScalarPix('center')
+    center = ScalarPixCoord('center')
     inner_width = PositiveScalar('inner_width')
     outer_width = PositiveScalar('outer_width')
     inner_height = PositiveScalar('inner_height')

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -9,8 +9,8 @@ import operator
 import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 
-from ..core.attributes import (ScalarPix, PositiveScalar, QuantityLength,
-                               ScalarSky)
+from ..core.attributes import (ScalarPix, PositiveScalar, PositiveScalarAngle,
+                               ScalarAngle, ScalarSky)
 from ..core.compound import CompoundPixelRegion
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual
@@ -51,7 +51,7 @@ class AnnulusPixelRegion(PixelRegion, abc.ABC):
     def as_artist(self, origin=(0, 0), **kwargs):
         return self._compound_region.as_artist(origin, **kwargs)
 
-    def to_mask(self, mode="center", subpixels=5):
+    def to_mask(self, mode='center', subpixels=5):
         return self._compound_region.to_mask(mode, subpixels)
 
     def rotate(self, center, angle):
@@ -179,8 +179,8 @@ class CircleAnnulusSkyRegion(SkyRegion):
 
     _params = ('center', 'inner_radius', 'outer_radius')
     center = ScalarSky('center')
-    inner_radius = QuantityLength('inner_radius')
-    outer_radius = QuantityLength('outer_radius')
+    inner_radius = PositiveScalarAngle('inner_radius')
+    outer_radius = PositiveScalarAngle('outer_radius')
 
     def __init__(self, center, inner_radius, outer_radius, meta=None,
                  visual=None):
@@ -235,7 +235,7 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
     outer_width = PositiveScalar('outer_width')
     inner_height = PositiveScalar('inner_height')
     outer_height = PositiveScalar('outer_height')
-    angle = QuantityLength('angle')
+    angle = ScalarAngle('angle')
 
     def __init__(self, center, inner_width, outer_width, inner_height,
                  outer_height, angle=0 * u.deg, meta=None, visual=None):
@@ -311,11 +311,11 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
                'outer_height', 'angle')
 
     center = ScalarSky('center')
-    inner_width = QuantityLength('inner_width')
-    outer_width = QuantityLength('outer_width')
-    inner_height = QuantityLength('inner_height')
-    outer_height = QuantityLength('outer_height')
-    angle = QuantityLength('angle')
+    inner_width = PositiveScalarAngle('inner_width')
+    outer_width = PositiveScalarAngle('outer_width')
+    inner_height = PositiveScalarAngle('inner_height')
+    outer_height = PositiveScalarAngle('outer_height')
+    angle = ScalarAngle('angle')
 
     def __init__(self, center, inner_width, outer_width, inner_height,
                  outer_height, angle=0 * u.deg, meta=None, visual=None):
@@ -391,7 +391,7 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
         outer_width = 8.5
         inner_height = 3.5
         outer_height = 6.5
-        angle = Angle("45deg")
+        angle = Angle('45deg')
 
         fig, ax = plt.subplots(1, 1)
 
@@ -499,7 +499,7 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
         outer_width = 8.5
         inner_height = 3.5
         outer_height = 6.5
-        angle = Angle("45deg")
+        angle = Angle('45deg')
 
         fig, ax = plt.subplots(1, 1)
 

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -10,7 +10,8 @@ import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 
 from ..core.attributes import (ScalarPixCoord, PositiveScalar,
-                               PositiveScalarAngle, ScalarAngle, ScalarSky)
+                               PositiveScalarAngle, ScalarAngle,
+                               ScalarSkyCoord)
 from ..core.compound import CompoundPixelRegion
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual
@@ -178,7 +179,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'inner_radius', 'outer_radius')
-    center = ScalarSky('center')
+    center = ScalarSkyCoord('center')
     inner_radius = PositiveScalarAngle('inner_radius')
     outer_radius = PositiveScalarAngle('outer_radius')
 
@@ -310,7 +311,7 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
     _params = ('center', 'inner_width', 'outer_width', 'inner_height',
                'outer_height', 'angle')
 
-    center = ScalarSky('center')
+    center = ScalarSkyCoord('center')
     inner_width = PositiveScalarAngle('inner_width')
     outer_width = PositiveScalarAngle('outer_width')
     inner_height = PositiveScalarAngle('inner_height')

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -9,7 +9,7 @@ import operator
 import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 
-from ..core.attributes import (ScalarPix, ScalarLength, QuantityLength,
+from ..core.attributes import (ScalarPix, PositiveScalar, QuantityLength,
                                ScalarSky)
 from ..core.compound import CompoundPixelRegion
 from ..core.core import PixelRegion, SkyRegion
@@ -125,8 +125,8 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
     _component_class = CirclePixelRegion
     _params = ('center', 'inner_radius', 'outer_radius')
     center = ScalarPix('center')
-    inner_radius = ScalarLength('inner_radius')
-    outer_radius = ScalarLength('outer_radius')
+    inner_radius = PositiveScalar('inner_radius')
+    outer_radius = PositiveScalar('outer_radius')
 
     def __init__(self, center, inner_radius, outer_radius, meta=None,
                  visual=None):
@@ -231,10 +231,10 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
     _params = ('center', 'inner_width', 'outer_width', 'inner_height',
                'outer_height', 'angle')
     center = ScalarPix('center')
-    inner_width = ScalarLength('inner_width')
-    outer_width = ScalarLength('outer_width')
-    inner_height = ScalarLength('inner_height')
-    outer_height = ScalarLength('outer_height')
+    inner_width = PositiveScalar('inner_width')
+    outer_width = PositiveScalar('outer_width')
+    inner_height = PositiveScalar('inner_height')
+    outer_height = PositiveScalar('outer_height')
     angle = QuantityLength('angle')
 
     def __init__(self, center, inner_width, outer_width, inner_height,

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -10,7 +10,7 @@ import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
-from ..core.attributes import (ScalarPix, ScalarLength, QuantityLength,
+from ..core.attributes import (ScalarPix, PositiveScalar, QuantityLength,
                                ScalarSky)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
@@ -64,7 +64,7 @@ class CirclePixelRegion(PixelRegion):
 
     _params = ('center', 'radius')
     center = ScalarPix('center')
-    radius = ScalarLength('radius')
+    radius = PositiveScalar('radius')
     mpl_artist = 'Patch'
 
     def __init__(self, center, radius, meta=None, visual=None):

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -10,7 +10,7 @@ import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
-from ..core.attributes import (ScalarPix, PositiveScalar, QuantityLength,
+from ..core.attributes import (ScalarPix, PositiveScalar, PositiveScalarAngle,
                                ScalarSky)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
@@ -202,7 +202,7 @@ class CircleSkyRegion(SkyRegion):
 
     _params = ('center', 'radius')
     center = ScalarSky('center')
-    radius = QuantityLength("radius")
+    radius = PositiveScalarAngle('radius')
 
     def __init__(self, center, radius, meta=None, visual=None):
         self.center = center

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -11,7 +11,7 @@ from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
 from ..core.attributes import (ScalarPixCoord, PositiveScalar,
-                               PositiveScalarAngle, ScalarSky)
+                               PositiveScalarAngle, ScalarSkyCoord)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -201,7 +201,7 @@ class CircleSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'radius')
-    center = ScalarSky('center')
+    center = ScalarSkyCoord('center')
     radius = PositiveScalarAngle('radius')
 
     def __init__(self, center, radius, meta=None, visual=None):

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -10,8 +10,8 @@ import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
-from ..core.attributes import (ScalarPix, PositiveScalar, PositiveScalarAngle,
-                               ScalarSky)
+from ..core.attributes import (ScalarPixCoord, PositiveScalar,
+                               PositiveScalarAngle, ScalarSky)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -63,7 +63,7 @@ class CirclePixelRegion(PixelRegion):
     """
 
     _params = ('center', 'radius')
-    center = ScalarPix('center')
+    center = ScalarPixCoord('center')
     radius = PositiveScalar('radius')
     mpl_artist = 'Patch'
 

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -10,7 +10,7 @@ import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
-from ..core.attributes import (ScalarPix, ScalarLength, QuantityLength,
+from ..core.attributes import (ScalarPix, PositiveScalar, QuantityLength,
                                ScalarSky)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
@@ -75,8 +75,8 @@ class EllipsePixelRegion(PixelRegion):
 
     _params = ('center', 'width', 'height', 'angle')
     center = ScalarPix('center')
-    width = ScalarLength('width')
-    height = ScalarLength('height')
+    width = PositiveScalar('width')
+    height = PositiveScalar('height')
     angle = QuantityLength('angle')
     mpl_artist = 'Patch'
 

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -10,8 +10,8 @@ import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
-from ..core.attributes import (ScalarPix, PositiveScalar, QuantityLength,
-                               ScalarSky)
+from ..core.attributes import (ScalarPix, PositiveScalar, PositiveScalarAngle,
+                               ScalarAngle, ScalarSky)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -77,7 +77,7 @@ class EllipsePixelRegion(PixelRegion):
     center = ScalarPix('center')
     width = PositiveScalar('width')
     height = PositiveScalar('height')
-    angle = QuantityLength('angle')
+    angle = ScalarAngle('angle')
     mpl_artist = 'Patch'
 
     def __init__(self, center, width, height, angle=0. * u.deg, meta=None,
@@ -350,9 +350,9 @@ class EllipseSkyRegion(SkyRegion):
 
     _params = ('center', 'width', 'height', 'angle')
     center = ScalarSky('center')
-    width = QuantityLength('width')
-    height = QuantityLength('height')
-    angle = QuantityLength('angle')
+    width = PositiveScalarAngle('width')
+    height = PositiveScalarAngle('height')
+    angle = ScalarAngle('angle')
 
     def __init__(self, center, width, height, angle=0. * u.deg, meta=None,
                  visual=None):

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -10,8 +10,8 @@ import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
-from ..core.attributes import (ScalarPix, PositiveScalar, PositiveScalarAngle,
-                               ScalarAngle, ScalarSky)
+from ..core.attributes import (ScalarPixCoord, PositiveScalar,
+                               PositiveScalarAngle, ScalarAngle, ScalarSky)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -74,7 +74,7 @@ class EllipsePixelRegion(PixelRegion):
     """
 
     _params = ('center', 'width', 'height', 'angle')
-    center = ScalarPix('center')
+    center = ScalarPixCoord('center')
     width = PositiveScalar('width')
     height = PositiveScalar('height')
     angle = ScalarAngle('angle')

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -11,7 +11,8 @@ from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
 from ..core.attributes import (ScalarPixCoord, PositiveScalar,
-                               PositiveScalarAngle, ScalarAngle, ScalarSky)
+                               PositiveScalarAngle, ScalarAngle,
+                               ScalarSkyCoord)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -349,7 +350,7 @@ class EllipseSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'width', 'height', 'angle')
-    center = ScalarSky('center')
+    center = ScalarSkyCoord('center')
     width = PositiveScalarAngle('width')
     height = PositiveScalarAngle('height')
     angle = ScalarAngle('angle')

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -6,7 +6,7 @@ This module defines line regions in both pixel and sky coordinates.
 from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
-from ..core.attributes import ScalarPixCoord, ScalarSky
+from ..core.attributes import ScalarPixCoord, ScalarSkyCoord
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual
@@ -178,8 +178,8 @@ class LineSkyRegion(SkyRegion):
     """
 
     _params = ('start', 'end')
-    start = ScalarSky('start')
-    end = ScalarSky('end')
+    start = ScalarSkyCoord('start')
+    end = ScalarSkyCoord('end')
 
     def __init__(self, start, end, meta=None, visual=None):
         self.start = start

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -130,7 +130,7 @@ class LinePixelRegion(PixelRegion):
         y = self.start.y - origin[1]
         dx = self.end.x - self.start.x
         dy = self.end.y - self.start.y
-        kwargs.setdefault("width", 0.1)
+        kwargs.setdefault('width', 0.1)
 
         mpl_kwargs = self.visual.define_mpl_kwargs(self.mpl_artist)
         mpl_kwargs.update(kwargs)

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -6,7 +6,7 @@ This module defines line regions in both pixel and sky coordinates.
 from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
-from ..core.attributes import ScalarPix, ScalarSky
+from ..core.attributes import ScalarPixCoord, ScalarSky
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual
@@ -56,8 +56,8 @@ class LinePixelRegion(PixelRegion):
     """
 
     _params = ('start', 'end')
-    start = ScalarPix('start')
-    end = ScalarPix('end')
+    start = ScalarPixCoord('start')
+    end = ScalarPixCoord('end')
     mpl_artist = 'Patch'
 
     def __init__(self, start, end, meta=None, visual=None):

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -6,7 +6,7 @@ This module defines point regions in both pixel and sky coordinates.
 from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
-from ..core.attributes import ScalarPixCoord, ScalarSky
+from ..core.attributes import ScalarPixCoord, ScalarSkyCoord
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual
@@ -166,7 +166,7 @@ class PointSkyRegion(SkyRegion):
     """
 
     _params = ('center',)
-    center = ScalarSky('center')
+    center = ScalarSkyCoord('center')
 
     def __init__(self, center, meta=None, visual=None):
         self.center = center

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -6,7 +6,7 @@ This module defines point regions in both pixel and sky coordinates.
 from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
-from ..core.attributes import ScalarPix, ScalarSky
+from ..core.attributes import ScalarPixCoord, ScalarSky
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual
@@ -61,7 +61,7 @@ class PointPixelRegion(PixelRegion):
     """
 
     _params = ('center',)
-    center = ScalarPix('center')
+    center = ScalarPixCoord('center')
     mpl_artist = 'Line2D'
 
     def __init__(self, center, meta=None, visual=None):

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -7,7 +7,7 @@ import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
-from ..core.attributes import (OneDPix, OneDSky, ScalarPix, ScalarLength,
+from ..core.attributes import (OneDPix, OneDSky, ScalarPix, PositiveScalar,
                                QuantityLength)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
@@ -283,8 +283,8 @@ class RegularPolygonPixelRegion(PolygonPixelRegion):
 
     _params = ('center', 'nvertices', 'radius', 'angle')
     center = ScalarPix('center')
-    nvertices = ScalarLength('nvertices')
-    radius = ScalarLength('radius')
+    nvertices = PositiveScalar('nvertices')
+    radius = PositiveScalar('radius')
     angle = QuantityLength('angle')
 
     def __init__(self, center, nvertices, radius, angle=0. * u.deg,

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -8,7 +8,7 @@ from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
 from ..core.attributes import (OneDPix, OneDSky, ScalarPix, PositiveScalar,
-                               QuantityLength)
+                               ScalarAngle)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -285,7 +285,7 @@ class RegularPolygonPixelRegion(PolygonPixelRegion):
     center = ScalarPix('center')
     nvertices = PositiveScalar('nvertices')
     radius = PositiveScalar('radius')
-    angle = QuantityLength('angle')
+    angle = ScalarAngle('angle')
 
     def __init__(self, center, nvertices, radius, angle=0. * u.deg,
                  meta=None, visual=None):

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -7,8 +7,8 @@ import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
-from ..core.attributes import (OneDPix, OneDSky, ScalarPix, PositiveScalar,
-                               ScalarAngle)
+from ..core.attributes import (OneDPixCoord, ScalarPixCoord, PositiveScalar,
+                               ScalarAngle, OneDSky)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -61,7 +61,7 @@ class PolygonPixelRegion(PixelRegion):
     """
 
     _params = ('vertices',)
-    vertices = OneDPix('vertices')
+    vertices = OneDPixCoord('vertices')
     mpl_artist = 'Patch'
 
     def __init__(self, vertices, meta=None, visual=None,
@@ -282,7 +282,7 @@ class RegularPolygonPixelRegion(PolygonPixelRegion):
     """
 
     _params = ('center', 'nvertices', 'radius', 'angle')
-    center = ScalarPix('center')
+    center = ScalarPixCoord('center')
     nvertices = PositiveScalar('nvertices')
     radius = PositiveScalar('radius')
     angle = ScalarAngle('angle')

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -8,7 +8,7 @@ from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
 from ..core.attributes import (OneDPixCoord, ScalarPixCoord, PositiveScalar,
-                               ScalarAngle, OneDSky)
+                               ScalarAngle, OneDSkyCoord)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -353,7 +353,7 @@ class PolygonSkyRegion(SkyRegion):
     """
 
     _params = ('vertices',)
-    vertices = OneDSky('vertices')
+    vertices = OneDSkyCoord('vertices')
 
     def __init__(self, vertices, meta=None, visual=None):
         self.vertices = vertices

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -8,8 +8,8 @@ import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
-from ..core.attributes import (ScalarPix, PositiveScalar, PositiveScalarAngle,
-                               ScalarAngle, ScalarSky)
+from ..core.attributes import (ScalarPixCoord, PositiveScalar,
+                               PositiveScalarAngle, ScalarAngle, ScalarSky)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -72,7 +72,7 @@ class RectanglePixelRegion(PixelRegion):
     """
 
     _params = ('center', 'width', 'height', 'angle')
-    center = ScalarPix('center')
+    center = ScalarPixCoord('center')
     width = PositiveScalar('width')
     height = PositiveScalar('height')
     angle = ScalarAngle('angle')

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -8,7 +8,7 @@ import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
-from ..core.attributes import (ScalarPix, ScalarLength, QuantityLength,
+from ..core.attributes import (ScalarPix, PositiveScalar, QuantityLength,
                                ScalarSky)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
@@ -73,8 +73,8 @@ class RectanglePixelRegion(PixelRegion):
 
     _params = ('center', 'width', 'height', 'angle')
     center = ScalarPix('center')
-    width = ScalarLength('width')
-    height = ScalarLength('height')
+    width = PositiveScalar('width')
+    height = PositiveScalar('height')
     angle = QuantityLength('angle')
     mpl_artist = 'Patch'
 

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -9,7 +9,8 @@ from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
 from ..core.attributes import (ScalarPixCoord, PositiveScalar,
-                               PositiveScalarAngle, ScalarAngle, ScalarSky)
+                               PositiveScalarAngle, ScalarAngle,
+                               ScalarSkyCoord)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -388,7 +389,7 @@ class RectangleSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'width', 'height', 'angle')
-    center = ScalarSky('center')
+    center = ScalarSkyCoord('center')
     width = PositiveScalarAngle('width')
     height = PositiveScalarAngle('height')
     angle = ScalarAngle('angle')

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -8,8 +8,8 @@ import astropy.units as u
 from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
-from ..core.attributes import (ScalarPix, PositiveScalar, QuantityLength,
-                               ScalarSky)
+from ..core.attributes import (ScalarPix, PositiveScalar, PositiveScalarAngle,
+                               ScalarAngle, ScalarSky)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -75,7 +75,7 @@ class RectanglePixelRegion(PixelRegion):
     center = ScalarPix('center')
     width = PositiveScalar('width')
     height = PositiveScalar('height')
-    angle = QuantityLength('angle')
+    angle = ScalarAngle('angle')
     mpl_artist = 'Patch'
 
     def __init__(self, center, width, height, angle=0 * u.deg, meta=None,
@@ -389,9 +389,9 @@ class RectangleSkyRegion(SkyRegion):
 
     _params = ('center', 'width', 'height', 'angle')
     center = ScalarSky('center')
-    width = QuantityLength('width')
-    height = QuantityLength('height')
-    angle = QuantityLength('angle')
+    width = PositiveScalarAngle('width')
+    height = PositiveScalarAngle('height')
+    angle = ScalarAngle('angle')
 
     def __init__(self, center, width, height, angle=0 * u.deg, meta=None,
                  visual=None):

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -138,7 +138,7 @@ def test_attribute_validation_pixel_regions(region):
             for val in invalid_values.get(attr, None):
                 with pytest.raises(ValueError) as excinfo:
                     setattr(region, attr, val)
-                assert f'The {attr} must be' in str(excinfo.value)
+                assert f'{attr!r} must' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('region', SKY_REGIONS, ids=ids_func)
@@ -170,4 +170,4 @@ def test_attribute_validation_sky_regions(region):
             for val in invalid_values.get(attr, None):
                 with pytest.raises(ValueError) as excinfo:
                     setattr(region, attr, val)
-                assert f'The {attr} must be' in str(excinfo.value)
+                assert f'{attr!r} must' in str(excinfo.value)

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -115,13 +115,15 @@ def test_sky_to_pix(region):
 @pytest.mark.parametrize('region', PIXEL_REGIONS, ids=ids_func)
 def test_attribute_validation_pixel_regions(region):
     invalid_values = dict(center=[PixCoord([1, 2], [2, 3]), 1,
-                                  SkyCoord(1 * u.deg, 2 * u.deg)],
-                          radius=[u.Quantity("1deg"), [1], PixCoord(1, 2)],
+                                  SkyCoord(1 * u.deg, 2 * u.deg),
+                                  (10, 10), (10 * u.deg, 10 * u.deg)],
+                          radius=[u.Quantity("1deg"), [1], PixCoord(1, 2),
+                                  3 * u.km, 0.0, -10.],
                           angle=[u.Quantity([1 * u.deg, 2 * u.deg]), 2,
-                                 PixCoord(1, 2)],
+                                 PixCoord(1, 2), 3 * u.km],
                           vertices=[u.Quantity("1"), 2, PixCoord(1, 2),
-                                    PixCoord([[1, 2]], [[2, 3]])]
-                          )
+                                    PixCoord([[1, 2]], [[2, 3]]), 3 * u.km,
+                                    (10, 10), (10 * u.deg, 10 * u.deg)])
     invalid_values['width'] = invalid_values['radius']
     invalid_values['height'] = invalid_values['radius']
     invalid_values['inner_height'] = invalid_values['radius']
@@ -144,15 +146,19 @@ def test_attribute_validation_pixel_regions(region):
 @pytest.mark.parametrize('region', SKY_REGIONS, ids=ids_func)
 def test_attribute_validation_sky_regions(region):
     invalid_values = dict(center=[PixCoord([1, 2], [2, 3]), 1,
-                                  SkyCoord([1 * u.deg], [2 * u.deg])],
+                                  SkyCoord([1 * u.deg], [2 * u.deg]),
+                                  (10, 10), (10 * u.deg, 10 * u.deg)],
                           radius=[u.Quantity([1 * u.deg, 5 * u.deg]),
-                                  [1], SkyCoord(1 * u.deg, 2 * u.deg), 1],
+                                  [1], SkyCoord(1 * u.deg, 2 * u.deg),
+                                  1, 3 * u.km, 0.0 * u.deg, -10. * u.deg],
                           angle=[u.Quantity([1 * u.deg, 2 * u.deg]), 2,
-                                 SkyCoord(1 * u.deg, 2 * u.deg)],
+                                 SkyCoord(1 * u.deg, 2 * u.deg), 3. * u.km],
                           vertices=[u.Quantity("1deg"), 2,
                                     SkyCoord(1 * u.deg, 2 * u.deg),
                                     SkyCoord([[1 * u.deg, 2 * u.deg]],
-                                             [[2 * u.deg, 3 * u.deg]])])
+                                             [[2 * u.deg, 3 * u.deg]]),
+                                    3 * u.km, (10, 10),
+                                    (10 * u.deg, 10 * u.deg)])
 
     invalid_values['width'] = invalid_values['radius']
     invalid_values['height'] = invalid_values['radius']

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -74,6 +74,10 @@ class TestCirclePixelRegion(BaseTestPixelRegion):
         reg.radius = 3
         assert reg != self.reg
 
+    def test_zero_size(self):
+        with pytest.raises(ValueError):
+            CirclePixelRegion(PixCoord(50, 50), radius=0)
+
 
 class TestCircleSkyRegion(BaseTestSkyRegion):
     meta = RegionMeta({'text': 'test'})
@@ -117,7 +121,7 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
         radius = 2 * u.arcsec
         with pytest.raises(ValueError) as excinfo:
             CircleSkyRegion(center, radius)
-        estr = 'The center must be a scalar SkyCoord object'
+        estr = "'center' must be a scalar SkyCoord"
         assert estr in str(excinfo.value)
 
     def test_contains(self, wcs):
@@ -131,3 +135,7 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
         assert reg == self.reg
         reg.radius = 3 * u.arcsec
         assert reg != self.reg
+
+    def test_zero_size(self):
+        with pytest.raises(ValueError):
+            CircleSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg), 0. * u.arcsec)

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -100,17 +100,13 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         assert reg.bounding_box.shape == (a, b)
 
     def test_region_bbox_zero_size(self):
-        reg = EllipsePixelRegion(PixCoord(50, 50), width=0, height=0,
-                                 angle=0. * u.deg)
-        assert reg.bounding_box.shape == (1, 1)
+        with pytest.raises(ValueError):
+            EllipsePixelRegion(PixCoord(50, 50), width=0, height=0,
+                               angle=0. * u.deg)
 
-        reg = EllipsePixelRegion(PixCoord(50, 50), width=10, height=0,
-                                 angle=0. * u.deg)
-        assert reg.bounding_box.shape == (1, 11)
-
-        reg = EllipsePixelRegion(PixCoord(50, 50), width=0, height=10,
-                                 angle=0. * u.deg)
-        assert reg.bounding_box.shape == (11, 1)
+        with pytest.raises(ValueError):
+            EllipsePixelRegion(PixCoord(50, 50), width=10, height=0,
+                               angle=0. * u.deg)
 
     @pytest.mark.skipif(MPL_VERSION < 33, reason='requires `do_event`')
     @pytest.mark.parametrize('sync', (False, True))
@@ -300,7 +296,7 @@ class TestEllipseSkyRegion(BaseTestSkyRegion):
         height = 3 * u.arcsec
         with pytest.raises(ValueError) as excinfo:
             EllipseSkyRegion(center, width, height)
-        estr = 'The center must be a scalar SkyCoord object'
+        estr = "'center' must be a scalar SkyCoord"
         assert estr in str(excinfo.value)
 
     def test_contains(self, wcs):


### PR DESCRIPTION
Regions with zero or negative sizes (eventually) raise errors and are not useable.

This PR also updates the descriptor classes (and renames many of them, but they are not part of the public API).