### PR TITLE
Update attribute descriptors to use __set_name__

### DIFF
--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -77,12 +77,17 @@ class OneDPixCoord(RegionAttribute):
 class PositiveScalar(RegionAttribute):
     """
     Descriptor class to check that value is a strictly positive (> 0)
-    scalar.
+    scalar float/int (not `~astropy.units.Quantity`).
     """
 
     def _validate(self, value):
+        if isinstance(value, Quantity):
+            raise ValueError(f'{self.name!r} must be a scalar integer or '
+                             'float')
+
         if not np.isscalar(value) or value <= 0:
-            raise ValueError(f'{self.name!r} must be a positive scalar')
+            raise ValueError(f'{self.name!r} must be a strictly positive '
+                             'scalar')
 
 
 class ScalarSkyCoord(RegionAttribute):
@@ -143,7 +148,8 @@ class PositiveScalarAngle(RegionAttribute):
             if not value > 0:
                 raise ValueError(f'{self.name!r} must be strictly positive')
         else:
-            raise ValueError(f'{self.name!r} must be a positive scalar angle')
+            raise ValueError(f'{self.name!r} must be a strictly positive '
+                             'scalar angle')
 
 
 class RegionType(RegionAttribute):

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -21,17 +21,16 @@ class RegionAttribute(abc.ABC):
 
     Parameters
     ----------
-    name : str
-        The name of the attribute.
-
     description : str, optional
         The description of the attribute, which will be used as the
         attribute documentation.
     """
 
-    def __init__(self, name, description=''):
-        self.name = name
+    def __init__(self, description=''):
         self.__doc__ = description
+
+    def __set_name__(self, owner, name):
+        self.name = name
 
     def __get__(self, instance, owner):
         if instance is None:

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -43,7 +43,7 @@ class RegionAttribute(abc.ABC):
         instance.__dict__[self.name] = value
 
     def __delete__(self, instance):
-        del instance.__dict__[self.name]  # pragma: no cover
+        raise AttributeError(f'cannot delete {self.name!r}')
 
     @abc.abstractmethod
     def _validate(self, value):

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -21,13 +21,12 @@ class RegionAttribute(abc.ABC):
 
     Parameters
     ----------
-    description : str, optional
-        The description of the attribute, which will be used as the
-        attribute documentation.
+    doc : str, optional
+        The documentation string for the attribute.
     """
 
-    def __init__(self, description=''):
-        self.__doc__ = description
+    def __init__(self, doc=''):
+        self.__doc__ = doc
 
     def __set_name__(self, owner, name):
         self.name = name

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -52,45 +52,39 @@ class PixCoord:
         return self.__class__(copy.deepcopy(self.x), copy.deepcopy(self.y))
 
     @staticmethod
-    def _validate(val, name, expected='any'):
+    def _validate(obj, name, expected='any'):
         """
-        Validate that a given object is an appropriate `PixCoord`.
-
-        This is used for input validation throughout the regions
-        package, especially in the ``__init__`` method of pixel region
-        classes.
+        Validate that a given object is a valid `PixCoord`.
 
         Parameters
         ----------
-        val : `PixCoord`
+        obj : `PixCoord`
             The object to check.
         name : str
-            Parameter name (used for error messages).
-
-        expected : {'any', 'scalar', 'not scalar'}
+            The parameter name used for error messages.
+        expected : {'any', 'scalar', 'array'}
             What kind of PixCoord to check for.
 
         Returns
         -------
-        val : `PixCoord`
-            The input object (at the moment unmodified, might do fix-ups
-            here later).
+        obj : `PixCoord`
+            The input object, if valid.
         """
-        if not isinstance(val, PixCoord):
-            raise TypeError(f'{name} must be a PixCoord')
+        if not isinstance(obj, PixCoord):
+            raise TypeError(f'{name!r} must be a PixCoord')
 
         if expected == 'any':
             pass
         elif expected == 'scalar':
-            if not val.isscalar:
-                raise ValueError(f'{name} must be a scalar PixCoord')
-        elif expected == 'not scalar':
-            if val.isscalar:
-                raise ValueError(f'{name} must be a non-scalar PixCoord')
+            if not obj.isscalar:
+                raise ValueError(f'{name!r} must be a scalar PixCoord')
+        elif expected == 'array':
+            if obj.isscalar:
+                raise ValueError(f'{name!r} must be a PixCoord array')
         else:
