### PR TITLE
Remove unneeded doc templates

### DIFF
--- a/docs/_templates/autosummary/base.rst
+++ b/docs/_templates/autosummary/base.rst
@@ -1,2 +1,0 @@
-{% extends "autosummary_core/base.rst" %}
-{# The template this is inherited from is in astropy/sphinx/ext/templates/autosummary_core. If you want to modify this template, it is strongly recommended that you still inherit from the astropy template. #}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,2 +1,0 @@
-{% extends "autosummary_core/class.rst" %}
-{# The template this is inherited from is in astropy/sphinx/ext/templates/autosummary_core. If you want to modify this template, it is strongly recommended that you still inherit from the astropy template. #}

--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -1,2 +1,0 @@
-{% extends "autosummary_core/module.rst" %}
-{# The template this is inherited from is in astropy/sphinx/ext/templates/autosummary_core. If you want to modify this template, it is strongly recommended that you still inherit from the astropy template. #}

--- a/docs/shapes.rst
+++ b/docs/shapes.rst
@@ -1,6 +1,6 @@
 .. include:: references.txt
 
-.. testsetup:
+.. testsetup::
     >>> from regions import make_example_dataset
     >>> dataset = make_example_dataset(data='simulated')
     >>> wcs = dataset.wcs


### PR DESCRIPTION
This PR removes some old documentation template files that are not used/no longer needed.

This PR also fixes a missing colon in an rst directive.