### PR TITLE
Remove PointSkyRegion.contains()

### DIFF
--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -178,13 +178,6 @@ class PointSkyRegion(SkyRegion):
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
 
-    def contains(self, skycoord, wcs):  # pylint: disable=unused-argument
-        if self.meta.get('include', True):
-            # points never include anything
-            return False
-        else:
-            return True
-
     def to_pixel(self, wcs):
         center_x, center_y = skycoord_to_pixel(self.center, wcs=wcs)
         center = PixCoord(center_x, center_y)

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -95,8 +95,8 @@ class TestPointSkyRegion(BaseTestSkyRegion):
     def test_contains(self, wcs):
         position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
         # points do not contain things
-        assert all(self.reg.contains(position, wcs)
-                   == np.array([False, False], dtype='bool'))
+        assert_allclose(self.reg.contains(position, wcs),
+                    np.array([False, False], dtype='bool'))
 
     def test_eq(self):
         reg = self.reg.copy()


### PR DESCRIPTION
This PR solves issue #465 removing the overloaded `contains` method.
The test is corrected to compare the arrays themselves.