### PR TITLE
Use SPDX license expression in project metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = regions
 author = The Astropy Developers
 author_email = astropy.team@gmail.com
-license = BSD 3-Clause
+license = BSD-3-Clause
 license_file = LICENSE.rst
 url = https://github.com/astropy/regions
 github_project = astropy/regions


### PR DESCRIPTION
The emerging convention for licenses is the [SPDX License List](https://spdx.org/licenses/). 