-            raise ValueError(f'Invalid argument for `expected`: {expected}')
+            raise ValueError(f'Invalid value for "expected": {expected!r}')
 
-        return val
+        return obj
 
     @property
     def isscalar(self):

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -407,6 +407,20 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
         ax.set_aspect('equal')
     """
 
+    # duplicated from AsymmetricAnnulusPixelRegion because otherwise Sphinx
+    # ignores the docstrings in the parent class
+    center = ScalarPixCoord('The center pixel position as a PixCoord.')
+    inner_width = PositiveScalar('The inner width (before rotation) in '
+                                 'pixels as a float.')
+    outer_width = PositiveScalar('The outer width (before rotation) in '
+                                 'pixels as a float.')
+    inner_height = PositiveScalar('The inner height (before rotation) in '
+                                  'pixels as a float.')
+    outer_height = PositiveScalar('The outer height (before rotation) in '
+                                  'pixels as a float.')
+    angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
+                        'Quantity angle.')
+
     _component_class = EllipsePixelRegion
 
     def to_sky(self, wcs):
@@ -445,6 +459,20 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
         A dictionary that stores the visual meta attributes of this
         region.
     """
+
+    # duplicated from AsymmetricAnnulusSkyRegion because otherwise Sphinx
+    # ignores the docstrings in the parent class
+    center = ScalarSkyCoord('The center position as a SkyCoord.')
+    inner_width = PositiveScalarAngle('The inner width (before rotation) as '
+                                      'a Quantity angle.')
+    outer_width = PositiveScalarAngle('The outer width (before rotation) as '
+                                      'a Quantity angle.')
+    inner_height = PositiveScalarAngle('The inner height (before rotation) '
+                                       'as a Quantity angle.')
+    outer_height = PositiveScalarAngle('The outer height (before rotation) '
+                                       'as a Quantity angle.')
+    angle = ScalarAngle('The rotation angle measured anti-clockwise as a'
+                        'Quantity angle.')
 
     _component_class = EllipseSkyRegion
 
@@ -508,6 +536,20 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
         ax.set_aspect('equal')
     """
 
+    # duplicated from AsymmetricAnnulusPixelRegion because otherwise Sphinx
+    # ignores the docstrings in the parent class
+    center = ScalarPixCoord('The center pixel position as a PixCoord.')
+    inner_width = PositiveScalar('The inner width (before rotation) in '
+                                 'pixels as a float.')
+    outer_width = PositiveScalar('The outer width (before rotation) in '
+                                 'pixels as a float.')
+    inner_height = PositiveScalar('The inner height (before rotation) in '
+                                  'pixels as a float.')
+    outer_height = PositiveScalar('The outer height (before rotation) in '
+                                  'pixels as a float.')
+    angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
+                        'Quantity angle.')
+
     _component_class = RectanglePixelRegion
 
     def to_sky(self, wcs):
@@ -547,6 +589,20 @@ class RectangleAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
         A dictionary that stores the visual meta attributes of this
         region.
     """
+
+    # duplicated from AsymmetricAnnulusSkyRegion because otherwise Sphinx
+    # ignores the docstrings in the parent class
+    center = ScalarSkyCoord('The center position as a SkyCoord.')
+    inner_width = PositiveScalarAngle('The inner width (before rotation) as '
+                                      'a Quantity angle.')
+    outer_width = PositiveScalarAngle('The outer width (before rotation) as '
+                                      'a Quantity angle.')
+    inner_height = PositiveScalarAngle('The inner height (before rotation) '
+                                       'as a Quantity angle.')
+    outer_height = PositiveScalarAngle('The outer height (before rotation) '
+                                       'as a Quantity angle.')
+    angle = ScalarAngle('The rotation angle measured anti-clockwise as a'
+                        'Quantity angle.')
 
     _component_class = RectangleSkyRegion
 

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -120,12 +120,9 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
 
     _component_class = CirclePixelRegion
     _params = ('center', 'inner_radius', 'outer_radius')
