### PR TITLE
Fix ds9 serialization of empty region list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Bug Fixes
 
 - Fixed an issue with the CRTF for certain malformed input. [#448]
 
+- Fixed a bug where DS9 serialization of an empty list raised an error.
+  [#449]
+
 API Changes
 -----------
 

--- a/regions/io/ds9/tests/test_ds9.py
+++ b/regions/io/ds9/tests/test_ds9.py
@@ -595,3 +595,8 @@ def test_serialize_regularpolygon():
     result1 = region.serialize(format='ds9')
     result2 = poly_region.serialize(format='ds9')
     assert result1 == result2
+
+
+def test_serialize_empty_list():
+    regions = Regions([])
+    assert regions.serialize(format='ds9') == ''

--- a/regions/io/ds9/write.py
+++ b/regions/io/ds9/write.py
@@ -21,6 +21,9 @@ __all__ = []
 @RegionsRegistry.register(Region, 'serialize', 'ds9')
 @RegionsRegistry.register(Regions, 'serialize', 'ds9')
 def _serialize_ds9(regions, precision=8):
+    if not regions:
+        return ''
+
     region_data = []
     for region in regions:
         if isinstance(region, (CompoundPixelRegion, CompoundSkyRegion)):


### PR DESCRIPTION
DS9 serialization of an empty `Regions` list now returns an empty string.

Fixes #445.