### PR TITLE
Add common links to docs config

### DIFF
--- a/docs/common_links.txt
+++ b/docs/common_links.txt
@@ -1,0 +1,25 @@
+.. These are ReST substitutions and links that can be used throughout the docs
+.. (and docstrings) because they are added to ``docs/conf.py::rst_epilog``.
+
+.. ------------------------------------------------------------------
+.. RST SUBSITUTIONS
+
+.. NumPy
+.. |ndarray| replace:: :class:`numpy.ndarray`
+
+.. Astropy
+.. |Angle| replace:: `astropy.coordinates.Angle`
+.. |Latitude| replace:: `astropy.coordinates.Latitude`
+.. |Longitude| replace:: :class:`astropy.coordinates.Longitude`
+.. |SkyCoord| replace:: :class:`astropy.coordinates.SkyCoord`
+.. |Table| replace:: :class:`astropy.table.Table`
+.. |QTable| replace:: :class:`astropy.table.QTable`
+.. |Quantity| replace:: :class:`astropy.units.Quantity`
+.. |Unit| replace:: :class:`astropy.units.UnitBase`
+
+.. Regions
+.. |PixCoord| replace:: `~regions.PixCoord`
+
+.. Matplotlib
+.. _Matplotlib: https://matplotlib.org/
+.. |Patch| replace:: `~matplotlib.patches.Patch`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,8 +54,8 @@ plot_formats = ['png', 'hires.png', 'pdf', 'svg']
 
 # This is added to the end of RST files - a good place to put
 # substitutions to be used globally.
-# rst_epilog += """
-# """
+with open('common_links.txt', 'r') as fh:
+    rst_epilog += fh.read()
 
 
 # -- Project information ------------------------------------------------------

--- a/docs/shapes.rst
+++ b/docs/shapes.rst
@@ -162,17 +162,21 @@ Polygon
 .. This is not available yet, for now see `spherical_geometry`_ for
 .. spherical polygons and `Shapely`_ for pixel polygons.
 
-`~regions.PolygonSkyRegion` and `~regions.PolygonPixelRegion`
+`~regions.PolygonSkyRegion`, `~regions.PolygonPixelRegion`, and
+`~regions.RegularPolygonPixelRegion`
 
 .. code-block:: python
 
     >>> from astropy.coordinates import SkyCoord
     >>> from regions import PixCoord, PolygonSkyRegion, PolygonPixelRegion
+    >>> from regions import RegularPolygonPixelRegion
 
     >>> vertices = SkyCoord([1, 2, 2], [1, 1, 2], unit='deg', frame='fk5')
     >>> region_sky = PolygonSkyRegion(vertices=vertices)
     >>> vertices = PixCoord(x=[1, 2, 2], y=[1, 1, 2])
     >>> region_pix = PolygonPixelRegion(vertices=vertices)
+    >>> center = PixCoord(25, 25)
+    >>> region2_pix = RegularPolygonPixelRegion(center, 6, 15)
 
 
 Point

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -280,7 +280,7 @@ class PixelRegion(Region):
     @abc.abstractmethod
     def area(self):
         """
-        The area of the region.
+        The exact analytical area of the region shape.
         """
         raise NotImplementedError
 

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -122,7 +122,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
 
     _component_class = CirclePixelRegion
     _params = ('center', 'inner_radius', 'outer_radius')
-    center = ScalarPixCoord('The center pixel position as a PixCoord.')
+    center = ScalarPixCoord('The center pixel position as a |PixCoord|.')
     inner_radius = PositiveScalar('The inner radius in pixels as a float.')
     outer_radius = PositiveScalar('The outer radius in pixels as a float.')
 
@@ -176,9 +176,11 @@ class CircleAnnulusSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'inner_radius', 'outer_radius')
-    center = ScalarSkyCoord('The center position as a SkyCoord.')
-    inner_radius = PositiveScalarAngle('The inner radius as a Quantity angle.')
-    outer_radius = PositiveScalarAngle('The outer radius as a Quantity angle.')
+    center = ScalarSkyCoord('The center position as a |SkyCoord|.')
+    inner_radius = PositiveScalarAngle('The inner radius as a |Quantity| '
+                                       'angle.')
+    outer_radius = PositiveScalarAngle('The outer radius as a |Quantity| '
+                                       'angle.')
 
     def __init__(self, center, inner_radius, outer_radius, meta=None,
                  visual=None):
@@ -228,7 +230,7 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
 
     _params = ('center', 'inner_width', 'outer_width', 'inner_height',
                'outer_height', 'angle')
