### PR TITLE
Use unified WCS methods

### DIFF
--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -7,7 +7,6 @@ import abc
 import operator
 
 import astropy.units as u
-from astropy.wcs.utils import pixel_to_skycoord
 
 from ..core.attributes import (ScalarPixCoord, PositiveScalar,
                                PositiveScalarAngle, ScalarAngle,
@@ -151,7 +150,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
                                      self.meta, self.visual)
 
     def to_sky(self, wcs):
-        center = pixel_to_skycoord(self.center.x, self.center.y, wcs)
+        center = wcs.pixel_to_world(self.center.x, self.center.y)
         _, pixscale, _ = pixel_scale_angle_at_skycoord(center, wcs)
         inner_radius = self.inner_radius * u.pix * pixscale
         outer_radius = self.outer_radius * u.pix * pixscale
@@ -278,7 +277,7 @@ class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
                                      self.meta, self.visual)
 
     def to_sky_args(self, wcs):
-        center = pixel_to_skycoord(self.center.x, self.center.y, wcs)
+        center = wcs.pixel_to_world(self.center.x, self.center.y)
         _, pixscale, north_angle = pixel_scale_angle_at_skycoord(center, wcs)
         inner_width = (self.inner_width * u.pix * pixscale).to(u.arcsec)
         outer_width = (self.outer_width * u.pix * pixscale).to(u.arcsec)

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -7,7 +7,6 @@ import math
 
 from astropy.coordinates import Angle
 import astropy.units as u
