### PR TITLE
Update Cython in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools",
             "setuptools_scm",
             "wheel",
-            "cython==0.29.22",
+            "cython==0.29.30",
             "oldest-supported-numpy",
             "extension-helpers"]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
Update Cython in pyproject.toml so it builds in Python 3.11 .

Sorry for not using fork. I am working on something else on the WSL2 terminal and it is much easier to open this PR from GitHub interface.