-    center = ScalarPixCoord('The center pixel position as a PixCoord.')
+    center = ScalarPixCoord('The center pixel position as a |PixCoord|.')
     inner_width = PositiveScalar('The inner width (before rotation) in '
                                  'pixels as a float.')
     outer_width = PositiveScalar('The outer width (before rotation) in '
@@ -238,7 +240,7 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
     outer_height = PositiveScalar('The outer height (before rotation) in '
                                   'pixels as a float.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
-                        'Quantity angle.')
+                        '|Quantity| angle.')
 
     def __init__(self, center, inner_width, outer_width, inner_height,
                  outer_height, angle=0 * u.deg, meta=None, visual=None):
@@ -316,17 +318,17 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
     _params = ('center', 'inner_width', 'outer_width', 'inner_height',
                'outer_height', 'angle')
 
-    center = ScalarSkyCoord('The center position as a SkyCoord.')
+    center = ScalarSkyCoord('The center position as a |SkyCoord|.')
     inner_width = PositiveScalarAngle('The inner width (before rotation) as '
-                                      'a Quantity angle.')
+                                      'a |Quantity| angle.')
     outer_width = PositiveScalarAngle('The outer width (before rotation) as '
-                                      'a Quantity angle.')
+                                      'a |Quantity| angle.')
     inner_height = PositiveScalarAngle('The inner height (before rotation) '
-                                       'as a Quantity angle.')
+                                       'as a |Quantity| angle.')
     outer_height = PositiveScalarAngle('The outer height (before rotation) '
-                                       'as a Quantity angle.')
+                                       'as a |Quantity| angle.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a'
-                        'Quantity angle.')
+                        '|Quantity| angle.')
 
     def __init__(self, center, inner_width, outer_width, inner_height,
                  outer_height, angle=0 * u.deg, meta=None, visual=None):
@@ -419,7 +421,7 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
 
     # duplicated from AsymmetricAnnulusPixelRegion because otherwise Sphinx
     # ignores the docstrings in the parent class
-    center = ScalarPixCoord('The center pixel position as a PixCoord.')
+    center = ScalarPixCoord('The center pixel position as a |PixCoord|.')
     inner_width = PositiveScalar('The inner width (before rotation) in '
                                  'pixels as a float.')
     outer_width = PositiveScalar('The outer width (before rotation) in '
@@ -429,7 +431,7 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
     outer_height = PositiveScalar('The outer height (before rotation) in '
                                   'pixels as a float.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
-                        'Quantity angle.')
+                        '|Quantity| angle.')
 
     _component_class = EllipsePixelRegion
 
@@ -472,17 +474,17 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
 
     # duplicated from AsymmetricAnnulusSkyRegion because otherwise Sphinx
     # ignores the docstrings in the parent class
-    center = ScalarSkyCoord('The center position as a SkyCoord.')
+    center = ScalarSkyCoord('The center position as a |SkyCoord|.')
     inner_width = PositiveScalarAngle('The inner width (before rotation) as '
-                                      'a Quantity angle.')
+                                      'a |Quantity| angle.')
     outer_width = PositiveScalarAngle('The outer width (before rotation) as '
-                                      'a Quantity angle.')
+                                      'a |Quantity| angle.')
     inner_height = PositiveScalarAngle('The inner height (before rotation) '
-                                       'as a Quantity angle.')
+                                       'as a |Quantity| angle.')
     outer_height = PositiveScalarAngle('The outer height (before rotation) '
-                                       'as a Quantity angle.')
-    angle = ScalarAngle('The rotation angle measured anti-clockwise as a'
-                        'Quantity angle.')
+                                       'as a |Quantity| angle.')
+    angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
+                        '|Quantity| angle.')
 
     _component_class = EllipseSkyRegion
 
@@ -550,7 +552,7 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
 
     # duplicated from AsymmetricAnnulusPixelRegion because otherwise Sphinx
     # ignores the docstrings in the parent class
-    center = ScalarPixCoord('The center pixel position as a PixCoord.')
+    center = ScalarPixCoord('The center pixel position as a |PixCoord|.')
     inner_width = PositiveScalar('The inner width (before rotation) in '
                                  'pixels as a float.')
     outer_width = PositiveScalar('The outer width (before rotation) in '
@@ -560,7 +562,7 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
     outer_height = PositiveScalar('The outer height (before rotation) in '
                                   'pixels as a float.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
-                        'Quantity angle.')
+                        '|Quantity| angle.')
 
     _component_class = RectanglePixelRegion
 
@@ -604,17 +606,17 @@ class RectangleAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
 
     # duplicated from AsymmetricAnnulusSkyRegion because otherwise Sphinx
     # ignores the docstrings in the parent class
