### PR TITLE
Allow region meta or visual keywords to be a dict

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ General
 New Features
 ------------
 
+- Region meta and visual metadata can be now input as a ``dict``. [#462]
+
 Bug Fixes
 ---------
 

--- a/docs/common_links.txt
+++ b/docs/common_links.txt
@@ -19,6 +19,8 @@
 
 .. Regions
 .. |PixCoord| replace:: `~regions.PixCoord`
+.. |RegionMeta| replace:: `~regions.RegionMeta`
+.. |RegionVisual| replace:: `~regions.RegionVisual`
 
 .. Matplotlib
 .. _Matplotlib: https://matplotlib.org/

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -177,7 +177,7 @@ class RegionMetaDescr(RegionAttribute):
     """
     def __set__(self, instance, value):
         # RegionMeta subclasses dict
-        if type(value) == dict:  # pylint: disable=C0123
+        if isinstance(value, dict) and not isinstance(value, RegionMeta):
             value = RegionMeta(value)
         super().__set__(instance, value)
 
@@ -197,7 +197,7 @@ class RegionVisualDescr(RegionAttribute):
 
     def __set__(self, instance, value):
         # RegionVisual subclasses dict
-        if type(value) == dict:  # pylint: disable=C0123
+        if isinstance(value, dict) and not isinstance(value, RegionVisual):
             value = RegionVisual(value)
         super().__set__(instance, value)
 

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -11,6 +11,7 @@ from astropy.units import Quantity
 import numpy as np
 
 from .pixcoord import PixCoord
+from .metadata import RegionMeta, RegionVisual
 
 __all__ = []
 
@@ -165,3 +166,42 @@ class RegionType(RegionAttribute):
         if not isinstance(value, self.regionclass):
             raise ValueError(f'{self.name!r} must be a '
                              f'{self.regionclass.__name__} object')
+
+
+class RegionMetaDescr(RegionAttribute):
+    """
+    Descriptor class for the region meta dictionary.
+
+    If input as a pure `dict`, it will be converted to a `RegionMeta`
+    object.
+    """
+    def __set__(self, instance, value):
+        # RegionMeta subclasses dict
+        if type(value) == dict:  # pylint: disable=C0123
+            value = RegionMeta(value)
+        super().__set__(instance, value)
+
+    def _validate(self, value):
+        if not isinstance(value, RegionMeta):
+            raise ValueError(f'{self.name!r} must be a dict or RegionMeta '
+                             'object')
+
+
+class RegionVisualDescr(RegionAttribute):
+    """
+    Descriptor class for the region visual dictionary.
+
+    If input as a pure `dict`, it will be converted to a `RegionVisual`
+    object.
+    """
+
+    def __set__(self, instance, value):
+        # RegionVisual subclasses dict
+        if type(value) == dict:  # pylint: disable=C0123
+            value = RegionVisual(value)
+        super().__set__(instance, value)
+
+    def _validate(self, value):
+        if not isinstance(value, RegionVisual):
+            raise ValueError(f'{self.name!r} must be a dict or RegionVisual '
+                             'object')

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -11,7 +11,8 @@ from astropy.wcs.utils import pixel_to_skycoord
 
 from ..core.attributes import (ScalarPixCoord, PositiveScalar,
                                PositiveScalarAngle, ScalarAngle,
-                               ScalarSkyCoord)
+                               ScalarSkyCoord, RegionMetaDescr,
+                               RegionVisualDescr)
 from ..core.compound import CompoundPixelRegion
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual
@@ -92,10 +93,10 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
         The inner radius of the annulus in pixels.
     outer_radius : float
         The outer radius of the annulus in pixels.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
 
     Examples
@@ -125,6 +126,8 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
     center = ScalarPixCoord('The center pixel position as a |PixCoord|.')
     inner_radius = PositiveScalar('The inner radius in pixels as a float.')
     outer_radius = PositiveScalar('The outer radius in pixels as a float.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, inner_radius, outer_radius, meta=None,
                  visual=None):
@@ -168,10 +171,10 @@ class CircleAnnulusSkyRegion(SkyRegion):
         The inner radius of the annulus in angular units.
     outer_radius : `~astropy.units.Quantity`
         The outer radius of the annulus in angular units.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
     """
 
@@ -181,6 +184,8 @@ class CircleAnnulusSkyRegion(SkyRegion):
                                        'angle.')
     outer_radius = PositiveScalarAngle('The outer radius as a |Quantity| '
                                        'angle.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, inner_radius, outer_radius, meta=None,
                  visual=None):
