### PR TITLE
Update PixelAperture.plot() to return mpl artists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -100,6 +100,10 @@ API Changes
   the DS9 serializer and writer.  The new ``precision`` keyword can be
   used when serializing and writing DS9 regions. [#436]
 
+- The ``PixelRegion.plot()`` method now returns a
+  ``matplotlib.artist.Artist`` object, which can be used in plot legends.
+  [#441]
+
 
 0.5 (2021-07-20)
 ================

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -290,8 +290,10 @@ class RegionBoundingBox:
 
         Returns
         -------
-        ax : `~matplotlib.axes.Axes`
-            Axes on which the patch is added.
+        patch : `matplotlib.patches.Patch`
+            The matplotlib patch object for the plotted bounding box.
+            The patch can be used, for example, when adding a plot
+            legend.
         """
         reg = self.to_region()
         return reg.plot(origin=origin, ax=ax, **kwargs)

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -393,8 +393,10 @@ class PixelRegion(Region):
 
         Returns
         -------
-        ax : `~matplotlib.axes.Axes`
-            The axes on which the patch was added.
+        artist : `matplotlib.artist.Artist`
+            The matplotlib artist (typically a `~matplotlib.patches.Patch`
+            object) for the plotted region. The artist can be used, for
+            example, when adding a plot legend.
         """
         import matplotlib.pyplot as plt
 
@@ -404,7 +406,7 @@ class PixelRegion(Region):
         artist = self.as_artist(origin=origin, **kwargs)
         ax.add_artist(artist)
 
-        return ax
+        return artist
 
 
 class SkyRegion(Region):

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -111,8 +111,10 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
         reg = CircleAnnulusPixelRegion(PixCoord(x=6, y=6),
                                        inner_radius=5.5,
                                        outer_radius=8.0)
-        reg.plot(ax=ax, facecolor='none', edgecolor='red', lw=2)
+        patch = reg.plot(ax=ax, facecolor='none', edgecolor='red', lw=2,
+                         label='Circle Annulus')
 
+        ax.legend(handles=(patch,), loc='upper center')
         ax.set_xlim(-5, 20)
         ax.set_ylim(-5, 20)
         ax.set_aspect('equal')
@@ -406,8 +408,10 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
                                         inner_height=3.5,
                                         outer_height=6.5,
                                         angle=Angle('45deg'))
-        reg.plot(ax=ax, facecolor='none', edgecolor='red', lw=2)
+        patch = reg.plot(ax=ax, facecolor='none', edgecolor='red', lw=2,
+                         label='Ellipse Annulus')
 
+        ax.legend(handles=(patch,), loc='upper center')
         ax.set_xlim(-5, 20)
         ax.set_ylim(-5, 20)
         ax.set_aspect('equal')
@@ -535,8 +539,10 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
                                           inner_height=3.5,
                                           outer_height=6.5,
                                           angle=Angle('45deg'))
-        reg.plot(ax=ax, facecolor='none', edgecolor='red', lw=2)
+        patch = reg.plot(ax=ax, facecolor='none', edgecolor='red', lw=2,
+                         label='Rectangle Annulus')
 
+        ax.legend(handles=(patch,), loc='upper center')
         ax.set_xlim(-5, 20)
         ax.set_ylim(-5, 20)
         ax.set_aspect('equal')

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -50,8 +50,10 @@ class CirclePixelRegion(PixelRegion):
         fig, ax = plt.subplots(1, 1)
 
         reg = CirclePixelRegion(PixCoord(x=8, y=7), radius=3.5)
-        reg.plot(ax=ax, facecolor='none', edgecolor='red', lw=2)
+        patch = reg.plot(ax=ax, facecolor='none', edgecolor='red', lw=2,
+                         label='Circle')
 
+        ax.legend(handles=(patch,), loc='upper center')
         ax.set_xlim(0, 15)
         ax.set_ylim(0, 15)
         ax.set_aspect('equal')

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -61,8 +61,10 @@ class EllipsePixelRegion(PixelRegion):
 
         reg = EllipsePixelRegion(PixCoord(15, 10), width=16, height=10,
                                  angle=Angle(30, 'deg'))