-    center = ScalarSkyCoord('The center position as a SkyCoord.')
+    center = ScalarSkyCoord('The center position as a |SkyCoord|.')
     inner_width = PositiveScalarAngle('The inner width (before rotation) as '
-                                      'a Quantity angle.')
+                                      'a |Quantity| angle.')
     outer_width = PositiveScalarAngle('The outer width (before rotation) as '
-                                      'a Quantity angle.')
+                                      'a |Quantity| angle.')
     inner_height = PositiveScalarAngle('The inner height (before rotation) '
-                                       'as a Quantity angle.')
+                                       'as a |Quantity| angle.')
     outer_height = PositiveScalarAngle('The outer height (before rotation) '
-                                       'as a Quantity angle.')
-    angle = ScalarAngle('The rotation angle measured anti-clockwise as a'
-                        'Quantity angle.')
+                                       'as a |Quantity| angle.')
+    angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
+                        '|Quantity| angle.')
 
     _component_class = RectangleSkyRegion
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -61,7 +61,7 @@ class CirclePixelRegion(PixelRegion):
 
     _params = ('center', 'radius')
     _mpl_artist = 'Patch'
-    center = ScalarPixCoord('The center pixel position as a PixCoord.')
+    center = ScalarPixCoord('The center pixel position as a |PixCoord|.')
     radius = PositiveScalar('The radius in pixels as a float.')
 
     def __init__(self, center, radius, meta=None, visual=None):
@@ -198,8 +198,8 @@ class CircleSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'radius')
-    center = ScalarSkyCoord('The center position as a SkyCoord.')
-    radius = PositiveScalarAngle('The radius as a Quantity angle.')
+    center = ScalarSkyCoord('The center position as a |SkyCoord|.')
+    radius = PositiveScalarAngle('The radius as a |Quantity| angle.')
 
     def __init__(self, center, radius, meta=None, visual=None):
         self.center = center

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -72,13 +72,13 @@ class EllipsePixelRegion(PixelRegion):
 
     _params = ('center', 'width', 'height', 'angle')
     _mpl_artist = 'Patch'
-    center = ScalarPixCoord('The center pixel position as a PixCoord.')
+    center = ScalarPixCoord('The center pixel position as a |PixCoord|.')
     width = PositiveScalar('The width of the ellipse (before rotation) in '
                            'pixels as a float.')
     height = PositiveScalar('The height of the ellipse (before rotation) in '
                             'pixels as a float.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
-                        'Quantity angle.')
+                        '|Quantity| angle.')
 
     def __init__(self, center, width, height, angle=0. * u.deg, meta=None,
                  visual=None):
@@ -91,7 +91,6 @@ class EllipsePixelRegion(PixelRegion):
 
     @property
     def area(self):
-        """Region area (float)"""
         return math.pi / 4 * self.width * self.height
 
     def contains(self, pixcoord):
@@ -352,13 +351,13 @@ class EllipseSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'width', 'height', 'angle')
-    center = ScalarSkyCoord('The center position as a SkyCoord.')
+    center = ScalarSkyCoord('The center position as a |SkyCoord|.')
     width = PositiveScalarAngle('The width of the ellipse (before rotation) '
-                                'as a Quantity angle.')
+                                'as a |Quantity| angle.')
     height = PositiveScalarAngle('The height of the ellipse (before rotation) '
-                                 'as a Quantity angle.')
+                                 'as a |Quantity| angle.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
-                        'Quantity angle.')
+                        '|Quantity| angle.')
 
     def __init__(self, center, width, height, angle=0. * u.deg, meta=None,
                  visual=None):

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -54,8 +54,8 @@ class LinePixelRegion(PixelRegion):
 
     _params = ('start', 'end')
     _mpl_artist = 'Patch'
-    start = ScalarPixCoord('The start pixel position as a PixCoord.')
-    end = ScalarPixCoord('The end pixel position as a PixCoord.')
+    start = ScalarPixCoord('The start pixel position as a |PixCoord|.')
+    end = ScalarPixCoord('The end pixel position as a |PixCoord|.')
 
     def __init__(self, start, end, meta=None, visual=None):
         self.start = start
@@ -175,8 +175,8 @@ class LineSkyRegion(SkyRegion):
     """
 
     _params = ('start', 'end')
-    start = ScalarSkyCoord('The start position as a SkyCoord.')
-    end = ScalarSkyCoord('The end position as a SkyCoord.')
+    start = ScalarSkyCoord('The start position as a |SkyCoord|.')
+    end = ScalarSkyCoord('The end position as a |SkyCoord|.')
 
     def __init__(self, start, end, meta=None, visual=None):
         self.start = start

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -62,7 +62,7 @@ class PointPixelRegion(PixelRegion):
 
     _params = ('center',)
     _mpl_artist = 'Line2D'
-    center = ScalarPixCoord('The point pixel position as a PixCoord.')
+    center = ScalarPixCoord('The point pixel position as a |PixCoord|.')
 
     def __init__(self, center, meta=None, visual=None):
         self.center = center
@@ -166,7 +166,7 @@ class PointSkyRegion(SkyRegion):
     """
 
     _params = ('center',)
