### PR TITLE
Temporarily disable ellipse and rectangle selector tests

### DIFF
--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -109,7 +109,9 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
                                angle=0. * u.deg)
 
     @pytest.mark.skipif(MPL_VERSION < 33, reason='requires `do_event`')
-    @pytest.mark.parametrize('sync', (False, True))
+    # temporarily disable sync=True test due to random failures
+    # @pytest.mark.parametrize('sync', (False, True))
+    @pytest.mark.parametrize('sync', (False,))
     def test_as_mpl_selector(self, sync):
 
         plt = pytest.importorskip('matplotlib.pyplot')

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -116,7 +116,9 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
         assert reg != self.reg
 
     @pytest.mark.skipif(MPL_VERSION < 33, reason='requires `do_event`')
-    @pytest.mark.parametrize('sync', (False, True))
+    # temporarily disable sync=True test due to random failures
+    # @pytest.mark.parametrize('sync', (False, True))
+    @pytest.mark.parametrize('sync', (False,))
     def test_as_mpl_selector(self, sync):
         plt = pytest.importorskip('matplotlib.pyplot')
         from matplotlib.testing.widgets import do_event


### PR DESCRIPTION
These selector tests started failing again.  This PR temporarily disables them until the root issue is found.