@@ -241,6 +246,8 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
                                   'pixels as a float.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
                         '|Quantity| angle.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, inner_width, outer_width, inner_height,
                  outer_height, angle=0 * u.deg, meta=None, visual=None):
@@ -308,10 +315,10 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
         The rotation angle of the annulus, measured anti-clockwise. If
         set to zero (the default), the width axis is lined up with the
         longitude axis of the celestial coordinates
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
     """
 
@@ -329,6 +336,8 @@ class AsymmetricAnnulusSkyRegion(SkyRegion):
                                        'as a |Quantity| angle.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a'
                         '|Quantity| angle.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, inner_width, outer_width, inner_height,
                  outer_height, angle=0 * u.deg, meta=None, visual=None):
@@ -387,10 +396,10 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
         The rotation angle of the elliptical annulus, measured
         anti-clockwise. If set to zero (the default), the width axis is
         lined up with the x axis.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
 
     Examples
@@ -465,10 +474,10 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
         The rotation angle of the elliptical annulus, measured
         anti-clockwise. If set to zero (the default), the width axis is
         lined up with the longitude axis of the celestial coordinates
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
     """
 
@@ -518,10 +527,10 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
         The rotation angle of the rectangular annulus, measured
         anti-clockwise. If set to zero (the default), the width axis is
         lined up with the x axis.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
 
     Examples
@@ -597,10 +606,10 @@ class RectangleAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
         The rotation angle of the rectangular annulus, measured
         anti-clockwise. If set to zero (the default), the width axis is
         lined up with the longitude axis of the celestial coordinates
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
     """
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -11,7 +11,8 @@ from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
 from ..core.attributes import (ScalarPixCoord, PositiveScalar,
-                               PositiveScalarAngle, ScalarSkyCoord)
+                               PositiveScalarAngle, ScalarSkyCoord,
+                               RegionMetaDescr, RegionVisualDescr)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -33,10 +34,10 @@ class CirclePixelRegion(PixelRegion):
         The center position.
     radius : float
         The radius in pixels.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
 
     Examples
@@ -63,6 +64,8 @@ class CirclePixelRegion(PixelRegion):
     _mpl_artist = 'Patch'
     center = ScalarPixCoord('The center pixel position as a |PixCoord|.')
     radius = PositiveScalar('The radius in pixels as a float.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, radius, meta=None, visual=None):
         self.center = center
@@ -190,16 +193,18 @@ class CircleSkyRegion(SkyRegion):
         The center position.
     radius : `~astropy.units.Quantity`
         The radius in angular units.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
     """
 
     _params = ('center', 'radius')
     center = ScalarSkyCoord('The center position as a |SkyCoord|.')
     radius = PositiveScalarAngle('The radius as a |Quantity| angle.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, radius, meta=None, visual=None):
         self.center = center

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -12,7 +12,8 @@ import numpy as np
 
 from ..core.attributes import (ScalarPixCoord, PositiveScalar,
                                PositiveScalarAngle, ScalarAngle,
-                               ScalarSkyCoord)
+                               ScalarSkyCoord, RegionMetaDescr,
+                               RegionVisualDescr)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -40,10 +41,10 @@ class EllipsePixelRegion(PixelRegion):
         The rotation angle of the ellipse, measured anti-clockwise. If
         set to zero (the default), the width axis is lined up with the x
         axis.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
 
     Examples