-    center = ScalarPixCoord('center',
-                            description='The center pixel position.')
-    inner_radius = PositiveScalar('inner_radius',
-                                  description='The inner radius in pixels.')
-    outer_radius = PositiveScalar('outer_radius',
-                                  description='The outer radius in pixels.')
+    center = ScalarPixCoord(description='The center pixel position.')
+    inner_radius = PositiveScalar(description='The inner radius in pixels.')
+    outer_radius = PositiveScalar(description='The outer radius in pixels.')
 
     def __init__(self, center, inner_radius, outer_radius, meta=None,
                  visual=None):
@@ -177,14 +174,11 @@ class CircleAnnulusSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'inner_radius', 'outer_radius')
-    center = ScalarSkyCoord('center',
-                            description=('The center position in sky '
+    center = ScalarSkyCoord(description=('The center position in sky '
                                          'coordinates'))
-    inner_radius = PositiveScalarAngle('inner_radius',
-                                       description=('The inner radius as an '
+    inner_radius = PositiveScalarAngle(description=('The inner radius as an '
                                                     'angle.'))
-    outer_radius = PositiveScalarAngle('outer_radius',
-                                       description=('The outer radius as an '
+    outer_radius = PositiveScalarAngle(description=('The outer radius as an '
                                                     'angle.'))
 
     def __init__(self, center, inner_radius, outer_radius, meta=None,
@@ -235,18 +229,12 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
 
     _params = ('center', 'inner_width', 'outer_width', 'inner_height',
                'outer_height', 'angle')
-    center = ScalarPixCoord('center',
-                            description='The center position in pixels.')
-    inner_width = PositiveScalar('inner_width',
-                                 description='The inner width in pixels.')
-    outer_width = PositiveScalar('outer_width',
-                                 description='The outer width in pixels.')
-    inner_height = PositiveScalar('inner_height',
-                                  description='The inner height in pixels.')
-    outer_height = PositiveScalar('outer_height',
-                                  description='The outer height in pixels.')
-    angle = ScalarAngle('angle',
-                        description=('The rotation angle measured '
+    center = ScalarPixCoord(description='The center position in pixels.')
+    inner_width = PositiveScalar(description='The inner width in pixels.')
+    outer_width = PositiveScalar(description='The outer width in pixels.')
+    inner_height = PositiveScalar(description='The inner height in pixels.')
+    outer_height = PositiveScalar( description='The outer height in pixels.')
+    angle = ScalarAngle(description=('The rotation angle measured '
                                      'anti-clockwise.'))
 
     def __init__(self, center, inner_width, outer_width, inner_height,
@@ -322,23 +310,17 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
     _params = ('center', 'inner_width', 'outer_width', 'inner_height',
                'outer_height', 'angle')
 
-    center = ScalarSkyCoord('center',
-                            description=('The center position in sky '
+    center = ScalarSkyCoord(description=('The center position in sky '
                                          'coordinates'))
-    inner_width = PositiveScalarAngle('inner_width',
-                                      description=('The inner width as an '
+    inner_width = PositiveScalarAngle(description=('The inner width as an '
                                                    'angle.'))
-    outer_width = PositiveScalarAngle('outer_width',
-                                      description=('The outer width as an '
+    outer_width = PositiveScalarAngle(description=('The outer width as an '
                                                    'angle.'))
-    inner_height = PositiveScalarAngle('inner_height',
-                                       description=('The inner height as an '
+    inner_height = PositiveScalarAngle(description=('The inner height as an '
                                                     'angle.'))
-    outer_height = PositiveScalarAngle('outer_height',
-                                       description=('The outer height as an '
+    outer_height = PositiveScalarAngle(description=('The outer height as an '
                                                     'angle.'))
-    angle = ScalarAngle('angle',
-                        description=('The rotation angle measured '
+    angle = ScalarAngle(description=('The rotation angle measured '
                                      'anti-clockwise.'))
 
     def __init__(self, center, inner_width, outer_width, inner_height,

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -120,9 +120,9 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
 
     _component_class = CirclePixelRegion
     _params = ('center', 'inner_radius', 'outer_radius')
-    center = ScalarPixCoord(description='The center pixel position.')
-    inner_radius = PositiveScalar(description='The inner radius in pixels.')
-    outer_radius = PositiveScalar(description='The outer radius in pixels.')
+    center = ScalarPixCoord('The center pixel position as a PixCoord.')
+    inner_radius = PositiveScalar('The inner radius in pixels as a float.')
+    outer_radius = PositiveScalar('The outer radius in pixels as a float.')
 
     def __init__(self, center, inner_radius, outer_radius, meta=None,
                  visual=None):
@@ -174,12 +174,9 @@ class CircleAnnulusSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'inner_radius', 'outer_radius')
-    center = ScalarSkyCoord(description=('The center position in sky '
-                                         'coordinates'))
-    inner_radius = PositiveScalarAngle(description=('The inner radius as an '
-                                                    'angle.'))
-    outer_radius = PositiveScalarAngle(description=('The outer radius as an '
-                                                    'angle.'))
+    center = ScalarSkyCoord('The center position as a SkyCoord.')
+    inner_radius = PositiveScalarAngle('The inner radius as a Quantity angle.')
+    outer_radius = PositiveScalarAngle('The outer radius as a Quantity angle.')
 
     def __init__(self, center, inner_radius, outer_radius, meta=None,
                  visual=None):
@@ -229,13 +226,17 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
 
     _params = ('center', 'inner_width', 'outer_width', 'inner_height',
                'outer_height', 'angle')
-    center = ScalarPixCoord(description='The center position in pixels.')
-    inner_width = PositiveScalar(description='The inner width in pixels.')
-    outer_width = PositiveScalar(description='The outer width in pixels.')
-    inner_height = PositiveScalar(description='The inner height in pixels.')
-    outer_height = PositiveScalar( description='The outer height in pixels.')
-    angle = ScalarAngle(description=('The rotation angle measured '
-                                     'anti-clockwise.'))
+    center = ScalarPixCoord('The center pixel position as a PixCoord.')
+    inner_width = PositiveScalar('The inner width (before rotation) in '
+                                 'pixels as a float.')
+    outer_width = PositiveScalar('The outer width (before rotation) in '
+                                 'pixels as a float.')
+    inner_height = PositiveScalar('The inner height (before rotation) in '
+                                  'pixels as a float.')
+    outer_height = PositiveScalar('The outer height (before rotation) in '
+                                  'pixels as a float.')
+    angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
+                        'Quantity angle.')
 
     def __init__(self, center, inner_width, outer_width, inner_height,
                  outer_height, angle=0 * u.deg, meta=None, visual=None):
@@ -310,18 +311,17 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
     _params = ('center', 'inner_width', 'outer_width', 'inner_height',
                'outer_height', 'angle')
 
-    center = ScalarSkyCoord(description=('The center position in sky '
-                                         'coordinates'))
-    inner_width = PositiveScalarAngle(description=('The inner width as an '
-                                                   'angle.'))
-    outer_width = PositiveScalarAngle(description=('The outer width as an '
-                                                   'angle.'))
-    inner_height = PositiveScalarAngle(description=('The inner height as an '
-                                                    'angle.'))
-    outer_height = PositiveScalarAngle(description=('The outer height as an '
-                                                    'angle.'))
-    angle = ScalarAngle(description=('The rotation angle measured '
-                                     'anti-clockwise.'))
+    center = ScalarSkyCoord('The center position as a SkyCoord.')
+    inner_width = PositiveScalarAngle('The inner width (before rotation) as '
+                                      'a Quantity angle.')
+    outer_width = PositiveScalarAngle('The outer width (before rotation) as '
+                                      'a Quantity angle.')
+    inner_height = PositiveScalarAngle('The inner height (before rotation) '
+                                       'as a Quantity angle.')
+    outer_height = PositiveScalarAngle('The outer height (before rotation) '
+                                       'as a Quantity angle.')
+    angle = ScalarAngle('The rotation angle measured anti-clockwise as a'
+                        'Quantity angle.')
 
     def __init__(self, center, inner_width, outer_width, inner_height,
                  outer_height, angle=0 * u.deg, meta=None, visual=None):

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -59,8 +59,8 @@ class CirclePixelRegion(PixelRegion):
 
     _params = ('center', 'radius')
     _mpl_artist = 'Patch'
-    center = ScalarPixCoord(description='The center pixel position.')
-    radius = PositiveScalar(description='The radius in pixels.')
+    center = ScalarPixCoord('The center pixel position as a PixCoord.')
+    radius = PositiveScalar('The radius in pixels as a float.')
 
     def __init__(self, center, radius, meta=None, visual=None):
         self.center = center
@@ -196,9 +196,8 @@ class CircleSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'radius')
-    center = ScalarSkyCoord(description=('The center position in sky '
-                                         'coordinates.'))
-    radius = PositiveScalarAngle(description='The radius in angular units.')
+    center = ScalarSkyCoord('The center position as a SkyCoord.')
+    radius = PositiveScalarAngle('The radius as a Quantity angle.')
 
     def __init__(self, center, radius, meta=None, visual=None):
         self.center = center

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -59,8 +59,8 @@ class CirclePixelRegion(PixelRegion):
 
     _params = ('center', 'radius')
     _mpl_artist = 'Patch'
-    center = ScalarPixCoord('center', description='The center pixel position.')
-    radius = PositiveScalar('radius', description='The radius in pixels.')
+    center = ScalarPixCoord(description='The center pixel position.')
+    radius = PositiveScalar(description='The radius in pixels.')
 
     def __init__(self, center, radius, meta=None, visual=None):
         self.center = center
@@ -196,10 +196,9 @@ class CircleSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'radius')
-    center = ScalarSkyCoord('center', description=('The center position in '
-                                                   'sky coordinates.'))
-    radius = PositiveScalarAngle('radius',
-                                 description='The radius in angular units.')
+    center = ScalarSkyCoord(description=('The center position in sky '
+                                         'coordinates.'))
+    radius = PositiveScalarAngle(description='The radius in angular units.')
 
     def __init__(self, center, radius, meta=None, visual=None):
         self.center = center

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -70,13 +70,13 @@ class EllipsePixelRegion(PixelRegion):
 
     _params = ('center', 'width', 'height', 'angle')
     _mpl_artist = 'Patch'
-    center = ScalarPixCoord(description='The center pixel position.')
-    width = PositiveScalar(description=('The width of the ellipse (before '
-                                        'rotation) in pixels.'))
-    height = PositiveScalar(description=('The height of the ellipse (before '
-                                         'rotation) in pixels.'))
-    angle = ScalarAngle(description=('The rotation angle measured '
-                                     'anti-clockwise.'))
+    center = ScalarPixCoord('The center pixel position as a PixCoord.')
+    width = PositiveScalar('The width of the ellipse (before rotation) in '
+                           'pixels as a float.')
+    height = PositiveScalar('The height of the ellipse (before rotation) in '
+                            'pixels as a float.')
+    angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
+                        'Quantity angle.')
 
     def __init__(self, center, width, height, angle=0. * u.deg, meta=None,
                  visual=None):
@@ -347,15 +347,13 @@ class EllipseSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'width', 'height', 'angle')
-    center = ScalarSkyCoord(description=('The center position in sky '
-                                         'coordinates.'))
-    width = PositiveScalarAngle(description=('The width of the ellipse '
-                                             '(before rotation) as an angle.'))
-    height = PositiveScalarAngle(description=('The height of the ellipse '
-                                              '(before rotation) as an '
-                                              'angle.'))
-    angle = ScalarAngle(description=('The rotation angle measured '
-                                     'anti-clockwise.'))
+    center = ScalarSkyCoord('The center position as a SkyCoord.')
+    width = PositiveScalarAngle('The width of the ellipse (before rotation) '
+                                'as a Quantity angle.')
+    height = PositiveScalarAngle('The height of the ellipse (before rotation) '
+                                 'as a Quantity angle.')
+    angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
+                        'Quantity angle.')
 
     def __init__(self, center, width, height, angle=0. * u.deg, meta=None,
                  visual=None):

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -70,15 +70,12 @@ class EllipsePixelRegion(PixelRegion):
 
     _params = ('center', 'width', 'height', 'angle')
     _mpl_artist = 'Patch'
-    center = ScalarPixCoord('center', description='The center pixel position.')
-    width = PositiveScalar('width',
-                           description=('The width of the ellipse (before '
+    center = ScalarPixCoord(description='The center pixel position.')
+    width = PositiveScalar(description=('The width of the ellipse (before '
                                         'rotation) in pixels.'))
-    height = PositiveScalar('height',
-                            description=('The height of the ellipse (before '
+    height = PositiveScalar(description=('The height of the ellipse (before '
                                          'rotation) in pixels.'))
-    angle = ScalarAngle('angle',
-                        description=('The rotation angle measured '
+    angle = ScalarAngle(description=('The rotation angle measured '
                                      'anti-clockwise.'))
 
     def __init__(self, center, width, height, angle=0. * u.deg, meta=None,
@@ -350,18 +347,14 @@ class EllipseSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'width', 'height', 'angle')
-    center = ScalarSkyCoord('center',
-                            description=('The center position in sky '
+    center = ScalarSkyCoord(description=('The center position in sky '
                                          'coordinates.'))
-    width = PositiveScalarAngle('width',
-                                description=('The width of the ellipse '
+    width = PositiveScalarAngle(description=('The width of the ellipse '
                                              '(before rotation) as an angle.'))
-    height = PositiveScalarAngle('height',
-                                 description=('The height of the ellipse '
+    height = PositiveScalarAngle(description=('The height of the ellipse '
                                               '(before rotation) as an '
                                               'angle.'))
-    angle = ScalarAngle('angle',
-                        description=('The rotation angle measured '
+    angle = ScalarAngle(description=('The rotation angle measured '
                                      'anti-clockwise.'))
 
     def __init__(self, center, width, height, angle=0. * u.deg, meta=None,

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -53,8 +53,8 @@ class LinePixelRegion(PixelRegion):
 
     _params = ('start', 'end')
     _mpl_artist = 'Patch'
-    start = ScalarPixCoord(description='The start pixel position.')
-    end = ScalarPixCoord(description='The end pixel position.')
+    start = ScalarPixCoord('The start pixel position as a PixCoord.')
+    end = ScalarPixCoord('The end pixel position as a PixCoord.')
 
     def __init__(self, start, end, meta=None, visual=None):
         self.start = start
@@ -174,9 +174,8 @@ class LineSkyRegion(SkyRegion):
     """
 
     _params = ('start', 'end')
-    start = ScalarSkyCoord(description=('The start position as a sky '
-                                        'coordinate.'))
-    end = ScalarSkyCoord(description='The end position as a sky coordinate.')
+    start = ScalarSkyCoord('The start position as a SkyCoord.')
+    end = ScalarSkyCoord('The end position as a SkyCoord.')
 
     def __init__(self, start, end, meta=None, visual=None):
         self.start = start

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -53,8 +53,8 @@ class LinePixelRegion(PixelRegion):
 
     _params = ('start', 'end')
     _mpl_artist = 'Patch'
-    start = ScalarPixCoord('start', description='The start pixel position.')
-    end = ScalarPixCoord('end', description='The end pixel position.')
+    start = ScalarPixCoord(description='The start pixel position.')
+    end = ScalarPixCoord(description='The end pixel position.')
 
     def __init__(self, start, end, meta=None, visual=None):
         self.start = start
@@ -174,11 +174,9 @@ class LineSkyRegion(SkyRegion):
     """
 
     _params = ('start', 'end')
-    start = ScalarSkyCoord('start',
-                           description=('The start position as a sky '
+    start = ScalarSkyCoord(description=('The start position as a sky '
                                         'coordinate.'))
-    end = ScalarSkyCoord('end',
-                         description='The end position as a sky coordinate.')
+    end = ScalarSkyCoord(description='The end position as a sky coordinate.')
 
     def __init__(self, start, end, meta=None, visual=None):
         self.start = start

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -62,7 +62,7 @@ class PointPixelRegion(PixelRegion):
 
     _params = ('center',)
     _mpl_artist = 'Line2D'
-    center = ScalarPixCoord('center', description='The point pixel position.')
+    center = ScalarPixCoord(description='The point pixel position.')
 
     def __init__(self, center, meta=None, visual=None):
         self.center = center
@@ -166,8 +166,7 @@ class PointSkyRegion(SkyRegion):
     """
 
     _params = ('center',)
-    center = ScalarSkyCoord('center',
-                            description=('The point position as a sky '
+    center = ScalarSkyCoord(description=('The point position as a sky '
                                          'coordinate.'))
 
     def __init__(self, center, meta=None, visual=None):

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -62,7 +62,7 @@ class PointPixelRegion(PixelRegion):
 
     _params = ('center',)
     _mpl_artist = 'Line2D'
-    center = ScalarPixCoord(description='The point pixel position.')
+    center = ScalarPixCoord('The point pixel position as a PixCoord.')
 
     def __init__(self, center, meta=None, visual=None):
         self.center = center
@@ -166,8 +166,7 @@ class PointSkyRegion(SkyRegion):
     """
 
     _params = ('center',)
-    center = ScalarSkyCoord(description=('The point position as a sky '
-                                         'coordinate.'))
+    center = ScalarSkyCoord('The point position as a SkyCoord.')
 
     def __init__(self, center, meta=None, visual=None):
         self.center = center

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -61,8 +61,7 @@ class PolygonPixelRegion(PixelRegion):
 
     _params = ('vertices',)
     _mpl_artist = 'Patch'
-    vertices = OneDPixCoord('vertices',
-                            description='The vertices of the polygon.')
+    vertices = OneDPixCoord(description='The vertices of the polygon.')
 
     def __init__(self, vertices, meta=None, visual=None,
                  origin=PixCoord(0, 0)):
@@ -361,8 +360,7 @@ class PolygonSkyRegion(SkyRegion):
     """
 
     _params = ('vertices',)
-    vertices = OneDSkyCoord('vertices',
-                            description=('The vertices of the polygon as '
+    vertices = OneDSkyCoord(description=('The vertices of the polygon as '
                                          'sky coordinates.'))
 
     def __init__(self, vertices, meta=None, visual=None):

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -61,7 +61,8 @@ class PolygonPixelRegion(PixelRegion):
 
     _params = ('vertices',)
     _mpl_artist = 'Patch'
-    vertices = OneDPixCoord(description='The vertices of the polygon.')
+    vertices = OneDPixCoord('The vertices of the polygon as a PixCoord '
+                            'array.')
 
     def __init__(self, vertices, meta=None, visual=None,
                  origin=PixCoord(0, 0)):
@@ -360,8 +361,8 @@ class PolygonSkyRegion(SkyRegion):
     """
 
     _params = ('vertices',)
-    vertices = OneDSkyCoord(description=('The vertices of the polygon as '
-                                         'sky coordinates.'))
+    vertices = OneDSkyCoord('The vertices of the polygon as a SkyCoord '
+                            'array.')
 
     def __init__(self, vertices, meta=None, visual=None):
         self.vertices = vertices

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -68,13 +68,13 @@ class RectanglePixelRegion(PixelRegion):
 
     _params = ('center', 'width', 'height', 'angle')
     _mpl_artist = 'Patch'
-    center = ScalarPixCoord(description='The center pixel position.')
-    width = PositiveScalar(description=('The width of the rectangle (before '
-                                        'rotation) in pixels.'))
-    height = PositiveScalar(description=('The height of the rectangle (before '
-                                         'rotation) in pixels.'))
-    angle = ScalarAngle(description=('The rotation angle measured '
-                                     'anti-clockwise.'))
+    center = ScalarPixCoord('The center pixel position as a PixCoord.')
+    width = PositiveScalar('The width of the rectangle (before rotation) in '
+                           'pixels as a float.')
+    height = PositiveScalar('The height of the rectangle (before rotation) '
+                            'in pixels as a float.')
+    angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
+                        'Quantity angle.')
 
     def __init__(self, center, width, height, angle=0 * u.deg, meta=None,
                  visual=None):
@@ -386,15 +386,13 @@ class RectangleSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'width', 'height', 'angle')
-    center = ScalarSkyCoord(description=('The center position in sky '
-                                         'coordinates.'))
-    width = PositiveScalarAngle(description=('The width of the rectangle '
-                                             '(before rotation) as an angle.'))
-    height = PositiveScalarAngle(description=('The height of the rectangle '
-                                              '(before rotation) as an '
-                                              'angle.'))
-    angle = ScalarAngle(description=('The rotation angle measured '
-                                     'anti-clockwise.'))
+    center = ScalarSkyCoord('The center position as a SkyCoord.')
+    width = PositiveScalarAngle('The width of the rectangle (before rotation) '
+                                'as a Quantity angle.')
+    height = PositiveScalarAngle('The height of the rectangle (before '
+                                 'rotation) as a Quantity angle.')
+    angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
+                        'Quantity angle.')
 
     def __init__(self, center, width, height, angle=0 * u.deg, meta=None,
                  visual=None):

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -68,15 +68,12 @@ class RectanglePixelRegion(PixelRegion):
 
     _params = ('center', 'width', 'height', 'angle')
     _mpl_artist = 'Patch'
-    center = ScalarPixCoord('center', description='The center pixel position.')
-    width = PositiveScalar('width',
-                           description=('The width of the rectangle (before '
+    center = ScalarPixCoord(description='The center pixel position.')
+    width = PositiveScalar(description=('The width of the rectangle (before '
                                         'rotation) in pixels.'))
-    height = PositiveScalar('height',
-                            description=('The height of the rectangle (before '
+    height = PositiveScalar(description=('The height of the rectangle (before '
                                          'rotation) in pixels.'))
-    angle = ScalarAngle('angle',
-                        description=('The rotation angle measured '
+    angle = ScalarAngle(description=('The rotation angle measured '
                                      'anti-clockwise.'))
 
     def __init__(self, center, width, height, angle=0 * u.deg, meta=None,
@@ -389,18 +386,14 @@ class RectangleSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'width', 'height', 'angle')
-    center = ScalarSkyCoord('center',
-                            description=('The center position in sky '
+    center = ScalarSkyCoord(description=('The center position in sky '
                                          'coordinates.'))
-    width = PositiveScalarAngle('width',
-                                description=('The width of the rectangle '
+    width = PositiveScalarAngle(description=('The width of the rectangle '
                                              '(before rotation) as an angle.'))
-    height = PositiveScalarAngle('height',
-                                 description=('The height of the rectangle '
+    height = PositiveScalarAngle(description=('The height of the rectangle '
                                               '(before rotation) as an '
                                               'angle.'))
-    angle = ScalarAngle('angle',
-                        description=('The rotation angle measured '
+    angle = ScalarAngle(description=('The rotation angle measured '
                                      'anti-clockwise.'))
 
     def __init__(self, center, width, height, angle=0 * u.deg, meta=None,

--- a/regions/shapes/tests/test_common.py
+++ b/regions/shapes/tests/test_common.py
@@ -18,6 +18,12 @@ class BaseTestRegion:
     def test_str(self):
         assert str(self.reg) == self.expected_str
 
+    def test_del(self):
+        # test that Region shape attributes (descriptors) cannot be
+        # deleted)
+        with pytest.raises(AttributeError):
+            delattr(self, self._params[0])
+
 
 class BaseTestPixelRegion(BaseTestRegion):
 

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -51,8 +51,7 @@ class TextPixelRegion(PointPixelRegion):
 
     _params = ('center', 'text')
     _mpl_artist = 'Text'
-    center = ScalarPixCoord('center',
-                            description=('The leftmost pixel position before '
+    center = ScalarPixCoord(description=('The leftmost pixel position before '
                                          'rotation.'))
 
     def __init__(self, center, text, meta=None, visual=None):
@@ -122,8 +121,7 @@ class TextSkyRegion(PointSkyRegion):
     """
 
     _params = ('center', 'text')
-    center = ScalarSkyCoord('center',
-                            description=('The leftmost position before '
+    center = ScalarSkyCoord(description=('The leftmost position before '
                                          'rotation as a sky coordinate.'))
 
     def __init__(self, center, text, meta=None, visual=None):

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -51,8 +51,8 @@ class TextPixelRegion(PointPixelRegion):
 
     _params = ('center', 'text')
     _mpl_artist = 'Text'
-    center = ScalarPixCoord(description=('The leftmost pixel position before '
-                                         'rotation.'))
+    center = ScalarPixCoord('The leftmost pixel position (before rotation) '
+                            'as a PixCoord.')
 
     def __init__(self, center, text, meta=None, visual=None):
         super().__init__(center, meta, visual)
@@ -121,8 +121,8 @@ class TextSkyRegion(PointSkyRegion):
     """
 
     _params = ('center', 'text')
-    center = ScalarSkyCoord(description=('The leftmost position before '
-                                         'rotation as a sky coordinate.'))
+    center = ScalarSkyCoord('The leftmost position (before rotation) as a '
+                            'SkyCoord.')
 
     def __init__(self, center, text, meta=None, visual=None):
         super().__init__(center, meta, visual)


### PR DESCRIPTION
This PR updates the descriptors (used as region attribute validators) to use `__set_name__` (PEP-487).  It also adds attribute docs for the ellipse/rectangle pixel/sky regions, which were not being rendered by Sphinx.  It also improves the docs for several attributes.