-        reg.plot(ax=ax, facecolor='none', edgecolor='red', lw=2)
+        patch = reg.plot(ax=ax, facecolor='none', edgecolor='red', lw=2,
+                         label='Ellipse')
 
+        ax.legend(handles=(patch,), loc='upper center')
         ax.set_xlim(0, 30)
         ax.set_ylim(0, 20)
         ax.set_aspect('equal')

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -44,8 +44,9 @@ class LinePixelRegion(PixelRegion):
         start = PixCoord(x=15, y=10)
         end = PixCoord(x=20, y=25)
         reg = LinePixelRegion(start=start, end=end)
-        reg.plot(ax=ax, edgecolor='red', lw=2)
+        patch = reg.plot(ax=ax, edgecolor='red', lw=2, label='Line')
 
+        ax.legend(handles=(patch,), loc='upper center')
         ax.set_xlim(0, 30)
         ax.set_ylim(0, 30)
         ax.set_aspect('equal')

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -52,8 +52,10 @@ class PolygonPixelRegion(PixelRegion):
         x, y = [45, 45, 55, 60], [75, 70, 65, 75]
         vertices = PixCoord(x=x, y=y)
         reg = PolygonPixelRegion(vertices=vertices)
-        reg.plot(ax=ax, facecolor='none', edgecolor='red', lw=2)
+        patch = reg.plot(ax=ax, facecolor='none', edgecolor='red', lw=2,
+                         label='Polygon')
 
+        ax.legend(handles=(patch,), loc='upper center')
         ax.set_xlim(30, 80)
         ax.set_ylim(50, 80)
         ax.set_aspect('equal')

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -59,8 +59,10 @@ class RectanglePixelRegion(PixelRegion):
 
         reg = RectanglePixelRegion(PixCoord(x=15, y=10), width=8,
                                    height=5, angle=Angle(30, 'deg'))
-        reg.plot(ax=ax, facecolor='none', edgecolor='red', lw=2)
+        patch = reg.plot(ax=ax, facecolor='none', edgecolor='red', lw=2,
+                         label='Rectangle')
 
+        ax.legend(handles=(patch,), loc='upper center')
         ax.set_xlim(0, 30)
         ax.set_ylim(0, 20)
         ax.set_aspect('equal')

--- a/regions/shapes/tests/test_common.py
+++ b/regions/shapes/tests/test_common.py
@@ -8,6 +8,7 @@ from numpy.testing import assert_equal, assert_allclose
 import pytest
 
 from ...core.pixcoord import PixCoord
+from ..._utils.optional_deps import HAS_MATPLOTLIB  # noqa
 
 
 class BaseTestRegion:
@@ -22,7 +23,7 @@ class BaseTestRegion:
         # test that Region shape attributes (descriptors) cannot be
         # deleted)
         with pytest.raises(AttributeError):
-            delattr(self, self._params[0])
+            delattr(self.reg, self.reg._params[0])
 
 
 class BaseTestPixelRegion(BaseTestRegion):
@@ -71,6 +72,12 @@ class BaseTestPixelRegion(BaseTestRegion):
         assert actual.shape == (3, len(x))
         assert_equal(actual[:, :len(self.inside)], True)
         assert_equal(actual[:, len(self.inside):], False)
+
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
+    def test_plot(self):
+        from matplotlib.artist import Artist
+        artist = self.reg.plot()
+        assert isinstance(artist, Artist)
 
 
 class BaseTestSkyRegion(BaseTestRegion):


### PR DESCRIPTION
This PR updates the `plot` method for pixel-based regions to return a `matplotlib.artist.Artist` (typically this will be a `matplotlib.patches.Patch` object).  This is very useful, for example, when creating plot legends.  This API was discussed back in https://github.com/astropy/regions/issues/296, but never implemented until now.

Closes #296