@@ -79,6 +80,8 @@ class EllipsePixelRegion(PixelRegion):
                             'pixels as a float.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
                         '|Quantity| angle.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, width, height, angle=0. * u.deg, meta=None,
                  visual=None):
@@ -179,7 +182,7 @@ class EllipsePixelRegion(PixelRegion):
 
     def as_artist(self, origin=(0, 0), **kwargs):
         """
-        Return a matplotlib patch object for this region
+        Return a matplotlib patch object for the region
         (`matplotlib.patches.Ellipse`).
 
         Parameters
@@ -343,10 +346,10 @@ class EllipseSkyRegion(SkyRegion):
         The rotation angle of the ellipse, measured anti-clockwise. If
         set to zero (the default), the width axis is lined up with the
         longitude axis of the celestial coordinates.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
     """
 
@@ -358,6 +361,8 @@ class EllipseSkyRegion(SkyRegion):
                                  'as a |Quantity| angle.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
                         '|Quantity| angle.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, width, height, angle=0. * u.deg, meta=None,
                  visual=None):

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -6,7 +6,8 @@ This module defines line regions in both pixel and sky coordinates.
 from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
-from ..core.attributes import ScalarPixCoord, ScalarSkyCoord
+from ..core.attributes import (ScalarPixCoord, ScalarSkyCoord,
+                               RegionMetaDescr, RegionVisualDescr)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual
@@ -25,10 +26,10 @@ class LinePixelRegion(PixelRegion):
         The start position.
     end : `~regions.PixCoord`
         The end position.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
 
     Examples
@@ -56,6 +57,8 @@ class LinePixelRegion(PixelRegion):
     _mpl_artist = 'Patch'
     start = ScalarPixCoord('The start pixel position as a |PixCoord|.')
     end = ScalarPixCoord('The end pixel position as a |PixCoord|.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, start, end, meta=None, visual=None):
         self.start = start
@@ -167,16 +170,18 @@ class LineSkyRegion(SkyRegion):
         The start position.
     end : `~astropy.coordinates.SkyCoord`
         The end position.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
     """
 
     _params = ('start', 'end')
     start = ScalarSkyCoord('The start position as a |SkyCoord|.')
     end = ScalarSkyCoord('The end position as a |SkyCoord|.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, start, end, meta=None, visual=None):
         self.start = start

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -6,7 +6,8 @@ This module defines point regions in both pixel and sky coordinates.
 from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
-from ..core.attributes import ScalarPixCoord, ScalarSkyCoord
+from ..core.attributes import (ScalarPixCoord, ScalarSkyCoord,
+                               RegionMetaDescr, RegionVisualDescr)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual
@@ -24,10 +25,10 @@ class PointPixelRegion(PixelRegion):
     ----------
     center : `~regions.PixCoord`
         The position of the point.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
 
     Examples
@@ -63,6 +64,8 @@ class PointPixelRegion(PixelRegion):
     _params = ('center',)
     _mpl_artist = 'Line2D'
     center = ScalarPixCoord('The point pixel position as a |PixCoord|.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, meta=None, visual=None):
         self.center = center
@@ -158,15 +161,17 @@ class PointSkyRegion(SkyRegion):
     ----------
     center : `~astropy.coordinates.SkyCoord`
         The position of the point.
-    meta : `regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
     """
 
     _params = ('center',)
     center = ScalarSkyCoord('The point position as a |SkyCoord|.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, meta=None, visual=None):
         self.center = center

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -8,7 +8,8 @@ from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import numpy as np
 
 from ..core.attributes import (OneDPixCoord, ScalarPixCoord, PositiveScalar,
-                               ScalarAngle, OneDSkyCoord)
+                               ScalarAngle, OneDSkyCoord, RegionMetaDescr,
+                               RegionVisualDescr)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -29,10 +30,10 @@ class PolygonPixelRegion(PixelRegion):
     ----------
     vertices : `~regions.PixCoord`
         The vertices of the polygon.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
     origin : `~regions.PixCoord`, optional
         The origin for polynomial vertices. Using this keyword allows
@@ -63,7 +64,10 @@ class PolygonPixelRegion(PixelRegion):
 
     _params = ('vertices',)
     _mpl_artist = 'Patch'
-    vertices = OneDPixCoord('The vertices of the polygon as a |PixCoord| array.')
+    vertices = OneDPixCoord('The vertices of the polygon as a |PixCoord| '
+                            'array.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, vertices, meta=None, visual=None,
                  origin=PixCoord(0, 0)):
@@ -223,10 +227,10 @@ class RegularPolygonPixelRegion(PolygonPixelRegion):
         The rotation angle of the polygon, measured anti-clockwise. If
         set to zero (the default), the polygon will point "up" following
         the `matplotlib.patches.RegularPolygon` convention.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
 
     Attributes
@@ -289,6 +293,8 @@ class RegularPolygonPixelRegion(PolygonPixelRegion):
                             'pixels as a float.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
                         '|Quantity| angle.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, nvertices, radius, angle=0. * u.deg,
                  meta=None, visual=None):
