### PR TITLE
Implement CircleSectorPixRegion

### DIFF
--- a/docs/shapes.rst
+++ b/docs/shapes.rst
@@ -59,6 +59,21 @@ Circle
     ...                                       outer_radius=5.2)
 
 
+`~regions.CircleSectorPixelRegion`
+
+.. code-block:: python
+
+    >>> from astropy.coordinates import SkyCoord
+    >>> from astropy import units as u
+    >>> from regions import PixCoord
+    >>> from regions import CircleSectorPixelRegion
+
+    >>> region_pix = CircleAnnulusPixelRegion(center=PixCoord(x=42, y=43),
+    ...                                       radius=4.2,
+    ...                                       angle_start=0 * u.deg,
+    ...                                       angle_stop=120 * u.deg)
+
+
 Ellipse
 *******
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -285,11 +285,11 @@ class CircleSectorPixelRegion(PixelRegion):
     @property
     def theta(self):
         """Opening angle of the sector (`~astropy.coordinates.Angle`)"""
-        return Angle(self.angle_stop - self.angle_start).wrap_at("180d")
+        return self.angle_stop - self.angle_start
 
     @property
     def area(self):
-        return self.radius ** 2 * self.theta.rad / 2.
+        return self.radius ** 2 * self.theta.to_value("rad") / 2.
 
     def contains(self, pixcoord):
         pixcoord = PixCoord._validate(pixcoord, name='pixcoord')
@@ -297,9 +297,9 @@ class CircleSectorPixelRegion(PixelRegion):
 
         dx = pixcoord.x - self.center.x
         dy = pixcoord.y - self.center.y
-        angle = Angle(np.arctan2(dy, dx), "rad").wrap_at("0d")
+        angle = (Angle(np.arctan2(dy, dx), "rad") - self.angle_start).wrap_at("360d") 
 
-        in_angle = (angle > Angle(self.angle_start).wrap_at("0d")) & (angle < Angle(self.angle_stop).wrap_at("0d"))
+        in_angle = (angle > 0 * u.deg) & (angle < self.theta)
         in_sector = in_circle & in_angle
 
         if self.meta.get('include', True):
@@ -323,7 +323,7 @@ class CircleSectorPixelRegion(PixelRegion):
         y_stop = self.radius * np.sin(self.angle_stop)
 
         def wrap(angle):
-            return Angle(angle).wrap_at("0d")
+            return Angle(angle).wrap_at("360d")
 
         cross_0 = wrap(self.angle_start) > wrap(self.angle_stop)
         cross_90 = wrap(self.angle_start - 90 * u.deg) > wrap(self.angle_stop - 90 * u.deg)

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -285,7 +285,7 @@ class CircleSectorPixelRegion(PixelRegion):
     @property
     def theta(self):
         """Opening angle of the sector (`~astropy.coordinates.Angle`)"""
-        return self.angle_stop - self.angle_start
+        return Angle(self.angle_stop - self.angle_start).wrap_at("180d")
 
     @property
     def area(self):

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -13,7 +13,7 @@ import pytest
 from ...core import PixCoord, RegionMeta, RegionVisual
 from ...tests.helpers import make_simple_wcs
 from ..._utils.optional_deps import HAS_MATPLOTLIB  # noqa
-from ..circle import CirclePixelRegion, CircleSkyRegion
+from ..circle import CirclePixelRegion, CircleSkyRegion, CircleSectorPixelRegion
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 
 
@@ -139,3 +139,28 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
     def test_zero_size(self):
         with pytest.raises(ValueError):
             CircleSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg), 0. * u.arcsec)
+
+
+class TestCircleSectorPixelRegion(BaseTestPixelRegion):
+    meta = RegionMeta({'text': 'test'})
+    visual = RegionVisual({'color': 'blue'})
+    reg = CircleSectorPixelRegion(center=PixCoord(3, 4), radius=2, angle_start=30 * u.deg, angle_stop=120 * u.deg, meta=meta, visual=visual)
+    sample_box = [0, 6, 1, 7]
+    inside = [(3, 5)]
+    outside = [(2, 4)]
+    expected_area = np.pi
+    expected_repr = '<CircleSectorPixelRegion(center=PixCoord(x=3, y=4), radius=2, angle_start=30.0 deg, angle_stop=120.0 deg)>'
+    expected_str = ('Region: CircleSectorPixelRegion\n'
+                    'center: PixCoord(x=3, y=4)\n'
+                    'radius: 2\n'
+                    'angle_start: 30.0 deg\n'
+                    'angle_stop: 120.0 deg')
+
+
+    @pytest.mark.skipif('not HAS_MATPLOTLIB')
+    def test_as_artist(self):
+        patch = self.reg.as_artist()
+        assert_allclose(patch.center, (3, 4))
+        assert_allclose(patch.r, 2)
+        assert_allclose(patch.theta1, 30)
+        assert_allclose(patch.theta2, 120)


### PR DESCRIPTION
This PR is a draft to implement a `CircleSectorPixRegion`. I needed this for a specific analysis, so I decided to implement it. Here is a notebook to illustrate that the bounding box and contains methods work correctly for all quadrants https://github.com/adonath/notebooks-public/blob/master/circle_sector_pix_region_illustration.ipynb