-    center = ScalarSkyCoord('The point position as a SkyCoord.')
+    center = ScalarSkyCoord('The point position as a |SkyCoord|.')
 
     def __init__(self, center, meta=None, visual=None):
         self.center = center

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -63,8 +63,7 @@ class PolygonPixelRegion(PixelRegion):
 
     _params = ('vertices',)
     _mpl_artist = 'Patch'
-    vertices = OneDPixCoord('The vertices of the polygon as a PixCoord '
-                            'array.')
+    vertices = OneDPixCoord('The vertices of the polygon as a |PixCoord| array.')
 
     def __init__(self, vertices, meta=None, visual=None,
                  origin=PixCoord(0, 0)):
@@ -284,10 +283,12 @@ class RegularPolygonPixelRegion(PolygonPixelRegion):
     """
 
     _params = ('center', 'nvertices', 'radius', 'angle')
-    center = ScalarPixCoord('center')
-    nvertices = PositiveScalar('nvertices')
-    radius = PositiveScalar('radius')
-    angle = ScalarAngle('angle')
+    center = ScalarPixCoord('The center pixel position as a |PixCoord|.')
+    nvertices = PositiveScalar('The number of polygon vertices.')
+    radius = PositiveScalar('The distance from the center to any vertex in '
+                            'pixels as a float.')
+    angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
+                        '|Quantity| angle.')
 
     def __init__(self, center, nvertices, radius, angle=0. * u.deg,
                  meta=None, visual=None):
@@ -363,8 +364,7 @@ class PolygonSkyRegion(SkyRegion):
     """
 
     _params = ('vertices',)
-    vertices = OneDSkyCoord('The vertices of the polygon as a SkyCoord '
-                            'array.')
+    vertices = OneDSkyCoord('The vertices of the polygon as a |SkyCoord| array.')
 
     def __init__(self, vertices, meta=None, visual=None):
         self.vertices = vertices

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -70,13 +70,13 @@ class RectanglePixelRegion(PixelRegion):
 
     _params = ('center', 'width', 'height', 'angle')
     _mpl_artist = 'Patch'
-    center = ScalarPixCoord('The center pixel position as a PixCoord.')
+    center = ScalarPixCoord('The center pixel position as a |PixCoord|.')
     width = PositiveScalar('The width of the rectangle (before rotation) in '
                            'pixels as a float.')
     height = PositiveScalar('The height of the rectangle (before rotation) '
                             'in pixels as a float.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
-                        'Quantity angle.')
+                        '|Quantity| angle.')
 
     def __init__(self, center, width, height, angle=0 * u.deg, meta=None,
                  visual=None):
@@ -391,13 +391,13 @@ class RectangleSkyRegion(SkyRegion):
     """
 
     _params = ('center', 'width', 'height', 'angle')
-    center = ScalarSkyCoord('The center position as a SkyCoord.')
+    center = ScalarSkyCoord('The center position as a |SkyCoord|.')
     width = PositiveScalarAngle('The width of the rectangle (before rotation) '
-                                'as a Quantity angle.')
+                                'as a |Quantity| angle.')
     height = PositiveScalarAngle('The height of the rectangle (before '
-                                 'rotation) as a Quantity angle.')
+                                 'rotation) as a |Quantity| angle.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
-                        'Quantity angle.')
+                        '|Quantity| angle.')
 
     def __init__(self, center, width, height, angle=0 * u.deg, meta=None,
                  visual=None):

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -52,7 +52,7 @@ class TextPixelRegion(PointPixelRegion):
     _params = ('center', 'text')
     _mpl_artist = 'Text'
     center = ScalarPixCoord('The leftmost pixel position (before rotation) '
-                            'as a PixCoord.')
+                            'as a |PixCoord|.')
 
     def __init__(self, center, text, meta=None, visual=None):
         super().__init__(center, meta, visual)
@@ -122,7 +122,7 @@ class TextSkyRegion(PointSkyRegion):
 
     _params = ('center', 'text')
     center = ScalarSkyCoord('The leftmost position (before rotation) as a '
-                            'SkyCoord.')
+                            '|SkyCoord|.')
 
     def __init__(self, center, text, meta=None, visual=None):
         super().__init__(center, meta, visual)


### PR DESCRIPTION
This PR adds common link replacements to be used in the documentation.  It also adds `RegularPolygonPixelRegion` to the shapes docs.