@@ -356,15 +362,18 @@ class PolygonSkyRegion(SkyRegion):
     ----------
     vertices : `~astropy.coordinates.SkyCoord`
         The vertices of the polygon.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
     """
 
     _params = ('vertices',)
-    vertices = OneDSkyCoord('The vertices of the polygon as a |SkyCoord| array.')
+    vertices = OneDSkyCoord('The vertices of the polygon as a |SkyCoord| '
+                            'array.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, vertices, meta=None, visual=None):
         self.vertices = vertices

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -10,7 +10,8 @@ import numpy as np
 
 from ..core.attributes import (ScalarPixCoord, PositiveScalar,
                                PositiveScalarAngle, ScalarAngle,
-                               ScalarSkyCoord)
+                               ScalarSkyCoord, RegionMetaDescr,
+                               RegionVisualDescr)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
@@ -40,10 +41,10 @@ class RectanglePixelRegion(PixelRegion):
         The rotation angle of the rectangle, measured anti-clockwise. If
         set to zero (the default), the width axis is lined up with the x
         axis.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
 
     Examples
@@ -77,6 +78,8 @@ class RectanglePixelRegion(PixelRegion):
                             'in pixels as a float.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
                         '|Quantity| angle.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, width, height, angle=0 * u.deg, meta=None,
                  visual=None):
@@ -219,7 +222,7 @@ class RectanglePixelRegion(PixelRegion):
     def as_mpl_selector(self, ax, active=True, sync=True, callback=None,
                         **kwargs):
         """
-        A matplotlib editable widget for this region
+        A matplotlib editable widget for the region
         (`matplotlib.widgets.RectangleSelector`).
 
         Parameters
@@ -383,10 +386,10 @@ class RectangleSkyRegion(SkyRegion):
         The rotation angle of the rectangle, measured anti-clockwise. If
         set to zero (the default), the width axis is lined up with the
         longitude axis of the celestial coordinates.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
     """
 
@@ -398,6 +401,8 @@ class RectangleSkyRegion(SkyRegion):
                                  'rotation) as a |Quantity| angle.')
     angle = ScalarAngle('The rotation angle measured anti-clockwise as a '
                         '|Quantity| angle.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, width, height, angle=0 * u.deg, meta=None,
                  visual=None):

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -12,6 +12,7 @@ import pytest
 
 from ...core.core import PixelRegion, Region, SkyRegion
 from ...core.mask import RegionMask
+from ...core.metadata import RegionMeta, RegionVisual
 from ...core.pixcoord import PixCoord
 from ..annulus import (CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
                        EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
@@ -177,3 +178,16 @@ def test_attribute_validation_sky_regions(region):
                 with pytest.raises(ValueError) as excinfo:
                     setattr(region, attr, val)
                 assert f'{attr!r} must' in str(excinfo.value)
+
+
+@pytest.mark.parametrize('region', PIXEL_REGIONS + SKY_REGIONS, ids=ids_func)
+def test_metadata(region):
+    region.meta = {'text': 'hello'}
+    region.visual = {'color': 'blue'}
+    assert isinstance(region.meta, RegionMeta)
+    assert isinstance(region.visual, RegionVisual)
+
+    with pytest.raises(ValueError):
+        region.meta = 1
+    with pytest.raises(ValueError):
+        region.visual = 'blue'

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -3,6 +3,7 @@
 The tests in this file simply check what functionality is currently
 implemented and doesn't check anything about correctness.
 """
