### PR TITLE
Fix ambiguous CRFT length regex

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ New Features
 Bug Fixes
 ---------
 
+- Fixed an issue with the CRTF for certain malformed input. [#448]
+
 API Changes
 -----------
 

--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -31,7 +31,7 @@ regex_global = re.compile(r'^global\s+(?P<parameters>.*)?')
 regex_coordinate = re.compile(r'\[([\w.+-:]*?)\s*[,]\s*([\w.+-:]*?)\]')
 
 # Single length format, e.g., helps extract the radius of a circle
-regex_length = re.compile(r'(?:\[[^=]*\])+[,]\s*([^\[]*)\]')
+regex_length = re.compile(r'(?:\[[^=\]]*\])+[,]\s*([^\[]*)\]')
 
 # Extracts each 'parameter=value' pair
 regex_meta = re.compile(r'(?:(\w+)\s*=[\s\'\"]*([^,\[\]]+?)[\'\",]+)|(?:(\w+)\s*=\s*\[(.*?)\])')  # noqa


### PR DESCRIPTION
This PR fixes the ambiguous CRFT length regex, which can cause a [runaway regular expression](https://www.regular-expressions.info/catastrophic.html). For example, parsing the following malformed region causes "catastrophic backtracking":  `ann circle[][][18h12m24s, -23d11m00s, 2.3arcsec]`, due to the presence of `][`.