-from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
 from ..core.attributes import (ScalarPixCoord, PositiveScalar,
@@ -87,7 +86,7 @@ class CirclePixelRegion(PixelRegion):
 
     def to_sky(self, wcs):
         # TODO: write a pixel_to_skycoord_scale_angle
-        center = pixel_to_skycoord(self.center.x, self.center.y, wcs)
+        center = wcs.pixel_to_world(self.center.x, self.center.y)
         _, pixscale, _ = pixel_scale_angle_at_skycoord(center, wcs)
         radius = Angle(self.radius * u.pix * pixscale, 'arcsec')
         return CircleSkyRegion(center, radius, meta=self.meta.copy(),

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -7,7 +7,6 @@ import math
 
 from astropy.coordinates import Angle
 import astropy.units as u
-from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
 from ..core.attributes import (ScalarPixCoord, PositiveScalar,
@@ -109,8 +108,7 @@ class EllipsePixelRegion(PixelRegion):
             return np.logical_not(in_ell)
 
     def to_sky(self, wcs):
-        # TODO: write a pixel_to_skycoord_scale_angle
-        center = pixel_to_skycoord(self.center.x, self.center.y, wcs)
+        center = wcs.pixel_to_world(self.center.x, self.center.y)
         _, pixscale, north_angle = pixel_scale_angle_at_skycoord(center, wcs)
         height = Angle(self.height * u.pix * pixscale, 'arcsec')
         width = Angle(self.width * u.pix * pixscale, 'arcsec')

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -3,7 +3,6 @@
 This module defines line regions in both pixel and sky coordinates.
 """
 
-from astropy.wcs.utils import skycoord_to_pixel
 import numpy as np
 
 from ..core.attributes import (ScalarPixCoord, ScalarSkyCoord,
@@ -197,9 +196,9 @@ class LineSkyRegion(SkyRegion):
             return True
 
     def to_pixel(self, wcs):
-        start_x, start_y = skycoord_to_pixel(self.start, wcs=wcs)
+        start_x, start_y = wcs.world_to_pixel(self.start)
         start = PixCoord(start_x, start_y)
-        end_x, end_y = skycoord_to_pixel(self.end, wcs=wcs)
+        end_x, end_y = wcs.world_to_pixel(self.end)
         end = PixCoord(end_x, end_y)
         return LinePixelRegion(start, end, meta=self.meta.copy(),
                                visual=self.visual.copy())

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -3,7 +3,7 @@
 This module defines line regions in both pixel and sky coordinates.
 """
 
-from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
+from astropy.wcs.utils import skycoord_to_pixel
 import numpy as np
 
 from ..core.attributes import (ScalarPixCoord, ScalarSkyCoord,
@@ -82,8 +82,8 @@ class LinePixelRegion(PixelRegion):
             return np.logical_not(in_reg)
 
     def to_sky(self, wcs):
-        start = pixel_to_skycoord(self.start.x, self.start.y, wcs)
-        end = pixel_to_skycoord(self.end.x, self.end.y, wcs)
+        start = wcs.pixel_to_world(self.start.x, self.start.y)
+        end = wcs.pixel_to_world(self.end.x, self.end.y)
         return LineSkyRegion(start, end, meta=self.meta.copy(),
                              visual=self.visual.copy())
 

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -3,7 +3,6 @@
 This module defines point regions in both pixel and sky coordinates.
 """
 
-from astropy.wcs.utils import skycoord_to_pixel
 import numpy as np
 
 from ..core.attributes import (ScalarPixCoord, ScalarSkyCoord,
@@ -186,7 +185,7 @@ class PointSkyRegion(SkyRegion):
             return True
 
     def to_pixel(self, wcs):
-        center_x, center_y = skycoord_to_pixel(self.center, wcs=wcs)
+        center_x, center_y = wcs.world_to_pixel(self.center)
         center = PixCoord(center_x, center_y)
         return PointPixelRegion(center, meta=self.meta.copy(),
                                 visual=self.visual.copy())

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -3,7 +3,7 @@
 This module defines point regions in both pixel and sky coordinates.
 """
 
-from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
+from astropy.wcs.utils import skycoord_to_pixel
 import numpy as np
 
 from ..core.attributes import (ScalarPixCoord, ScalarSkyCoord,
@@ -89,7 +89,7 @@ class PointPixelRegion(PixelRegion):
             return np.logical_not(in_reg)
 
     def to_sky(self, wcs):
-        center = pixel_to_skycoord(self.center.x, self.center.y, wcs=wcs)
+        center = wcs.pixel_to_world(self.center.x, self.center.y)
         return PointSkyRegion(center, meta=self.meta.copy(),
                               visual=self.visual.copy())
 

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -4,7 +4,7 @@ This module defines polygon regions in both pixel and sky coordinates.
 """
 
 import astropy.units as u
-from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
+from astropy.wcs.utils import skycoord_to_pixel
 import numpy as np
 
 from ..core.attributes import (OneDPixCoord, ScalarPixCoord, PositiveScalar,
@@ -107,7 +107,7 @@ class PolygonPixelRegion(PixelRegion):
             return np.logical_not(in_poly)
 
     def to_sky(self, wcs):
-        vertices_sky = pixel_to_skycoord(self.vertices.x, self.vertices.y, wcs)
+        vertices_sky = wcs.pixel_to_world(self.vertices.x, self.vertices.y)
         return PolygonSkyRegion(vertices=vertices_sky, meta=self.meta.copy(),
                                 visual=self.visual.copy())
 

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -4,7 +4,6 @@ This module defines polygon regions in both pixel and sky coordinates.
 """
 
 import astropy.units as u
-from astropy.wcs.utils import skycoord_to_pixel
 import numpy as np
 
 from ..core.attributes import (OneDPixCoord, ScalarPixCoord, PositiveScalar,
@@ -381,7 +380,7 @@ class PolygonSkyRegion(SkyRegion):
         self.visual = visual or RegionVisual()
 
     def to_pixel(self, wcs):
-        x, y = skycoord_to_pixel(self.vertices, wcs)
+        x, y = wcs.world_to_pixel(self.vertices)
         vertices_pix = PixCoord(x, y)
         return PolygonPixelRegion(vertices_pix, meta=self.meta.copy(),
                                   visual=self.visual.copy())

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -5,7 +5,6 @@ This module defines rectangular regions in both pixel and sky coordinates.
 
 from astropy.coordinates import Angle
 import astropy.units as u
-from astropy.wcs.utils import pixel_to_skycoord
 import numpy as np
 
 from ..core.attributes import (ScalarPixCoord, PositiveScalar,
@@ -109,7 +108,7 @@ class RectanglePixelRegion(PixelRegion):
             return np.logical_not(in_rect)
 
     def to_sky(self, wcs):
-        center = pixel_to_skycoord(self.center.x, self.center.y, wcs)
+        center = wcs.pixel_to_world(self.center.x, self.center.y)
         _, pixscale, north_angle = pixel_scale_angle_at_skycoord(center, wcs)
         width = Angle(self.width * u.pix * pixscale, 'arcsec')
         height = Angle(self.height * u.pix * pixscale, 'arcsec')

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -3,8 +3,6 @@
 This module defines text regions in both pixel and sky coordinates.
 """
 
-from astropy.wcs.utils import pixel_to_skycoord
-
 from .point import PointPixelRegion, PointSkyRegion
 from ..core.attributes import (ScalarPixCoord, ScalarSkyCoord,
                                RegionMetaDescr, RegionVisualDescr)
@@ -62,7 +60,7 @@ class TextPixelRegion(PointPixelRegion):
         self.text = text
 
     def to_sky(self, wcs):
-        center = pixel_to_skycoord(self.center.x, self.center.y, wcs=wcs)
+        center = wcs.pixel_to_world(self.center.x, self.center.y)
 
         # rotation value is relative to the coordinate system axes;
         # convert from counterclockwise angle from the positive x axis


### PR DESCRIPTION
This PR updated the code to use the Astropy unified WCS methods for converting between sky and pixel coords.