+from collections import OrderedDict
 import itertools
 
 from astropy.coordinates import SkyCoord
@@ -184,6 +185,12 @@ def test_attribute_validation_sky_regions(region):
 def test_metadata(region):
     region.meta = {'text': 'hello'}
     region.visual = {'color': 'blue'}
+    assert isinstance(region.meta, RegionMeta)
+    assert isinstance(region.visual, RegionVisual)
+
+    # dict subclasses are allowed
+    region.meta = OrderedDict({'text': 'hello'})
+    region.visual = OrderedDict({'color': 'blue'})
     assert isinstance(region.meta, RegionMeta)
     assert isinstance(region.visual, RegionVisual)
 

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -6,7 +6,8 @@ This module defines text regions in both pixel and sky coordinates.
 from astropy.wcs.utils import pixel_to_skycoord
 
 from .point import PointPixelRegion, PointSkyRegion
-from ..core.attributes import ScalarPixCoord, ScalarSkyCoord
+from ..core.attributes import (ScalarPixCoord, ScalarSkyCoord,
+                               RegionMetaDescr, RegionVisualDescr)
 from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
 
 __all__ = ['TextSkyRegion', 'TextPixelRegion']
@@ -22,10 +23,10 @@ class TextPixelRegion(PointPixelRegion):
         The leftmost point of the text string before rotation.
     text : str
         The text string.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
 
     Examples
@@ -53,6 +54,8 @@ class TextPixelRegion(PointPixelRegion):
     _mpl_artist = 'Text'
     center = ScalarPixCoord('The leftmost pixel position (before rotation) '
                             'as a |PixCoord|.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, text, meta=None, visual=None):
         super().__init__(center, meta, visual)
@@ -113,16 +116,18 @@ class TextSkyRegion(PointSkyRegion):
         The leftmost position of the text string before rotation.
     text : str
         The text string.
-    meta : `~regions.RegionMeta`, optional
-        A dictionary that stores the meta attributes of this region.
-    visual : `~regions.RegionVisual`, optional
-        A dictionary that stores the visual meta attributes of this
+    meta : `~regions.RegionMeta` or `dict`, optional
+        A dictionary that stores the meta attributes of the region.
+    visual : `~regions.RegionVisual` or `dict`, optional
+        A dictionary that stores the visual meta attributes of the
         region.
     """
 
     _params = ('center', 'text')
     center = ScalarSkyCoord('The leftmost position (before rotation) as a '
                             '|SkyCoord|.')
+    meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
+    visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
 
     def __init__(self, center, text, meta=None, visual=None):
         super().__init__(center, meta, visual)


### PR DESCRIPTION
This PR allows region `meta` or `visual` values to be input as a `dict`, which is then converted by new descriptor classes to a `RegionMeta` or `RegionVisual` object.  The descriptor classes also add validation to ensure that `meta` and `visual` are either a `dict` or the appropriate object (e.g. `reg.visual = 'blue'` will now raise an error).

I consider this more as a new feature than a bug fix since the docs did not state that `dict` was previously an allowed input type.

Closes #461 