### PR TITLE
MNT: Misc formatting/style updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,86 @@
+ci:
+  autofix_prs: false
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-added-large-files
+        # Prevent giant files from being committed.
+      - id: check-ast
+        # Simply check whether files parse as valid python.
+      - id: check-case-conflict
+        # Check for files with names that would conflict on a case-insensitive
+        # filesystem like MacOS HFS+ or Windows FAT.
+      - id: check-json
+        # Attempts to load all json files to verify syntax.
+      - id: check-merge-conflict
+        # Check for files that contain merge conflict strings.
+      - id: check-symlinks
+        # Checks for symlinks which do not point to anything.
+      - id: check-toml
+        # Attempts to load all TOML files to verify syntax.
+      - id: check-xml
+        # Attempts to load all xml files to verify syntax.
+      - id: check-yaml
+        # Attempts to load all yaml files to verify syntax.
+      - id: debug-statements
+        # Check for debugger imports and py37+ breakpoint() calls in python
+        # source.
+      - id: detect-private-key
+        # Checks for the existence of private keys.
+      - id: end-of-file-fixer
+        # Makes sure files end in a newline and only a newline.
+        exclude: ".*(svg.*|extern.*|pkl.*|reg.*)$"
+      - id: trailing-whitespace
+        # Trims trailing whitespace.
+        exclude: ".*(data.*|extern.*)$"
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+      - id: python-check-mock-methods
+        # Prevent common mistakes of assert mck.not_called(), assert
+        # mck.called_once_with(...) and mck.assert_called.
+      - id: rst-directive-colons
+        # Detect mistake of rst directive not ending with double colon.
+      - id: rst-inline-touching-normal
+        # Detect mistake of inline code touching normal text in rst.
+      - id: text-unicode-replacement-char
+        # Forbid files which have a UTF-8 Unicode replacement character.
+      - id: python-check-blanket-noqa
+        # Enforce that all noqa annotations always occur with specific codes.
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+      - id: pyupgrade
+        args: ["--py38-plus"]
+        exclude: ".*(extern.*)$"
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.11.1
+    hooks:
+      - id: isort
+        name: isort (python)
+        additional_dependencies: [toml]
+      - id: isort
+        name: isort (cython)
+        types: [cython]
+        additional_dependencies: [toml]
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        args: ["--ignore", "E501,W503"]
+
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.4.0
+    hooks:
+      - id: yesqa
+
+  # - repo: https://github.com/MarcoGorelli/absolufy-imports
+  #   rev: v0.3.1
+  #   hooks:
+  #   - id: absolufy-imports

--- a/dev/regions_parse.py
+++ b/dev/regions_parse.py
@@ -2,9 +2,10 @@
 
 from pathlib import Path
 
-from astropy import log
 import click
 import pyregion
+from astropy import log
+
 from regions import read_ds9
 
 log.setLevel('DEBUG')

--- a/dev/regions_pyregion_comparison.py
+++ b/dev/regions_pyregion_comparison.py
@@ -14,14 +14,15 @@ The test files are the ones used since PyAstro16 (see
 https://zenodo.org/record/56793).
 """
 
-from pathlib import Path
 import re
 import timeit
+from pathlib import Path
 
-from astropy.table import Table
 import numpy as np
 import pyregion
-from regions import read_ds9, DS9RegionParserError
+from astropy.table import Table
+
+from regions import DS9RegionParserError, read_ds9
 
 TEST_FILE_DIR = Path('../regions/io/ds9/tests/data')
 REPETITIONS = 1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,10 +12,10 @@
 # the global Astropy configuration which is loaded here before anything
 # else. See astropy.sphinx.conf for which values are set there.
 
-from configparser import ConfigParser
-from datetime import datetime
 import os
 import sys
+from configparser import ConfigParser
+from datetime import datetime
 
 try:
     from sphinx_astropy.conf.v1 import *  # noqa

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ from configparser import ConfigParser
 from datetime import datetime
 
 try:
-    from sphinx_astropy.conf.v1 import *  # noqa
+    from sphinx_astropy.conf.v1 import *  # noqa: F403
 except ImportError:
     print('ERROR: the documentation requires the sphinx-astropy package to '
           'be installed')
@@ -38,16 +38,16 @@ highlight_language = 'python3'
 needs_sphinx = '1.7'
 
 # Extend astropy intersphinx_mapping with packages we use here
-intersphinx_mapping['photutils'] = ('https://photutils.readthedocs.io/en/stable/', None)  # noqa
-#intersphinx_mapping['shapely'] = ('https://shapely.readthedocs.io/en/stable/', None)  # noqa
+intersphinx_mapping['photutils'] = ('https://photutils.readthedocs.io/en/stable/', None)  # noqa: F405
+#intersphinx_mapping['shapely'] = ('https://shapely.readthedocs.io/en/stable/', None)
 
 # Exclude astropy intersphinx_mapping for unused packages
-del intersphinx_mapping['scipy']  # noqa
-del intersphinx_mapping['h5py']  # noqa
+del intersphinx_mapping['scipy']  # noqa: F405
+del intersphinx_mapping['h5py']  # noqa: F405
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns.append('_templates')  # noqa
+exclude_patterns.append('_templates')  # noqa: F405
 
 plot_formats = ['png', 'hires.png', 'pdf', 'svg']
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ from datetime import datetime
 
 try:
     from sphinx_astropy.conf.v1 import *  # noqa: F403
+    from sphinx_astropy.conf.v1 import rst_epilog  # noqa: E402
 except ImportError:
     print('ERROR: the documentation requires the sphinx-astropy package to '
           'be installed')
@@ -39,7 +40,7 @@ needs_sphinx = '1.7'
 
 # Extend astropy intersphinx_mapping with packages we use here
 intersphinx_mapping['photutils'] = ('https://photutils.readthedocs.io/en/stable/', None)  # noqa: F405
-#intersphinx_mapping['shapely'] = ('https://shapely.readthedocs.io/en/stable/', None)
+# intersphinx_mapping['shapely'] = ('https://shapely.readthedocs.io/en/stable/', None)
 
 # Exclude astropy intersphinx_mapping for unused packages
 del intersphinx_mapping['scipy']  # noqa: F405

--- a/docs/plot_compound.py
+++ b/docs/plot_compound.py
@@ -2,10 +2,10 @@
 """
 Example script illustrating compound regions.
 """
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+from astropy.coordinates import Angle, SkyCoord
 
-from astropy.coordinates import SkyCoord, Angle
 from regions import CircleSkyRegion, make_example_dataset
 
 # load example dataset to get skymap

--- a/docs/plot_reg.py
+++ b/docs/plot_reg.py
@@ -1,11 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.utils.data import get_pkg_data_filename
 from astropy.io import fits
+from astropy.utils.data import get_pkg_data_filename
 from matplotlib import pyplot as plt
 
 from regions import Regions
-
 
 image_file = get_pkg_data_filename('tutorials/FITS-images/HorseHead.fits')
 image_data = fits.getdata(image_file, ext=0, memmap=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,8 @@ requires = ['setuptools',
             'oldest-supported-numpy',
             'extension-helpers']
 build-backend = 'setuptools.build_meta'
+
+[tool.isort]
+    skip_glob = ['regions/*__init__.py*']
+    known_first_party = ['regions']
+    use_parentheses = true

--- a/regions/__init__.py
+++ b/regions/__init__.py
@@ -6,12 +6,12 @@ handling.
 
 # Affiliated packages may add whatever they like to this file, but
 # should keep this content at the top.
-from ._astropy_init import *  # noqa
+from ._astropy_init import *  # noqa: F401, F403
 
-from ._utils.examples import *  # noqa
-from .core import *  # noqa
-from .io import *  # noqa
-from .shapes import *  # noqa
+from ._utils.examples import *  # noqa: F401, F403
+from .core import *  # noqa: F401, F403
+from .io import *  # noqa: F401, F403
+from .shapes import *  # noqa: F401, F403
 
 
 # Set the bibtex entry to the article referenced in CITATION.rst.

--- a/regions/__init__.py
+++ b/regions/__init__.py
@@ -29,4 +29,4 @@ def _get_bibtex():
 
 __citation__ = __bibtex__ = _get_bibtex()
 
-del _get_bibtex  # noqa
+del _get_bibtex

--- a/regions/__init__.py
+++ b/regions/__init__.py
@@ -6,14 +6,12 @@ handling.
 
 # Affiliated packages may add whatever they like to this file, but
 # should keep this content at the top.
-# ----------------------------------------------------------------------------
 from ._astropy_init import *  # noqa
-# ----------------------------------------------------------------------------
 
+from ._utils.examples import *  # noqa
 from .core import *  # noqa
 from .io import *  # noqa
 from .shapes import *  # noqa
-from ._utils.examples import *  # noqa
 
 
 # Set the bibtex entry to the article referenced in CITATION.rst.

--- a/regions/_astropy_init.py
+++ b/regions/_astropy_init.py
@@ -10,4 +10,5 @@ except ImportError:
 
 # Create the test function for self test
 from astropy.tests.runner import TestRunner
+
 test = TestRunner.make_test_runner_in(os.path.dirname(__file__))

--- a/regions/_geometry/__init__.py
+++ b/regions/_geometry/__init__.py
@@ -5,5 +5,5 @@ Geometry subpackage for low-level geometry functions.
 
 from .circular_overlap import *  # noqa
 from .elliptical_overlap import *  # noqa
-from .rectangular_overlap import *  # noqa
 from .polygonal_overlap import *  # noqa
+from .rectangular_overlap import *  # noqa

--- a/regions/_geometry/__init__.py
+++ b/regions/_geometry/__init__.py
@@ -3,7 +3,7 @@
 Geometry subpackage for low-level geometry functions.
 """
 
-from .circular_overlap import *  # noqa
-from .elliptical_overlap import *  # noqa
-from .polygonal_overlap import *  # noqa
-from .rectangular_overlap import *  # noqa
+from .circular_overlap import *  # noqa: F401, F403
+from .elliptical_overlap import *  # noqa: F401, F403
+from .polygonal_overlap import *  # noqa: F401, F403
+from .rectangular_overlap import *  # noqa: F401, F403

--- a/regions/_geometry/core.pyx
+++ b/regions/_geometry/core.pyx
@@ -5,6 +5,7 @@ The functions here are the core geometry functions.
 """
 
 import numpy as np
+
 cimport numpy as np
 
 
@@ -22,7 +23,6 @@ DTYPE = np.float64
 ctypedef np.float64_t DTYPE_t
 
 cimport cython
-
 
 ctypedef struct point:
     double x

--- a/regions/_geometry/elliptical_overlap.pyx
+++ b/regions/_geometry/elliptical_overlap.pyx
@@ -9,6 +9,7 @@ intersection of a triangle with a unit circle.
 """
 
 import numpy as np
+
 cimport numpy as np
 
 __all__ = ['elliptical_overlap_grid']
@@ -31,7 +32,7 @@ cimport cython
 # NOTE: Here we need to make sure we use cimport to import the C functions from
 # core (since these were defined with cdef). This also requires the core.pxd
 # file to exist with the function signatures.
-from .core cimport distance, area_triangle, overlap_area_triangle_unit_circle
+from .core cimport area_triangle, distance, overlap_area_triangle_unit_circle
 
 
 def elliptical_overlap_grid(double xmin, double xmax, double ymin, double ymax,

--- a/regions/_geometry/tests/test_circular_overlap_grid.py
+++ b/regions/_geometry/tests/test_circular_overlap_grid.py
@@ -8,7 +8,7 @@ import itertools
 import pytest
 from numpy.testing import assert_allclose
 
-from .. import circular_overlap_grid
+from regions._geometry import circular_overlap_grid
 
 grid_sizes = [50, 500, 1000]
 circ_sizes = [0.2, 0.4, 0.8]

--- a/regions/_geometry/tests/test_circular_overlap_grid.py
+++ b/regions/_geometry/tests/test_circular_overlap_grid.py
@@ -5,11 +5,10 @@ Tests for the circular_overlap_grid module.
 
 import itertools
 
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
 from .. import circular_overlap_grid
-
 
 grid_sizes = [50, 500, 1000]
 circ_sizes = [0.2, 0.4, 0.8]

--- a/regions/_geometry/tests/test_elliptical_overlap_grid.py
+++ b/regions/_geometry/tests/test_elliptical_overlap_grid.py
@@ -5,11 +5,10 @@ Tests for the elliptical_overlap_grid module.
 
 import itertools
 
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
 from .. import elliptical_overlap_grid
-
 
 grid_sizes = [50, 500, 1000]
 maj_sizes = [0.2, 0.4, 0.8]

--- a/regions/_geometry/tests/test_elliptical_overlap_grid.py
+++ b/regions/_geometry/tests/test_elliptical_overlap_grid.py
@@ -8,7 +8,7 @@ import itertools
 import pytest
 from numpy.testing import assert_allclose
 
-from .. import elliptical_overlap_grid
+from regions._geometry import elliptical_overlap_grid
 
 grid_sizes = [50, 500, 1000]
 maj_sizes = [0.2, 0.4, 0.8]

--- a/regions/_geometry/tests/test_rectangular_overlap_grid.py
+++ b/regions/_geometry/tests/test_rectangular_overlap_grid.py
@@ -8,7 +8,7 @@ import itertools
 import pytest
 from numpy.testing import assert_allclose
 
-from .. import rectangular_overlap_grid
+from regions._geometry import rectangular_overlap_grid
 
 grid_sizes = [50, 500, 1000]
 rect_sizes = [0.2, 0.4, 0.8]

--- a/regions/_geometry/tests/test_rectangular_overlap_grid.py
+++ b/regions/_geometry/tests/test_rectangular_overlap_grid.py
@@ -5,11 +5,10 @@ Tests for the rectangular_overlap_grid module.
 
 import itertools
 
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
 from .. import rectangular_overlap_grid
-
 
 grid_sizes = [50, 500, 1000]
 rect_sizes = [0.2, 0.4, 0.8]

--- a/regions/_utils/__init__.py
+++ b/regions/_utils/__init__.py
@@ -3,4 +3,4 @@
 This subpackage provides general-purpose utility functions.
 """
 
-from .wcs_helpers import *  # noqa
+from .wcs_helpers import *  # noqa: F401, F403

--- a/regions/_utils/examples.py
+++ b/regions/_utils/examples.py
@@ -8,7 +8,7 @@ from astropy.table import vstack as table_vstack
 from astropy.utils import lazyproperty
 from astropy.wcs import WCS
 
-from ..core.pixcoord import PixCoord
+from regions.core.pixcoord import PixCoord
 
 __all__ = ['make_example_dataset']
 

--- a/regions/_utils/examples.py
+++ b/regions/_utils/examples.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.table import Table
 from astropy.table import vstack as table_vstack
 from astropy.utils import lazyproperty
 from astropy.wcs import WCS
-import numpy as np
 
 from ..core.pixcoord import PixCoord
 

--- a/regions/_utils/optional_deps.py
+++ b/regions/_utils/optional_deps.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 try:
-    import matplotlib  # noqa
+    import matplotlib
     HAS_MATPLOTLIB = True
     MPL_VERSION = getattr(matplotlib, '__version__', None)
     if MPL_VERSION is None:

--- a/regions/_utils/tests/test_examples.py
+++ b/regions/_utils/tests/test_examples.py
@@ -3,7 +3,7 @@
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ..examples import make_example_dataset
+from regions._utils.examples import make_example_dataset
 
 
 class TestExampleSimulatedDataset:

--- a/regions/_utils/wcs_helpers.py
+++ b/regions/_utils/wcs_helpers.py
@@ -7,7 +7,7 @@ This module provides WCS helper tools.
 import astropy.units as u
 import numpy as np
 
-from ..core.pixcoord import PixCoord
+from regions.core.pixcoord import PixCoord
 
 
 def pixel_scale_angle_at_skycoord(skycoord, wcs, offset=1 * u.arcsec):

--- a/regions/core/__init__.py
+++ b/regions/core/__init__.py
@@ -3,11 +3,11 @@
 This subpackage provides the core functionality for regions.
 """
 
-from .attributes import *  # noqa
-from .bounding_box import *  # noqa
-from .compound import *  # noqa
-from .core import *  # noqa
-from .mask import *  # noqa
-from .metadata import *  # noqa
-from .pixcoord import *  # noqa
-from .regions import *  # noqa
+from .attributes import *  # noqa: F401, F403
+from .bounding_box import *  # noqa: F401, F403
+from .compound import *  # noqa: F401, F403
+from .core import *  # noqa: F401, F403
+from .mask import *  # noqa: F401, F403
+from .metadata import *  # noqa: F401, F403
+from .pixcoord import *  # noqa: F401, F403
+from .regions import *  # noqa: F401, F403

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -6,12 +6,12 @@ validation of region classes.
 
 import abc
 
+import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.units import Quantity
-import numpy as np
 
-from .pixcoord import PixCoord
 from .metadata import RegionMeta, RegionVisual
+from .pixcoord import PixCoord
 
 __all__ = []
 

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -175,6 +175,7 @@ class RegionMetaDescr(RegionAttribute):
     If input as a pure `dict`, it will be converted to a `RegionMeta`
     object.
     """
+
     def __set__(self, instance, value):
         # RegionMeta subclasses dict
         if isinstance(value, dict) and not isinstance(value, RegionMeta):

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -10,8 +10,8 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.units import Quantity
 
-from .metadata import RegionMeta, RegionVisual
-from .pixcoord import PixCoord
+from regions.core.metadata import RegionMeta, RegionVisual
+from regions.core.pixcoord import PixCoord
 
 __all__ = []
 

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -264,8 +264,8 @@ class RegionBoundingBox:
         Return a `~regions.RectanglePixelRegion` that
         represents the bounding box.
         """
-        from ..shapes import RectanglePixelRegion
-        from .pixcoord import PixCoord
+        from regions.core.pixcoord import PixCoord
+        from regions.shapes import RectanglePixelRegion
 
         xypos = PixCoord(*self.center[::-1])
         height, width = self.shape

--- a/regions/core/bounding_box.py
+++ b/regions/core/bounding_box.py
@@ -3,8 +3,8 @@
 This module defines a class for a rectangular bounding box.
 """
 
-from astropy.io.fits.util import _is_int
 import numpy as np
+from astropy.io.fits.util import _is_int
 
 __all__ = ['RegionBoundingBox']
 

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -3,10 +3,10 @@ import operator as op
 
 import numpy as np
 
-from .attributes import RegionType
-from .core import PixelRegion, SkyRegion
-from .mask import RegionMask
-from .metadata import RegionMeta, RegionVisual
+from regions.core.attributes import RegionType
+from regions.core.core import PixelRegion, SkyRegion
+from regions.core.mask import RegionMask
+from regions.core.metadata import RegionMeta, RegionVisual
 
 __all__ = ['CompoundPixelRegion', 'CompoundSkyRegion']
 

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -5,9 +5,9 @@ import operator
 
 import numpy as np
 
-from .metadata import RegionMeta, RegionVisual
-from .pixcoord import PixCoord
-from .registry import RegionsRegistry
+from regions.core.metadata import RegionMeta, RegionVisual
+from regions.core.pixcoord import PixCoord
+from regions.core.registry import RegionsRegistry
 
 __all__ = ['Region', 'PixelRegion', 'SkyRegion']
 __doctest_skip__ = ['Region.serialize', 'Region.write']
@@ -219,7 +219,7 @@ class PixelRegion(Region):
         Return a region representing the intersection of this region
         with ``other``.
         """
-        from .compound import CompoundPixelRegion
+        from regions.core.compound import CompoundPixelRegion
         return CompoundPixelRegion(region1=self, region2=other,
                                    operator=operator.and_)
 
@@ -228,7 +228,7 @@ class PixelRegion(Region):
         Return the union of the two regions minus any areas contained in
         the intersection of the two regions.
         """
-        from .compound import CompoundPixelRegion
+        from regions.core.compound import CompoundPixelRegion
         return CompoundPixelRegion(region1=self, region2=other,
                                    operator=operator.xor)
 
@@ -237,7 +237,7 @@ class PixelRegion(Region):
         Return a region representing the union of this region with
         ``other``.
         """
-        from .compound import CompoundPixelRegion
+        from regions.core.compound import CompoundPixelRegion
         return CompoundPixelRegion(region1=self, region2=other,
                                    operator=operator.or_)
 
@@ -419,7 +419,7 @@ class SkyRegion(Region):
         Return a region representing the intersection of this region
         with ``other``.
         """
-        from .compound import CompoundSkyRegion
+        from regions.core.compound import CompoundSkyRegion
         return CompoundSkyRegion(region1=self, region2=other,
                                  operator=operator.and_)
 
@@ -428,7 +428,7 @@ class SkyRegion(Region):
         Return the union of the two regions minus any areas contained in
         the intersection of the two regions.
         """
-        from .compound import CompoundSkyRegion
+        from regions.core.compound import CompoundSkyRegion
         return CompoundSkyRegion(region1=self, region2=other,
                                  operator=operator.xor)
 
@@ -437,7 +437,7 @@ class SkyRegion(Region):
         Return a region representing the union of this region with
         ``other``.
         """
-        from .compound import CompoundSkyRegion
+        from regions.core.compound import CompoundSkyRegion
         return CompoundSkyRegion(region1=self, region2=other,
                                  operator=operator.or_)
 

--- a/regions/core/metadata.py
+++ b/regions/core/metadata.py
@@ -133,7 +133,7 @@ class RegionVisual(Meta):
                 kwargs['ha'] = 'center'  # text horizontal alignment
                 kwargs['va'] = 'center'  # text vertical alignment
             elif artist == 'Line2D':
-                from ..io.ds9.core import ds9_valid_symbols
+                from regions.io.ds9.core import ds9_valid_symbols
 
                 kwargs['marker'] = ds9_valid_symbols['boxcircle']
                 kwargs['markersize'] = 11

--- a/regions/core/pixcoord.py
+++ b/regions/core/pixcoord.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import copy
 
-from astropy.coordinates import SkyCoord
 import numpy as np
+from astropy.coordinates import SkyCoord
 
 __all__ = ['PixCoord']
 

--- a/regions/core/regions.py
+++ b/regions/core/regions.py
@@ -3,8 +3,8 @@
 This module provides a Regions class.
 """
 
-from .core import Region
-from .registry import RegionsRegistry
+from regions.core.core import Region
+from regions.core.registry import RegionsRegistry
 
 __all__ = ['Regions']
 __doctest_skip__ = ['Regions.read', 'Regions.write', 'Regions.parse',

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -6,10 +6,10 @@ Tests for the bounding_box module.
 import pytest
 from numpy.testing import assert_allclose
 
-from ..._utils.optional_deps import HAS_MATPLOTLIB
-from ...shapes import RectanglePixelRegion
-from ..bounding_box import RegionBoundingBox
-from ..pixcoord import PixCoord
+from regions._utils.optional_deps import HAS_MATPLOTLIB
+from regions.core.bounding_box import RegionBoundingBox
+from regions.core.pixcoord import PixCoord
+from regions.shapes import RectanglePixelRegion
 
 
 def test_bounding_box_init():

--- a/regions/core/tests/test_bounding_box.py
+++ b/regions/core/tests/test_bounding_box.py
@@ -3,13 +3,13 @@
 Tests for the bounding_box module.
 """
 
-from numpy.testing import assert_allclose
 import pytest
+from numpy.testing import assert_allclose
 
+from ..._utils.optional_deps import HAS_MATPLOTLIB
+from ...shapes import RectanglePixelRegion
 from ..bounding_box import RegionBoundingBox
 from ..pixcoord import PixCoord
-from ...shapes import RectanglePixelRegion
-from ..._utils.optional_deps import HAS_MATPLOTLIB
 
 
 def test_bounding_box_init():

--- a/regions/core/tests/test_compound.py
+++ b/regions/core/tests/test_compound.py
@@ -4,15 +4,15 @@ Tests for the compound module.
 """
 
 import operator
-import pytest
-import numpy as np
-from numpy.testing import assert_allclose
 
 import astropy.units as u
+import numpy as np
+import pytest
 from astropy.coordinates import SkyCoord
+from numpy.testing import assert_allclose
 
-from ...shapes import CircleSkyRegion, CirclePixelRegion
-from ...core import PixCoord, RegionBoundingBox, CompoundPixelRegion
+from ...core import CompoundPixelRegion, PixCoord, RegionBoundingBox
+from ...shapes import CirclePixelRegion, CircleSkyRegion
 from ...tests.helpers import make_simple_wcs
 
 

--- a/regions/core/tests/test_compound.py
+++ b/regions/core/tests/test_compound.py
@@ -11,9 +11,9 @@ import pytest
 from astropy.coordinates import SkyCoord
 from numpy.testing import assert_allclose
 
-from ...core import CompoundPixelRegion, PixCoord, RegionBoundingBox
-from ...shapes import CirclePixelRegion, CircleSkyRegion
-from ...tests.helpers import make_simple_wcs
+from regions.core import CompoundPixelRegion, PixCoord, RegionBoundingBox
+from regions.shapes import CirclePixelRegion, CircleSkyRegion
+from regions.tests.helpers import make_simple_wcs
 
 
 class TestCompoundPixel:

--- a/regions/core/tests/test_mask.py
+++ b/regions/core/tests/test_mask.py
@@ -8,10 +8,10 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_almost_equal
 
-from ...shapes import CircleAnnulusPixelRegion, CirclePixelRegion
-from ..bounding_box import RegionBoundingBox
-from ..mask import RegionMask
-from ..pixcoord import PixCoord
+from regions.core.bounding_box import RegionBoundingBox
+from regions.core.mask import RegionMask
+from regions.core.pixcoord import PixCoord
+from regions.shapes import CircleAnnulusPixelRegion, CirclePixelRegion
 
 POSITIONS = [(-20, -20), (-20, 20), (20, -20), (60, 60)]
 

--- a/regions/core/tests/test_mask.py
+++ b/regions/core/tests/test_mask.py
@@ -5,13 +5,13 @@ Tests for the mask module.
 
 import astropy.units as u
 import numpy as np
-from numpy.testing import assert_allclose, assert_almost_equal
 import pytest
+from numpy.testing import assert_allclose, assert_almost_equal
 
+from ...shapes import CircleAnnulusPixelRegion, CirclePixelRegion
 from ..bounding_box import RegionBoundingBox
 from ..mask import RegionMask
 from ..pixcoord import PixCoord
-from ...shapes import CirclePixelRegion, CircleAnnulusPixelRegion
 
 POSITIONS = [(-20, -20), (-20, 20), (20, -20), (60, 60)]
 

--- a/regions/core/tests/test_metadata.py
+++ b/regions/core/tests/test_metadata.py
@@ -4,7 +4,7 @@ Tests for the metadata module.
 """
 import pytest
 
-from ..metadata import RegionMeta, RegionVisual
+from regions.core.metadata import RegionMeta, RegionVisual
 
 
 def test_region_meta():

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -8,8 +8,8 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
 
-from ..._utils.examples import make_example_dataset
-from ..pixcoord import PixCoord
+from regions._utils.examples import make_example_dataset
+from regions.core.pixcoord import PixCoord
 
 
 @pytest.fixture(scope='session', name='wcs')

--- a/regions/core/tests/test_pixcoord.py
+++ b/regions/core/tests/test_pixcoord.py
@@ -5,8 +5,8 @@ Tests for the pixcoord module.
 
 import astropy.units as u
 import numpy as np
-from numpy.testing import assert_equal, assert_allclose
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 
 from ..._utils.examples import make_example_dataset
 from ..pixcoord import PixCoord

--- a/regions/io/__init__.py
+++ b/regions/io/__init__.py
@@ -2,15 +2,16 @@
 """
 This subpackage provides tools for reading and writing region files.
 """
-from .crtf.connect import *  # noqa
-from .crtf.core import *  # noqa
-from .crtf.read import *  # noqa
-from .crtf.write import *  # noqa
-from .ds9.connect import *  # noqa
-from .ds9.core import *  # noqa
-from .ds9.read import *  # noqa
-from .ds9.write import *  # noqa
-from .fits.connect import *  # noqa
-from .fits.core import *  # noqa
-from .fits.read import *  # noqa
-from .fits.write import *  # noqa
+
+from .crtf.connect import *  # noqa: F401, F403
+from .crtf.core import *  # noqa: F401, F403
+from .crtf.read import *  # noqa: F401, F403
+from .crtf.write import *  # noqa: F401, F403
+from .ds9.connect import *  # noqa: F401, F403
+from .ds9.core import *  # noqa: F401, F403
+from .ds9.read import *  # noqa: F401, F403
+from .ds9.write import *  # noqa: F401, F403
+from .fits.connect import *  # noqa: F401, F403
+from .fits.core import *  # noqa: F401, F403
+from .fits.read import *  # noqa: F401, F403
+from .fits.write import *  # noqa: F401, F403

--- a/regions/io/__init__.py
+++ b/regions/io/__init__.py
@@ -2,16 +2,14 @@
 """
 This subpackage provides tools for reading and writing region files.
 """
-from .ds9.connect import *  # noqa
-from .ds9.core import *  # noqa
-from .ds9.read import *  # noqa
-from .ds9.write import *  # noqa
-
 from .crtf.connect import *  # noqa
 from .crtf.core import *  # noqa
 from .crtf.read import *  # noqa
 from .crtf.write import *  # noqa
-
+from .ds9.connect import *  # noqa
+from .ds9.core import *  # noqa
+from .ds9.read import *  # noqa
+from .ds9.write import *  # noqa
 from .fits.connect import *  # noqa
 from .fits.core import *  # noqa
 from .fits.read import *  # noqa

--- a/regions/io/crtf/connect.py
+++ b/regions/io/crtf/connect.py
@@ -2,8 +2,8 @@
 
 from astropy.utils.data import get_readable_fileobj
 
-from ...core import Region, Regions
-from ...core.registry import RegionsRegistry
+from regions.core import Region, Regions
+from regions.core.registry import RegionsRegistry
 
 __all__ = []
 

--- a/regions/io/crtf/io_core.py
+++ b/regions/io/crtf/io_core.py
@@ -8,19 +8,19 @@ from astropy.coordinates import (Angle, SkyCoord, UnitSphericalRepresentation,
                                  frame_transform_graph)
 from astropy.utils.exceptions import AstropyUserWarning
 
-from ...core.core import PixCoord, SkyRegion
-from ...core.metadata import RegionMeta, RegionVisual
-from ...shapes import (CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
-                       CirclePixelRegion, CircleSkyRegion,
-                       EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
-                       EllipsePixelRegion, EllipseSkyRegion, LinePixelRegion,
-                       LineSkyRegion, PointPixelRegion, PointSkyRegion,
-                       PolygonPixelRegion, PolygonSkyRegion,
-                       RectangleAnnulusPixelRegion, RectangleAnnulusSkyRegion,
-                       RectanglePixelRegion, RectangleSkyRegion,
-                       RegularPolygonPixelRegion, TextPixelRegion,
-                       TextSkyRegion)
-from ..crtf.core import CRTFRegionParserWarning
+from regions.core.core import PixCoord, SkyRegion
+from regions.core.metadata import RegionMeta, RegionVisual
+from regions.io.crtf.core import CRTFRegionParserWarning
+from regions.shapes import (CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
+                            CirclePixelRegion, CircleSkyRegion,
+                            EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
+                            EllipsePixelRegion, EllipseSkyRegion,
+                            LinePixelRegion, LineSkyRegion, PointPixelRegion,
+                            PointSkyRegion, PolygonPixelRegion,
+                            PolygonSkyRegion, RectangleAnnulusPixelRegion,
+                            RectangleAnnulusSkyRegion, RectanglePixelRegion,
+                            RectangleSkyRegion, RegularPolygonPixelRegion,
+                            TextPixelRegion, TextSkyRegion)
 
 __all__ = []
 

--- a/regions/io/crtf/io_core.py
+++ b/regions/io/crtf/io_core.py
@@ -3,24 +3,23 @@
 import numbers
 from warnings import warn
 
+import astropy.units as u
 from astropy.coordinates import (Angle, SkyCoord, UnitSphericalRepresentation,
                                  frame_transform_graph)
-import astropy.units as u
 from astropy.utils.exceptions import AstropyUserWarning
 
-from ...shapes import (CirclePixelRegion, CircleSkyRegion,
-                       EllipsePixelRegion, EllipseSkyRegion,
-                       RectanglePixelRegion, RectangleSkyRegion,
-                       PolygonPixelRegion, RegularPolygonPixelRegion,
-                       PolygonSkyRegion,
-                       CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
-                       EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
-                       RectangleAnnulusPixelRegion, RectangleAnnulusSkyRegion,
-                       LinePixelRegion, LineSkyRegion,
-                       PointPixelRegion, PointSkyRegion,
-                       TextPixelRegion, TextSkyRegion)
 from ...core.core import PixCoord, SkyRegion
 from ...core.metadata import RegionMeta, RegionVisual
+from ...shapes import (CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
+                       CirclePixelRegion, CircleSkyRegion,
+                       EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
+                       EllipsePixelRegion, EllipseSkyRegion, LinePixelRegion,
+                       LineSkyRegion, PointPixelRegion, PointSkyRegion,
+                       PolygonPixelRegion, PolygonSkyRegion,
+                       RectangleAnnulusPixelRegion, RectangleAnnulusSkyRegion,
+                       RectanglePixelRegion, RectangleSkyRegion,
+                       RegularPolygonPixelRegion, TextPixelRegion,
+                       TextSkyRegion)
 from ..crtf.core import CRTFRegionParserWarning
 
 __all__ = []

--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -5,15 +5,14 @@ import itertools
 import re
 from warnings import warn
 
-from astropy.coordinates import Angle, frame_transform_graph
 import astropy.units as u
+from astropy.coordinates import Angle, frame_transform_graph
 from astropy.utils.data import get_readable_fileobj
 
 from ...core import Regions
 from ...core.registry import RegionsRegistry
+from .core import CRTFRegionParserError, CRTFRegionParserWarning, valid_symbols
 from .io_core import _Shape, _ShapeList, reg_mapping
-from .core import (CRTFRegionParserError, CRTFRegionParserWarning,
-                   valid_symbols)
 
 __all__ = []
 

--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -9,10 +9,11 @@ import astropy.units as u
 from astropy.coordinates import Angle, frame_transform_graph
 from astropy.utils.data import get_readable_fileobj
 
-from ...core import Regions
-from ...core.registry import RegionsRegistry
-from .core import CRTFRegionParserError, CRTFRegionParserWarning, valid_symbols
-from .io_core import _Shape, _ShapeList, reg_mapping
+from regions.core import Regions
+from regions.core.registry import RegionsRegistry
+from regions.io.crtf.core import (CRTFRegionParserError,
+                                  CRTFRegionParserWarning, valid_symbols)
+from regions.io.crtf.io_core import _Shape, _ShapeList, reg_mapping
 
 __all__ = []
 

--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -34,16 +34,16 @@ regex_coordinate = re.compile(r'\[([\w.+-:]*?)\s*[,]\s*([\w.+-:]*?)\]')
 regex_length = re.compile(r'(?:\[[^=\]]*\])+[,]\s*([^\[]*)\]')
 
 # Extracts each 'parameter=value' pair
-regex_meta = re.compile(r'(?:(\w+)\s*=[\s\'\"]*([^,\[\]]+?)[\'\",]+)|(?:(\w+)\s*=\s*\[(.*?)\])')  # noqa
+regex_meta = re.compile(r'(?:(\w+)\s*=[\s\'\"]*([^,\[\]]+?)[\'\",]+)|(?:(\w+)\s*=\s*\[(.*?)\])')  # noqa: E501
 
 # Region format which segregates the include ('+'|'-') parameter, the
 # kind of definition ('ann' for annotations or '' for regions) and region
 # type.
-regex_region = re.compile(r'(?P<include>[+-])?(?P<type>ann(?=\s))?\s*(?P<regiontype>[a-z]*?)\s?\[[^=]*]')  # noqa
+regex_region = re.compile(r'(?P<include>[+-])?(?P<type>ann(?=\s))?\s*(?P<regiontype>[a-z]*?)\s?\[[^=]*]')  # noqa: E501
 
 # Line format which checks the validity of the line and segregates the
 # meta attributes from the region format.
-regex_line = re.compile(r'(?P<region>[+-]?(?:ann(?=\s))?\s*[a-z]+?\s?\[[^=]+\])(?:\s*,?\s*(?P<parameters>.*))?')  # noqa
+regex_line = re.compile(r'(?P<region>[+-]?(?:ann(?=\s))?\s*[a-z]+?\s?\[[^=]+\])(?:\s*,?\s*(?P<parameters>.*))?')  # noqa: E501
 
 
 @RegionsRegistry.register(Regions, 'read', 'crtf')

--- a/regions/io/crtf/tests/test_casa_mask.py
+++ b/regions/io/crtf/tests/test_casa_mask.py
@@ -7,8 +7,8 @@ import astropy.units as u
 import pytest
 from astropy.coordinates import SkyCoord
 
-from ....shapes.ellipse import EllipseSkyRegion
-from ..write import _write_crtf
+from regions.io.crtf.write import _write_crtf
+from regions.shapes.ellipse import EllipseSkyRegion
 
 try:
     from casatasks import tclean

--- a/regions/io/crtf/tests/test_casa_mask.py
+++ b/regions/io/crtf/tests/test_casa_mask.py
@@ -3,17 +3,18 @@
 import pickle
 import tempfile
 
-from astropy.coordinates import SkyCoord
 import astropy.units as u
 import pytest
+from astropy.coordinates import SkyCoord
 
 from ....shapes.ellipse import EllipseSkyRegion
 from ..write import _write_crtf
 
 try:
-    from casatools import image, simulator
-    from casatools import measures as me
     from casatasks import tclean
+    from casatools import image
+    from casatools import measures as me
+    from casatools import simulator
     HAS_CASATOOLS = True
 except ImportError:
     HAS_CASATOOLS = False

--- a/regions/io/crtf/tests/test_crtf.py
+++ b/regions/io/crtf/tests/test_crtf.py
@@ -3,18 +3,17 @@
 Tests for the crtf subpackage.
 """
 
-from astropy.coordinates import Angle, SkyCoord
 import astropy.units as u
-from astropy.utils.data import get_pkg_data_filename
-from astropy.tests.helper import assert_quantity_allclose
 import pytest
+from astropy.coordinates import Angle, SkyCoord
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.data import get_pkg_data_filename
 
+from ....core import Regions
 from ....shapes.circle import CircleSkyRegion
 from ....shapes.ellipse import EllipseSkyRegion
-from ....core import Regions
 from ..core import CRTFRegionParserError
 from ..read import _CRTFParser
-
 
 implemented_region_types = ('ellipse', 'circle', 'rectangle', 'poly', 'point',
                             'text', 'symbol')

--- a/regions/io/crtf/tests/test_crtf.py
+++ b/regions/io/crtf/tests/test_crtf.py
@@ -9,11 +9,11 @@ from astropy.coordinates import Angle, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.data import get_pkg_data_filename
 
-from ....core import Regions
-from ....shapes.circle import CircleSkyRegion
-from ....shapes.ellipse import EllipseSkyRegion
-from ..core import CRTFRegionParserError
-from ..read import _CRTFParser
+from regions.core import Regions
+from regions.io.crtf.core import CRTFRegionParserError
+from regions.io.crtf.read import _CRTFParser
+from regions.shapes.circle import CircleSkyRegion
+from regions.shapes.ellipse import EllipseSkyRegion
 
 implemented_region_types = ('ellipse', 'circle', 'rectangle', 'poly', 'point',
                             'text', 'symbol')

--- a/regions/io/crtf/tests/test_io_core.py
+++ b/regions/io/crtf/tests/test_io_core.py
@@ -4,8 +4,8 @@ import pytest
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.units.quantity import Quantity
 
-from ..io_core import _to_shape_list
-from ..read import _CRTFParser
+from regions.io.crtf.io_core import _to_shape_list
+from regions.io.crtf.read import _CRTFParser
 
 
 def test_shape_crtf():

--- a/regions/io/crtf/tests/test_io_core.py
+++ b/regions/io/crtf/tests/test_io_core.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import pytest
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.units.quantity import Quantity
-import pytest
 
 from ..io_core import _to_shape_list
 from ..read import _CRTFParser

--- a/regions/io/crtf/write.py
+++ b/regions/io/crtf/write.py
@@ -2,9 +2,9 @@
 
 import os
 
-from ...core import Region, Regions
-from ...core.registry import RegionsRegistry
-from .io_core import _to_shape_list
+from regions.core import Region, Regions
+from regions.core.registry import RegionsRegistry
+from regions.io.crtf.io_core import _to_shape_list
 
 __all__ = []
 

--- a/regions/io/ds9/connect.py
+++ b/regions/io/ds9/connect.py
@@ -2,8 +2,8 @@
 
 from astropy.utils.data import get_readable_fileobj
 
-from ...core import Region, Regions
-from ...core.registry import RegionsRegistry
+from regions.core import Region, Regions
+from regions.core.registry import RegionsRegistry
 
 __all__ = []
 

--- a/regions/io/ds9/core.py
+++ b/regions/io/ds9/core.py
@@ -1,18 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import itertools
 
-from ...shapes import (CirclePixelRegion, CircleSkyRegion,
-                       EllipsePixelRegion, EllipseSkyRegion,
-                       RectanglePixelRegion, RectangleSkyRegion,
-                       PolygonPixelRegion, PolygonSkyRegion,
-                       CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
-                       EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
-                       RectangleAnnulusPixelRegion, RectangleAnnulusSkyRegion,
-                       LinePixelRegion, LineSkyRegion,
-                       PointPixelRegion, PointSkyRegion,
-                       TextPixelRegion, TextSkyRegion)
-
 from ..._utils.optional_deps import HAS_MATPLOTLIB
+from ...shapes import (CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
+                       CirclePixelRegion, CircleSkyRegion,
+                       EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
+                       EllipsePixelRegion, EllipseSkyRegion, LinePixelRegion,
+                       LineSkyRegion, PointPixelRegion, PointSkyRegion,
+                       PolygonPixelRegion, PolygonSkyRegion,
+                       RectangleAnnulusPixelRegion, RectangleAnnulusSkyRegion,
+                       RectanglePixelRegion, RectangleSkyRegion,
+                       TextPixelRegion, TextSkyRegion)
 
 __all__ = []
 

--- a/regions/io/ds9/core.py
+++ b/regions/io/ds9/core.py
@@ -1,16 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import itertools
 
-from ..._utils.optional_deps import HAS_MATPLOTLIB
-from ...shapes import (CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
-                       CirclePixelRegion, CircleSkyRegion,
-                       EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
-                       EllipsePixelRegion, EllipseSkyRegion, LinePixelRegion,
-                       LineSkyRegion, PointPixelRegion, PointSkyRegion,
-                       PolygonPixelRegion, PolygonSkyRegion,
-                       RectangleAnnulusPixelRegion, RectangleAnnulusSkyRegion,
-                       RectanglePixelRegion, RectangleSkyRegion,
-                       TextPixelRegion, TextSkyRegion)
+from regions._utils.optional_deps import HAS_MATPLOTLIB
+from regions.shapes import (CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
+                            CirclePixelRegion, CircleSkyRegion,
+                            EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
+                            EllipsePixelRegion, EllipseSkyRegion,
+                            LinePixelRegion, LineSkyRegion, PointPixelRegion,
+                            PointSkyRegion, PolygonPixelRegion,
+                            PolygonSkyRegion, RectangleAnnulusPixelRegion,
+                            RectangleAnnulusSkyRegion, RectanglePixelRegion,
+                            RectangleSkyRegion, TextPixelRegion, TextSkyRegion)
 
 __all__ = []
 

--- a/regions/io/ds9/meta.py
+++ b/regions/io/ds9/meta.py
@@ -4,7 +4,7 @@ import warnings
 
 from astropy.utils.exceptions import AstropyUserWarning
 
-from .core import ds9_valid_symbols, DS9ParserError
+from .core import DS9ParserError, ds9_valid_symbols
 
 __all__ = []
 

--- a/regions/io/ds9/meta.py
+++ b/regions/io/ds9/meta.py
@@ -4,7 +4,7 @@ import warnings
 
 from astropy.utils.exceptions import AstropyUserWarning
 
-from .core import DS9ParserError, ds9_valid_symbols
+from regions.io.ds9.core import DS9ParserError, ds9_valid_symbols
 
 __all__ = []
 

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -11,11 +11,11 @@ from astropy.coordinates import Angle, SkyCoord
 from astropy.utils.data import get_readable_fileobj
 from astropy.utils.exceptions import AstropyUserWarning
 
-from ...core import PixCoord, RegionMeta, Regions, RegionVisual
-from ...core.registry import RegionsRegistry
-from .core import (DS9ParserError, ds9_frame_map, ds9_params_template,
-                   ds9_shape_to_region)
-from .meta import _split_raw_metadata, _translate_ds9_to_visual
+from regions.core import PixCoord, RegionMeta, Regions, RegionVisual
+from regions.core.registry import RegionsRegistry
+from regions.io.ds9.core import (DS9ParserError, ds9_frame_map,
+                                 ds9_params_template, ds9_shape_to_region)
+from regions.io.ds9.meta import _split_raw_metadata, _translate_ds9_to_visual
 
 __all__ = []
 

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -1,20 +1,20 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from copy import deepcopy
-from dataclasses import dataclass
 import re
 import string
 import warnings
+from copy import deepcopy
+from dataclasses import dataclass
 
-from astropy.coordinates import Angle, SkyCoord
 import astropy.units as u
+from astropy.coordinates import Angle, SkyCoord
 from astropy.utils.data import get_readable_fileobj
 from astropy.utils.exceptions import AstropyUserWarning
 
-from ...core import Regions, RegionMeta, RegionVisual, PixCoord
+from ...core import PixCoord, RegionMeta, Regions, RegionVisual
 from ...core.registry import RegionsRegistry
-from .core import (ds9_frame_map, ds9_shape_to_region, ds9_params_template,
-                   DS9ParserError)
+from .core import (DS9ParserError, ds9_frame_map, ds9_params_template,
+                   ds9_shape_to_region)
 from .meta import _split_raw_metadata, _translate_ds9_to_visual
 
 __all__ = []

--- a/regions/io/ds9/tests/test_ds9.py
+++ b/regions/io/ds9/tests/test_ds9.py
@@ -14,11 +14,11 @@ from astropy.utils.data import get_pkg_data_filenames
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_equal
 
-from ...._utils.optional_deps import HAS_MATPLOTLIB
-from ....core import PixCoord, Regions, RegionVisual
-from ....shapes import (CirclePixelRegion, CircleSkyRegion, PointPixelRegion,
-                        RegularPolygonPixelRegion)
-from ....tests.helpers import assert_region_allclose
+from regions._utils.optional_deps import HAS_MATPLOTLIB
+from regions.core import PixCoord, Regions, RegionVisual
+from regions.shapes import (CirclePixelRegion, CircleSkyRegion,
+                            PointPixelRegion, RegularPolygonPixelRegion)
+from regions.tests.helpers import assert_region_allclose
 
 
 def test_roundtrip(tmpdir):

--- a/regions/io/ds9/tests/test_ds9.py
+++ b/regions/io/ds9/tests/test_ds9.py
@@ -6,19 +6,19 @@ Tests for the ds9 subpackage.
 import os
 import warnings
 
+import astropy.units as u
+import pytest
 from astropy.coordinates import Angle, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
-import astropy.units as u
 from astropy.utils.data import get_pkg_data_filenames
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_equal
-import pytest
 
-from ....core import Regions, PixCoord, RegionVisual
+from ...._utils.optional_deps import HAS_MATPLOTLIB
+from ....core import PixCoord, Regions, RegionVisual
 from ....shapes import (CirclePixelRegion, CircleSkyRegion, PointPixelRegion,
                         RegularPolygonPixelRegion)
 from ....tests.helpers import assert_region_allclose
-from ...._utils.optional_deps import HAS_MATPLOTLIB
 
 
 def test_roundtrip(tmpdir):

--- a/regions/io/ds9/write.py
+++ b/regions/io/ds9/write.py
@@ -8,12 +8,12 @@ from astropy.coordinates import Angle, SkyCoord
 from astropy.units import Quantity
 from astropy.utils.exceptions import AstropyUserWarning
 
-from ...core import (CompoundPixelRegion, CompoundSkyRegion, PixCoord,
-                     PixelRegion, Region, Regions)
-from ...core.registry import RegionsRegistry
-from ...shapes import RegularPolygonPixelRegion
-from .core import ds9_frame_map, ds9_shape_templates
-from .meta import _translate_metadata_to_ds9
+from regions.core import (CompoundPixelRegion, CompoundSkyRegion, PixCoord,
+                          PixelRegion, Region, Regions)
+from regions.core.registry import RegionsRegistry
+from regions.io.ds9.core import ds9_frame_map, ds9_shape_templates
+from regions.io.ds9.meta import _translate_metadata_to_ds9
+from regions.shapes import RegularPolygonPixelRegion
 
 __all__ = []
 

--- a/regions/io/ds9/write.py
+++ b/regions/io/ds9/write.py
@@ -1,15 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from copy import deepcopy
 import os
 import warnings
+from copy import deepcopy
 
 from astropy.coordinates import Angle, SkyCoord
 from astropy.units import Quantity
 from astropy.utils.exceptions import AstropyUserWarning
 
-from ...core import Region, Regions, PixelRegion, PixCoord
-from ...core import CompoundPixelRegion, CompoundSkyRegion
+from ...core import (CompoundPixelRegion, CompoundSkyRegion, PixCoord,
+                     PixelRegion, Region, Regions)
 from ...core.registry import RegionsRegistry
 from ...shapes import RegularPolygonPixelRegion
 from .core import ds9_frame_map, ds9_shape_templates

--- a/regions/io/fits/connect.py
+++ b/regions/io/fits/connect.py
@@ -4,8 +4,8 @@ import warnings
 
 from astropy.io import fits
 
-from ...core import Region, Regions
-from ...core.registry import RegionsRegistry
+from regions.core import Region, Regions
+from regions.core.registry import RegionsRegistry
 
 __all__ = []
 

--- a/regions/io/fits/core.py
+++ b/regions/io/fits/core.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ...shapes import (CircleAnnulusPixelRegion, CirclePixelRegion,
-                       EllipseAnnulusPixelRegion, EllipsePixelRegion,
-                       PointPixelRegion, PolygonPixelRegion,
-                       RectanglePixelRegion)
+from regions.shapes import (CircleAnnulusPixelRegion, CirclePixelRegion,
+                            EllipseAnnulusPixelRegion, EllipsePixelRegion,
+                            PointPixelRegion, PolygonPixelRegion,
+                            RectanglePixelRegion)
 
 __all__ = []
 

--- a/regions/io/fits/core.py
+++ b/regions/io/fits/core.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ...shapes import (CirclePixelRegion, EllipsePixelRegion,
-                       RectanglePixelRegion, PolygonPixelRegion,
-                       CircleAnnulusPixelRegion, EllipseAnnulusPixelRegion,
-                       PointPixelRegion)
+from ...shapes import (CircleAnnulusPixelRegion, CirclePixelRegion,
+                       EllipseAnnulusPixelRegion, EllipsePixelRegion,
+                       PointPixelRegion, PolygonPixelRegion,
+                       RectanglePixelRegion)
 
 __all__ = []
 

--- a/regions/io/fits/read.py
+++ b/regions/io/fits/read.py
@@ -2,13 +2,13 @@
 
 import warnings
 
+import astropy.units as u
+import numpy as np
 from astropy.io import fits
 from astropy.table import QTable
-import astropy.units as u
 from astropy.utils.exceptions import AstropyUserWarning
-import numpy as np
 
-from ...core import Regions, RegionMeta, PixCoord
+from ...core import PixCoord, RegionMeta, Regions
 from ...core.registry import RegionsRegistry
 from .core import FITSParserError, shape_map
 

--- a/regions/io/fits/read.py
+++ b/regions/io/fits/read.py
@@ -8,9 +8,9 @@ from astropy.io import fits
 from astropy.table import QTable
 from astropy.utils.exceptions import AstropyUserWarning
 
-from ...core import PixCoord, RegionMeta, Regions
-from ...core.registry import RegionsRegistry
-from .core import FITSParserError, shape_map
+from regions.core import PixCoord, RegionMeta, Regions
+from regions.core.registry import RegionsRegistry
+from regions.io.fits.core import FITSParserError, shape_map
 
 __all__ = []
 

--- a/regions/io/fits/tests/test_fits.py
+++ b/regions/io/fits/tests/test_fits.py
@@ -14,11 +14,12 @@ from astropy.utils.data import get_pkg_data_filenames
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_equal
 
-from ....core import PixCoord, RegionMeta, Regions
-from ....shapes import (CirclePixelRegion, CircleSkyRegion, LinePixelRegion,
-                        RectangleAnnulusPixelRegion, TextPixelRegion)
-from ....tests.helpers import assert_region_allclose
-from ..core import FITSParserError
+from regions.core import PixCoord, RegionMeta, Regions
+from regions.io.fits.core import FITSParserError
+from regions.shapes import (CirclePixelRegion, CircleSkyRegion,
+                            LinePixelRegion, RectangleAnnulusPixelRegion,
+                            TextPixelRegion)
+from regions.tests.helpers import assert_region_allclose
 
 
 def test_roundtrip(tmpdir):

--- a/regions/io/fits/tests/test_fits.py
+++ b/regions/io/fits/tests/test_fits.py
@@ -5,19 +5,18 @@ Tests for the fits subpackage.
 
 import warnings
 
-from astropy.coordinates import SkyCoord
 import astropy.units as u
+import numpy as np
+import pytest
+from astropy.coordinates import SkyCoord
+from astropy.table import QTable
 from astropy.utils.data import get_pkg_data_filenames
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy.table import QTable
-import numpy as np
 from numpy.testing import assert_equal
-import pytest
 
-from ....core import Regions, PixCoord, RegionMeta
-from ....shapes import (CirclePixelRegion, CircleSkyRegion,
-                        RectangleAnnulusPixelRegion, LinePixelRegion,
-                        TextPixelRegion)
+from ....core import PixCoord, RegionMeta, Regions
+from ....shapes import (CirclePixelRegion, CircleSkyRegion, LinePixelRegion,
+                        RectangleAnnulusPixelRegion, TextPixelRegion)
 from ....tests.helpers import assert_region_allclose
 from ..core import FITSParserError
 

--- a/regions/io/fits/write.py
+++ b/regions/io/fits/write.py
@@ -1,17 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from dataclasses import dataclass
 import warnings
+from dataclasses import dataclass
 
+import astropy.units as u
+import numpy as np
 from astropy.io import fits
 from astropy.table import QTable
-import astropy.units as u
 from astropy.utils.exceptions import AstropyUserWarning
-import numpy as np
 
 from ...core import Region, Regions, SkyRegion
-from ...shapes import RegularPolygonPixelRegion
 from ...core.registry import RegionsRegistry
+from ...shapes import RegularPolygonPixelRegion
 
 __all__ = []
 

--- a/regions/io/fits/write.py
+++ b/regions/io/fits/write.py
@@ -9,9 +9,9 @@ from astropy.io import fits
 from astropy.table import QTable
 from astropy.utils.exceptions import AstropyUserWarning
 
-from ...core import Region, Regions, SkyRegion
-from ...core.registry import RegionsRegistry
-from ...shapes import RegularPolygonPixelRegion
+from regions.core import Region, Regions, SkyRegion
+from regions.core.registry import RegionsRegistry
+from regions.shapes import RegularPolygonPixelRegion
 
 __all__ = []
 

--- a/regions/shapes/__init__.py
+++ b/regions/shapes/__init__.py
@@ -2,11 +2,12 @@
 """
 This subpackage defines region shapes.
 """
-from .annulus import *  # noqa
-from .circle import *  # noqa
-from .ellipse import *  # noqa
-from .line import *  # noqa
-from .point import *  # noqa
-from .polygon import *  # noqa
-from .rectangle import *  # noqa
-from .text import *  # noqa
+
+from .annulus import *  # noqa: F401, F403
+from .circle import *  # noqa: F401, F403
+from .ellipse import *  # noqa: F401, F403
+from .line import *  # noqa: F401, F403
+from .point import *  # noqa: F401, F403
+from .polygon import *  # noqa: F401, F403
+from .rectangle import *  # noqa: F401, F403
+from .text import *  # noqa: F401, F403

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -8,17 +8,18 @@ import operator
 
 import astropy.units as u
 
-from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
-from ..core.attributes import (PositiveScalar, PositiveScalarAngle,
-                               RegionMetaDescr, RegionVisualDescr, ScalarAngle,
-                               ScalarPixCoord, ScalarSkyCoord)
-from ..core.compound import CompoundPixelRegion
-from ..core.core import PixelRegion, SkyRegion
-from ..core.metadata import RegionMeta, RegionVisual
-from ..core.pixcoord import PixCoord
-from ..shapes.circle import CirclePixelRegion
-from ..shapes.ellipse import EllipsePixelRegion, EllipseSkyRegion
-from ..shapes.rectangle import RectanglePixelRegion, RectangleSkyRegion
+from regions._utils.wcs_helpers import pixel_scale_angle_at_skycoord
+from regions.core.attributes import (PositiveScalar, PositiveScalarAngle,
+                                     RegionMetaDescr, RegionVisualDescr,
+                                     ScalarAngle, ScalarPixCoord,
+                                     ScalarSkyCoord)
+from regions.core.compound import CompoundPixelRegion
+from regions.core.core import PixelRegion, SkyRegion
+from regions.core.metadata import RegionMeta, RegionVisual
+from regions.core.pixcoord import PixCoord
+from regions.shapes.circle import CirclePixelRegion
+from regions.shapes.ellipse import EllipsePixelRegion, EllipseSkyRegion
+from regions.shapes.rectangle import RectanglePixelRegion, RectangleSkyRegion
 
 __all__ = ['AnnulusPixelRegion', 'AsymmetricAnnulusPixelRegion',
            'AsymmetricAnnulusSkyRegion',

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -8,10 +8,10 @@ import operator
 
 import astropy.units as u
 
-from ..core.attributes import (ScalarPixCoord, PositiveScalar,
-                               PositiveScalarAngle, ScalarAngle,
-                               ScalarSkyCoord, RegionMetaDescr,
-                               RegionVisualDescr)
+from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
+from ..core.attributes import (PositiveScalar, PositiveScalarAngle,
+                               RegionMetaDescr, RegionVisualDescr, ScalarAngle,
+                               ScalarPixCoord, ScalarSkyCoord)
 from ..core.compound import CompoundPixelRegion
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual
@@ -19,7 +19,6 @@ from ..core.pixcoord import PixCoord
 from ..shapes.circle import CirclePixelRegion
 from ..shapes.ellipse import EllipsePixelRegion, EllipseSkyRegion
 from ..shapes.rectangle import RectanglePixelRegion, RectangleSkyRegion
-from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
 
 __all__ = ['AnnulusPixelRegion', 'AsymmetricAnnulusPixelRegion',
            'AsymmetricAnnulusSkyRegion',

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -9,16 +9,16 @@ import astropy.units as u
 import numpy as np
 from astropy.coordinates import Angle
 
-from .._geometry import circular_overlap_grid
-from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
-from ..core.attributes import (PositiveScalar, PositiveScalarAngle,
-                               RegionMetaDescr, RegionVisualDescr,
-                               ScalarPixCoord, ScalarSkyCoord)
-from ..core.bounding_box import RegionBoundingBox
-from ..core.core import PixelRegion, SkyRegion
-from ..core.mask import RegionMask
-from ..core.metadata import RegionMeta, RegionVisual
-from ..core.pixcoord import PixCoord
+from regions._geometry import circular_overlap_grid
+from regions._utils.wcs_helpers import pixel_scale_angle_at_skycoord
+from regions.core.attributes import (PositiveScalar, PositiveScalarAngle,
+                                     RegionMetaDescr, RegionVisualDescr,
+                                     ScalarPixCoord, ScalarSkyCoord)
+from regions.core.bounding_box import RegionBoundingBox
+from regions.core.core import PixelRegion, SkyRegion
+from regions.core.mask import RegionMask
+from regions.core.metadata import RegionMeta, RegionVisual
+from regions.core.pixcoord import PixCoord
 
 __all__ = ['CirclePixelRegion', 'CircleSkyRegion']
 

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -5,20 +5,20 @@ This module defines circular regions in both pixel and sky coordinates.
 
 import math
 
-from astropy.coordinates import Angle
 import astropy.units as u
 import numpy as np
+from astropy.coordinates import Angle
 
-from ..core.attributes import (ScalarPixCoord, PositiveScalar,
-                               PositiveScalarAngle, ScalarSkyCoord,
-                               RegionMetaDescr, RegionVisualDescr)
+from .._geometry import circular_overlap_grid
+from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
+from ..core.attributes import (PositiveScalar, PositiveScalarAngle,
+                               RegionMetaDescr, RegionVisualDescr,
+                               ScalarPixCoord, ScalarSkyCoord)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
 from ..core.metadata import RegionMeta, RegionVisual
 from ..core.pixcoord import PixCoord
-from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
-from .._geometry import circular_overlap_grid
 
 __all__ = ['CirclePixelRegion', 'CircleSkyRegion']
 

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -5,21 +5,20 @@ This module defines elliptical regions in both pixel and sky coordinates.
 
 import math
 
-from astropy.coordinates import Angle
 import astropy.units as u
 import numpy as np
+from astropy.coordinates import Angle
 
-from ..core.attributes import (ScalarPixCoord, PositiveScalar,
-                               PositiveScalarAngle, ScalarAngle,
-                               ScalarSkyCoord, RegionMetaDescr,
-                               RegionVisualDescr)
+from .._geometry import elliptical_overlap_grid
+from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
+from ..core.attributes import (PositiveScalar, PositiveScalarAngle,
+                               RegionMetaDescr, RegionVisualDescr, ScalarAngle,
+                               ScalarPixCoord, ScalarSkyCoord)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
 from ..core.metadata import RegionMeta, RegionVisual
 from ..core.pixcoord import PixCoord
-from .._geometry import elliptical_overlap_grid
-from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
 
 __all__ = ['EllipsePixelRegion', 'EllipseSkyRegion']
 
@@ -264,6 +263,7 @@ class EllipsePixelRegion(PixelRegion):
         ``selector.set_active(True)`` or ``selector.set_active(False)``.
         """
         from matplotlib.widgets import EllipseSelector
+
         from .._utils.optional_deps import MPL_VERSION
 
         if hasattr(self, '_mpl_selector'):

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -9,16 +9,17 @@ import astropy.units as u
 import numpy as np
 from astropy.coordinates import Angle
 
-from .._geometry import elliptical_overlap_grid
-from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
-from ..core.attributes import (PositiveScalar, PositiveScalarAngle,
-                               RegionMetaDescr, RegionVisualDescr, ScalarAngle,
-                               ScalarPixCoord, ScalarSkyCoord)
-from ..core.bounding_box import RegionBoundingBox
-from ..core.core import PixelRegion, SkyRegion
-from ..core.mask import RegionMask
-from ..core.metadata import RegionMeta, RegionVisual
-from ..core.pixcoord import PixCoord
+from regions._geometry import elliptical_overlap_grid
+from regions._utils.wcs_helpers import pixel_scale_angle_at_skycoord
+from regions.core.attributes import (PositiveScalar, PositiveScalarAngle,
+                                     RegionMetaDescr, RegionVisualDescr,
+                                     ScalarAngle, ScalarPixCoord,
+                                     ScalarSkyCoord)
+from regions.core.bounding_box import RegionBoundingBox
+from regions.core.core import PixelRegion, SkyRegion
+from regions.core.mask import RegionMask
+from regions.core.metadata import RegionMeta, RegionVisual
+from regions.core.pixcoord import PixCoord
 
 __all__ = ['EllipsePixelRegion', 'EllipseSkyRegion']
 
@@ -264,7 +265,7 @@ class EllipsePixelRegion(PixelRegion):
         """
         from matplotlib.widgets import EllipseSelector
 
-        from .._utils.optional_deps import MPL_VERSION
+        from regions._utils.optional_deps import MPL_VERSION
 
         if hasattr(self, '_mpl_selector'):
             raise AttributeError('Cannot attach more than one selector to a region.')

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -5,8 +5,8 @@ This module defines line regions in both pixel and sky coordinates.
 
 import numpy as np
 
-from ..core.attributes import (ScalarPixCoord, ScalarSkyCoord,
-                               RegionMetaDescr, RegionVisualDescr)
+from ..core.attributes import (RegionMetaDescr, RegionVisualDescr,
+                               ScalarPixCoord, ScalarSkyCoord)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -5,12 +5,12 @@ This module defines line regions in both pixel and sky coordinates.
 
 import numpy as np
 
-from ..core.attributes import (RegionMetaDescr, RegionVisualDescr,
-                               ScalarPixCoord, ScalarSkyCoord)
-from ..core.bounding_box import RegionBoundingBox
-from ..core.core import PixelRegion, SkyRegion
-from ..core.metadata import RegionMeta, RegionVisual
-from ..core.pixcoord import PixCoord
+from regions.core.attributes import (RegionMetaDescr, RegionVisualDescr,
+                                     ScalarPixCoord, ScalarSkyCoord)
+from regions.core.bounding_box import RegionBoundingBox
+from regions.core.core import PixelRegion, SkyRegion
+from regions.core.metadata import RegionMeta, RegionVisual
+from regions.core.pixcoord import PixCoord
 
 __all__ = ['LinePixelRegion', 'LineSkyRegion']
 

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -5,13 +5,12 @@ This module defines point regions in both pixel and sky coordinates.
 
 import numpy as np
 
-from ..core.attributes import (ScalarPixCoord, ScalarSkyCoord,
-                               RegionMetaDescr, RegionVisualDescr)
+from ..core.attributes import (RegionMetaDescr, RegionVisualDescr,
+                               ScalarPixCoord, ScalarSkyCoord)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.metadata import RegionMeta, RegionVisual
 from ..core.pixcoord import PixCoord
-
 
 __all__ = ['PointPixelRegion', 'PointSkyRegion']
 

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -5,12 +5,12 @@ This module defines point regions in both pixel and sky coordinates.
 
 import numpy as np
 
-from ..core.attributes import (RegionMetaDescr, RegionVisualDescr,
-                               ScalarPixCoord, ScalarSkyCoord)
-from ..core.bounding_box import RegionBoundingBox
-from ..core.core import PixelRegion, SkyRegion
-from ..core.metadata import RegionMeta, RegionVisual
-from ..core.pixcoord import PixCoord
+from regions.core.attributes import (RegionMetaDescr, RegionVisualDescr,
+                                     ScalarPixCoord, ScalarSkyCoord)
+from regions.core.bounding_box import RegionBoundingBox
+from regions.core.core import PixelRegion, SkyRegion
+from regions.core.metadata import RegionMeta, RegionVisual
+from regions.core.pixcoord import PixCoord
 
 __all__ = ['PointPixelRegion', 'PointSkyRegion']
 

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -6,16 +6,16 @@ This module defines polygon regions in both pixel and sky coordinates.
 import astropy.units as u
 import numpy as np
 
-from ..core.attributes import (OneDPixCoord, ScalarPixCoord, PositiveScalar,
-                               ScalarAngle, OneDSkyCoord, RegionMetaDescr,
-                               RegionVisualDescr)
+from .._geometry import polygonal_overlap_grid
+from .._geometry.pnpoly import points_in_polygon
+from ..core.attributes import (OneDPixCoord, OneDSkyCoord, PositiveScalar,
+                               RegionMetaDescr, RegionVisualDescr, ScalarAngle,
+                               ScalarPixCoord)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
 from ..core.metadata import RegionMeta, RegionVisual
 from ..core.pixcoord import PixCoord
-from .._geometry import polygonal_overlap_grid
-from .._geometry.pnpoly import points_in_polygon
 
 __all__ = ['PolygonPixelRegion', 'RegularPolygonPixelRegion',
            'PolygonSkyRegion']

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -6,16 +6,17 @@ This module defines polygon regions in both pixel and sky coordinates.
 import astropy.units as u
 import numpy as np
 
-from .._geometry import polygonal_overlap_grid
-from .._geometry.pnpoly import points_in_polygon
-from ..core.attributes import (OneDPixCoord, OneDSkyCoord, PositiveScalar,
-                               RegionMetaDescr, RegionVisualDescr, ScalarAngle,
-                               ScalarPixCoord)
-from ..core.bounding_box import RegionBoundingBox
-from ..core.core import PixelRegion, SkyRegion
-from ..core.mask import RegionMask
-from ..core.metadata import RegionMeta, RegionVisual
-from ..core.pixcoord import PixCoord
+from regions._geometry import polygonal_overlap_grid
+from regions._geometry.pnpoly import points_in_polygon
+from regions.core.attributes import (OneDPixCoord, OneDSkyCoord,
+                                     PositiveScalar, RegionMetaDescr,
+                                     RegionVisualDescr, ScalarAngle,
+                                     ScalarPixCoord)
+from regions.core.bounding_box import RegionBoundingBox
+from regions.core.core import PixelRegion, SkyRegion
+from regions.core.mask import RegionMask
+from regions.core.metadata import RegionMeta, RegionVisual
+from regions.core.pixcoord import PixCoord
 
 __all__ = ['PolygonPixelRegion', 'RegularPolygonPixelRegion',
            'PolygonSkyRegion']

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -3,22 +3,20 @@
 This module defines rectangular regions in both pixel and sky coordinates.
 """
 
-from astropy.coordinates import Angle
 import astropy.units as u
 import numpy as np
+from astropy.coordinates import Angle
 
-from ..core.attributes import (ScalarPixCoord, PositiveScalar,
-                               PositiveScalarAngle, ScalarAngle,
-                               ScalarSkyCoord, RegionMetaDescr,
-                               RegionVisualDescr)
+from .._geometry import rectangular_overlap_grid
+from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
+from ..core.attributes import (PositiveScalar, PositiveScalarAngle,
+                               RegionMetaDescr, RegionVisualDescr, ScalarAngle,
+                               ScalarPixCoord, ScalarSkyCoord)
 from ..core.bounding_box import RegionBoundingBox
 from ..core.core import PixelRegion, SkyRegion
 from ..core.mask import RegionMask
 from ..core.metadata import RegionMeta, RegionVisual
 from ..core.pixcoord import PixCoord
-from .._geometry import rectangular_overlap_grid
-from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
-
 from .polygon import PolygonPixelRegion
 
 __all__ = ['RectanglePixelRegion', 'RectangleSkyRegion']
@@ -261,6 +259,7 @@ class RectanglePixelRegion(PixelRegion):
         ``selector.set_active(True)`` or ``selector.set_active(False)``.
         """
         from matplotlib.widgets import RectangleSelector
+
         from .._utils.optional_deps import MPL_VERSION
 
         if hasattr(self, '_mpl_selector'):

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -7,17 +7,18 @@ import astropy.units as u
 import numpy as np
 from astropy.coordinates import Angle
 
-from .._geometry import rectangular_overlap_grid
-from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
-from ..core.attributes import (PositiveScalar, PositiveScalarAngle,
-                               RegionMetaDescr, RegionVisualDescr, ScalarAngle,
-                               ScalarPixCoord, ScalarSkyCoord)
-from ..core.bounding_box import RegionBoundingBox
-from ..core.core import PixelRegion, SkyRegion
-from ..core.mask import RegionMask
-from ..core.metadata import RegionMeta, RegionVisual
-from ..core.pixcoord import PixCoord
-from .polygon import PolygonPixelRegion
+from regions._geometry import rectangular_overlap_grid
+from regions._utils.wcs_helpers import pixel_scale_angle_at_skycoord
+from regions.core.attributes import (PositiveScalar, PositiveScalarAngle,
+                                     RegionMetaDescr, RegionVisualDescr,
+                                     ScalarAngle, ScalarPixCoord,
+                                     ScalarSkyCoord)
+from regions.core.bounding_box import RegionBoundingBox
+from regions.core.core import PixelRegion, SkyRegion
+from regions.core.mask import RegionMask
+from regions.core.metadata import RegionMeta, RegionVisual
+from regions.core.pixcoord import PixCoord
+from regions.shapes.polygon import PolygonPixelRegion
 
 __all__ = ['RectanglePixelRegion', 'RectangleSkyRegion']
 
@@ -260,7 +261,7 @@ class RectanglePixelRegion(PixelRegion):
         """
         from matplotlib.widgets import RectangleSelector
 
-        from .._utils.optional_deps import MPL_VERSION
+        from regions._utils.optional_deps import MPL_VERSION
 
         if hasattr(self, '_mpl_selector'):
             raise AttributeError('Cannot attach more than one selector to a region.')

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -6,12 +6,16 @@ from astropy.coordinates import SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_allclose
 
-from ...core import PixCoord, RegionMeta, RegionVisual
-from ...tests.helpers import make_simple_wcs
-from ..annulus import (CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
-                       EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
-                       RectangleAnnulusPixelRegion, RectangleAnnulusSkyRegion)
-from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
+from regions.core import PixCoord, RegionMeta, RegionVisual
+from regions.shapes.annulus import (CircleAnnulusPixelRegion,
+                                    CircleAnnulusSkyRegion,
+                                    EllipseAnnulusPixelRegion,
+                                    EllipseAnnulusSkyRegion,
+                                    RectangleAnnulusPixelRegion,
+                                    RectangleAnnulusSkyRegion)
+from regions.shapes.tests.test_common import (BaseTestPixelRegion,
+                                              BaseTestSkyRegion)
+from regions.tests.helpers import make_simple_wcs
 
 
 class TestCircleAnnulusPixelRegion(BaseTestPixelRegion):

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.coordinates import SkyCoord
 import astropy.units as u
-from astropy.tests.helper import assert_quantity_allclose
 import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_allclose
 
 from ...core import PixCoord, RegionMeta, RegionVisual

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -3,13 +3,13 @@
 The tests in this file simply check what functionality is currently
 implemented and doesn't check anything about correctness.
 """
-from collections import OrderedDict
 import itertools
+from collections import OrderedDict
 
-from astropy.coordinates import SkyCoord
 import astropy.units as u
-from astropy.wcs import WCS
 import pytest
+from astropy.coordinates import SkyCoord
+from astropy.wcs import WCS
 
 from ...core.core import PixelRegion, Region, SkyRegion
 from ...core.mask import RegionMask

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -11,18 +11,21 @@ import pytest
 from astropy.coordinates import SkyCoord
 from astropy.wcs import WCS
 
-from ...core.core import PixelRegion, Region, SkyRegion
-from ...core.mask import RegionMask
-from ...core.metadata import RegionMeta, RegionVisual
-from ...core.pixcoord import PixCoord
-from ..annulus import (CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
-                       EllipseAnnulusPixelRegion, EllipseAnnulusSkyRegion,
-                       RectangleAnnulusPixelRegion, RectangleAnnulusSkyRegion)
-from ..circle import CirclePixelRegion, CircleSkyRegion
-from ..ellipse import EllipsePixelRegion, EllipseSkyRegion
-from ..point import PointPixelRegion, PointSkyRegion
-from ..polygon import PolygonPixelRegion, PolygonSkyRegion
-from ..rectangle import RectanglePixelRegion, RectangleSkyRegion
+from regions.core.core import PixelRegion, Region, SkyRegion
+from regions.core.mask import RegionMask
+from regions.core.metadata import RegionMeta, RegionVisual
+from regions.core.pixcoord import PixCoord
+from regions.shapes.annulus import (CircleAnnulusPixelRegion,
+                                    CircleAnnulusSkyRegion,
+                                    EllipseAnnulusPixelRegion,
+                                    EllipseAnnulusSkyRegion,
+                                    RectangleAnnulusPixelRegion,
+                                    RectangleAnnulusSkyRegion)
+from regions.shapes.circle import CirclePixelRegion, CircleSkyRegion
+from regions.shapes.ellipse import EllipsePixelRegion, EllipseSkyRegion
+from regions.shapes.point import PointPixelRegion, PointSkyRegion
+from regions.shapes.polygon import PolygonPixelRegion, PolygonSkyRegion
+from regions.shapes.rectangle import RectanglePixelRegion, RectangleSkyRegion
 
 PIXEL_REGIONS = [
     CirclePixelRegion(PixCoord(3, 4), radius=5),

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -1,18 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import astropy.units as u
+import numpy as np
+import pytest
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.tests.helper import assert_quantity_allclose
-import astropy.units as u
 from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
-import numpy as np
 from numpy.testing import assert_allclose
-import pytest
 
+from ..._utils.optional_deps import HAS_MATPLOTLIB
 from ...core import PixCoord, RegionMeta, RegionVisual
 from ...tests.helpers import make_simple_wcs
-from ..._utils.optional_deps import HAS_MATPLOTLIB
 from ..circle import CirclePixelRegion, CircleSkyRegion
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -10,11 +10,12 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
 from numpy.testing import assert_allclose
 
-from ..._utils.optional_deps import HAS_MATPLOTLIB
-from ...core import PixCoord, RegionMeta, RegionVisual
-from ...tests.helpers import make_simple_wcs
-from ..circle import CirclePixelRegion, CircleSkyRegion
-from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
+from regions._utils.optional_deps import HAS_MATPLOTLIB
+from regions.core import PixCoord, RegionMeta, RegionVisual
+from regions.shapes.circle import CirclePixelRegion, CircleSkyRegion
+from regions.shapes.tests.test_common import (BaseTestPixelRegion,
+                                              BaseTestSkyRegion)
+from regions.tests.helpers import make_simple_wcs
 
 
 @pytest.fixture(scope='session', name='wcs')

--- a/regions/shapes/tests/test_common.py
+++ b/regions/shapes/tests/test_common.py
@@ -4,11 +4,11 @@ Base class for all shape tests.
 """
 
 import numpy as np
-from numpy.testing import assert_equal, assert_allclose
 import pytest
+from numpy.testing import assert_allclose, assert_equal
 
-from ...core.pixcoord import PixCoord
 from ..._utils.optional_deps import HAS_MATPLOTLIB
+from ...core.pixcoord import PixCoord
 
 
 class BaseTestRegion:

--- a/regions/shapes/tests/test_common.py
+++ b/regions/shapes/tests/test_common.py
@@ -7,8 +7,8 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
 
-from ..._utils.optional_deps import HAS_MATPLOTLIB
-from ...core.pixcoord import PixCoord
+from regions._utils.optional_deps import HAS_MATPLOTLIB
+from regions.core.pixcoord import PixCoord
 
 
 class BaseTestRegion:

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -1,19 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import astropy.units as u
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal
 import pytest
-
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.tests.helper import assert_quantity_allclose
-import astropy.units as u
 from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
+from numpy.testing import assert_allclose, assert_equal
 
+from ..._utils.optional_deps import HAS_MATPLOTLIB, MPL_VERSION
 from ...core import PixCoord, RegionMeta, RegionVisual
 from ...tests.helpers import make_simple_wcs
-from ..._utils.optional_deps import HAS_MATPLOTLIB, MPL_VERSION
 from ..ellipse import EllipsePixelRegion, EllipseSkyRegion
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -136,7 +136,7 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
 
         region = self.reg.copy(angle=0 * u.deg)
 
-        selector = region.as_mpl_selector(ax, callback=update_mask, sync=sync)  # noqa
+        selector = region.as_mpl_selector(ax, callback=update_mask, sync=sync)
 
         do_event(selector, 'press', xdata=7.3, ydata=4.4, button=1)
         do_event(selector, 'onmove', xdata=9.3, ydata=5.4, button=1)

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -10,11 +10,12 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
 from numpy.testing import assert_allclose, assert_equal
 
-from ..._utils.optional_deps import HAS_MATPLOTLIB, MPL_VERSION
-from ...core import PixCoord, RegionMeta, RegionVisual
-from ...tests.helpers import make_simple_wcs
-from ..ellipse import EllipsePixelRegion, EllipseSkyRegion
-from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
+from regions._utils.optional_deps import HAS_MATPLOTLIB, MPL_VERSION
+from regions.core import PixCoord, RegionMeta, RegionVisual
+from regions.shapes.ellipse import EllipsePixelRegion, EllipseSkyRegion
+from regions.shapes.tests.test_common import (BaseTestPixelRegion,
+                                              BaseTestSkyRegion)
+from regions.tests.helpers import make_simple_wcs
 
 
 @pytest.fixture(scope='session', name='wcs')

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -227,7 +227,7 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
 
     @pytest.mark.parametrize('userargs',
                              ({'useblit': True},
-                              {'grab_range': 20, 'minspanx': 5,  'minspany': 4},
+                              {'grab_range': 20, 'minspanx': 5, 'minspany': 4},
                               {'props': {'facecolor': 'blue', 'linewidth': 2}},
                               {'twit': 'gumby'}))
     def test_mpl_selector_kwargs(self, userargs):

--- a/regions/shapes/tests/test_line.py
+++ b/regions/shapes/tests/test_line.py
@@ -10,11 +10,12 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
 from numpy.testing import assert_allclose
 
-from ..._utils.optional_deps import HAS_MATPLOTLIB
-from ...core import PixCoord, RegionMeta, RegionVisual
-from ...tests.helpers import make_simple_wcs
-from ..line import LinePixelRegion, LineSkyRegion
-from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
+from regions._utils.optional_deps import HAS_MATPLOTLIB
+from regions.core import PixCoord, RegionMeta, RegionVisual
+from regions.shapes.line import LinePixelRegion, LineSkyRegion
+from regions.shapes.tests.test_common import (BaseTestPixelRegion,
+                                              BaseTestSkyRegion)
+from regions.tests.helpers import make_simple_wcs
 
 
 @pytest.fixture(scope='session', name='wcs')

--- a/regions/shapes/tests/test_line.py
+++ b/regions/shapes/tests/test_line.py
@@ -1,19 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from numpy.testing import assert_allclose
+import astropy.units as u
 import numpy as np
 import pytest
-
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.tests.helper import assert_quantity_allclose
-import astropy.units as u
 from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
+from numpy.testing import assert_allclose
 
+from ..._utils.optional_deps import HAS_MATPLOTLIB
 from ...core import PixCoord, RegionMeta, RegionVisual
 from ...tests.helpers import make_simple_wcs
-from ..._utils.optional_deps import HAS_MATPLOTLIB
 from ..line import LinePixelRegion, LineSkyRegion
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 

--- a/regions/shapes/tests/test_masks.py
+++ b/regions/shapes/tests/test_masks.py
@@ -7,11 +7,11 @@ import itertools
 import astropy.units as u
 import pytest
 
-from ...core import PixCoord, RegionMask
-from ...shapes.circle import CirclePixelRegion
-from ...shapes.ellipse import EllipsePixelRegion
-from ...shapes.polygon import PolygonPixelRegion
-from ...shapes.rectangle import RectanglePixelRegion
+from regions.core import PixCoord, RegionMask
+from regions.shapes.circle import CirclePixelRegion
+from regions.shapes.ellipse import EllipsePixelRegion
+from regions.shapes.polygon import PolygonPixelRegion
+from regions.shapes.rectangle import RectanglePixelRegion
 
 REGIONS = [CirclePixelRegion(PixCoord(3.981987, 4.131378), radius=3.3411),
            EllipsePixelRegion(PixCoord(5.981987, 4.131378), width=10.4466,

--- a/regions/shapes/tests/test_masks.py
+++ b/regions/shapes/tests/test_masks.py
@@ -10,8 +10,8 @@ import pytest
 from ...core import PixCoord, RegionMask
 from ...shapes.circle import CirclePixelRegion
 from ...shapes.ellipse import EllipsePixelRegion
-from ...shapes.rectangle import RectanglePixelRegion
 from ...shapes.polygon import PolygonPixelRegion
+from ...shapes.rectangle import RectanglePixelRegion
 
 REGIONS = [CirclePixelRegion(PixCoord(3.981987, 4.131378), radius=3.3411),
            EllipsePixelRegion(PixCoord(5.981987, 4.131378), width=10.4466,

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -9,11 +9,12 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
 from numpy.testing import assert_allclose
 
-from ..._utils.optional_deps import HAS_MATPLOTLIB
-from ...core import PixCoord, RegionMeta, RegionVisual
-from ...tests.helpers import make_simple_wcs
-from ..point import PointPixelRegion, PointSkyRegion
-from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
+from regions._utils.optional_deps import HAS_MATPLOTLIB
+from regions.core import PixCoord, RegionMeta, RegionVisual
+from regions.shapes.point import PointPixelRegion, PointSkyRegion
+from regions.shapes.tests.test_common import (BaseTestPixelRegion,
+                                              BaseTestSkyRegion)
+from regions.tests.helpers import make_simple_wcs
 
 
 @pytest.fixture(scope='session', name='wcs')

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -1,18 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import astropy.units as u
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
-
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
-import astropy.units as u
 from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
+from numpy.testing import assert_allclose
 
+from ..._utils.optional_deps import HAS_MATPLOTLIB
 from ...core import PixCoord, RegionMeta, RegionVisual
 from ...tests.helpers import make_simple_wcs
-from ..._utils.optional_deps import HAS_MATPLOTLIB
 from ..point import PointPixelRegion, PointSkyRegion
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -189,7 +189,7 @@ class TestPolygonSkyRegion(BaseTestSkyRegion):
 class TestRegionPolygonPixelRegion(BaseTestPixelRegion):
     meta = RegionMeta({'text': 'test'})
     visual = RegionVisual({'color': 'blue'})
-    reg = RegularPolygonPixelRegion(PixCoord(50, 50), 8, 20, angle=25*u.deg,
+    reg = RegularPolygonPixelRegion(PixCoord(50, 50), 8, 20, angle=25 * u.deg,
                                     meta=meta, visual=visual)
     inside = [(40, 40)]
     outside = [(20, 20), (80, 90)]

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -1,20 +1,20 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from copy import copy
-import numpy as np
-from numpy.testing import assert_allclose, assert_equal
-import pytest
 
-from astropy.coordinates import SkyCoord
 import astropy.units as u
+import numpy as np
+import pytest
+from astropy.coordinates import SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
+from numpy.testing import assert_allclose, assert_equal
 
-from ...core import PixCoord, RegionMeta, RegionVisual, RegionBoundingBox
-from ...tests.helpers import make_simple_wcs
 from ..._utils.examples import make_example_dataset
 from ..._utils.optional_deps import HAS_MATPLOTLIB
-from ..polygon import (PolygonPixelRegion, RegularPolygonPixelRegion,
-                       PolygonSkyRegion)
+from ...core import PixCoord, RegionBoundingBox, RegionMeta, RegionVisual
+from ...tests.helpers import make_simple_wcs
+from ..polygon import (PolygonPixelRegion, PolygonSkyRegion,
+                       RegularPolygonPixelRegion)
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 
 

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -9,13 +9,14 @@ from astropy.coordinates import SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_allclose, assert_equal
 
-from ..._utils.examples import make_example_dataset
-from ..._utils.optional_deps import HAS_MATPLOTLIB
-from ...core import PixCoord, RegionBoundingBox, RegionMeta, RegionVisual
-from ...tests.helpers import make_simple_wcs
-from ..polygon import (PolygonPixelRegion, PolygonSkyRegion,
-                       RegularPolygonPixelRegion)
-from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
+from regions._utils.examples import make_example_dataset
+from regions._utils.optional_deps import HAS_MATPLOTLIB
+from regions.core import PixCoord, RegionBoundingBox, RegionMeta, RegionVisual
+from regions.shapes.polygon import (PolygonPixelRegion, PolygonSkyRegion,
+                                    RegularPolygonPixelRegion)
+from regions.shapes.tests.test_common import (BaseTestPixelRegion,
+                                              BaseTestSkyRegion)
+from regions.tests.helpers import make_simple_wcs
 
 
 @pytest.fixture(scope='session', name='wcs')

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -142,7 +142,7 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
 
         region = self.reg.copy(angle=0 * u.deg)
 
-        selector = region.as_mpl_selector(ax, callback=update_mask, sync=sync)  # noqa
+        selector = region.as_mpl_selector(ax, callback=update_mask, sync=sync)
 
         do_event(selector, 'press', xdata=7.3, ydata=4.4, button=1)
         do_event(selector, 'onmove', xdata=9.3, ydata=5.4, button=1)

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -232,7 +232,7 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
 
     @pytest.mark.parametrize('userargs',
                              ({'useblit': True},
-                              {'grab_range': 20, 'minspanx': 5,  'minspany': 4},
+                              {'grab_range': 20, 'minspanx': 5, 'minspany': 4},
                               {'props': {'facecolor': 'blue', 'linewidth': 2}},
                               {'twit': 'gumby'}))
     def test_mpl_selector_kwargs(self, userargs):

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -1,19 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import numpy as np
-from numpy.testing import assert_allclose, assert_equal
-import pytest
-
 import astropy.units as u
+import numpy as np
+import pytest
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
+from numpy.testing import assert_allclose, assert_equal
 
+from ..._utils.optional_deps import HAS_MATPLOTLIB, MPL_VERSION
 from ...core import PixCoord, RegionMeta, RegionVisual
 from ...tests.helpers import make_simple_wcs
-from ..._utils.optional_deps import HAS_MATPLOTLIB, MPL_VERSION
 from ..rectangle import RectanglePixelRegion, RectangleSkyRegion
 from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
 
@@ -177,7 +176,8 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
         """Test dragging of entire region from central handle and anywhere."""
 
         plt = pytest.importorskip('matplotlib.pyplot')
-        from matplotlib.testing.widgets import do_event  # click_and_drag  # MPL_VERSION >= 36
+        from matplotlib.testing.widgets import (
+            do_event)  # click_and_drag  # MPL_VERSION >= 36
 
         data = np.random.random((16, 16))
         mask = np.zeros_like(data)

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -10,11 +10,12 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
 from numpy.testing import assert_allclose, assert_equal
 
-from ..._utils.optional_deps import HAS_MATPLOTLIB, MPL_VERSION
-from ...core import PixCoord, RegionMeta, RegionVisual
-from ...tests.helpers import make_simple_wcs
-from ..rectangle import RectanglePixelRegion, RectangleSkyRegion
-from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
+from regions._utils.optional_deps import HAS_MATPLOTLIB, MPL_VERSION
+from regions.core import PixCoord, RegionMeta, RegionVisual
+from regions.shapes.rectangle import RectanglePixelRegion, RectangleSkyRegion
+from regions.shapes.tests.test_common import (BaseTestPixelRegion,
+                                              BaseTestSkyRegion)
+from regions.tests.helpers import make_simple_wcs
 
 
 @pytest.fixture(scope='session', name='wcs')

--- a/regions/shapes/tests/test_text.py
+++ b/regions/shapes/tests/test_text.py
@@ -1,13 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import astropy.units as u
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
-
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
-import astropy.units as u
 from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
+from numpy.testing import assert_allclose
 
 from ...core import PixCoord, RegionMeta, RegionVisual
 from ...tests.helpers import make_simple_wcs

--- a/regions/shapes/tests/test_text.py
+++ b/regions/shapes/tests/test_text.py
@@ -8,10 +8,11 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
 from numpy.testing import assert_allclose
 
-from ...core import PixCoord, RegionMeta, RegionVisual
-from ...tests.helpers import make_simple_wcs
-from ..text import TextPixelRegion, TextSkyRegion
-from .test_common import BaseTestPixelRegion, BaseTestSkyRegion
+from regions.core import PixCoord, RegionMeta, RegionVisual
+from regions.shapes.tests.test_common import (BaseTestPixelRegion,
+                                              BaseTestSkyRegion)
+from regions.shapes.text import TextPixelRegion, TextSkyRegion
+from regions.tests.helpers import make_simple_wcs
 
 
 @pytest.fixture(scope='session', name='wcs')

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -3,10 +3,10 @@
 This module defines text regions in both pixel and sky coordinates.
 """
 
-from .point import PointPixelRegion, PointSkyRegion
-from ..core.attributes import (ScalarPixCoord, ScalarSkyCoord,
-                               RegionMetaDescr, RegionVisualDescr)
 from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
+from ..core.attributes import (RegionMetaDescr, RegionVisualDescr,
+                               ScalarPixCoord, ScalarSkyCoord)
+from .point import PointPixelRegion, PointSkyRegion
 
 __all__ = ['TextSkyRegion', 'TextPixelRegion']
 

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -3,10 +3,10 @@
 This module defines text regions in both pixel and sky coordinates.
 """
 
-from .._utils.wcs_helpers import pixel_scale_angle_at_skycoord
-from ..core.attributes import (RegionMetaDescr, RegionVisualDescr,
-                               ScalarPixCoord, ScalarSkyCoord)
-from .point import PointPixelRegion, PointSkyRegion
+from regions._utils.wcs_helpers import pixel_scale_angle_at_skycoord
+from regions.core.attributes import (RegionMetaDescr, RegionVisualDescr,
+                                     ScalarPixCoord, ScalarSkyCoord)
+from regions.shapes.point import PointPixelRegion, PointSkyRegion
 
 __all__ = ['TextSkyRegion', 'TextPixelRegion']
 

--- a/regions/tests/__init__.py
+++ b/regions/tests/__init__.py
@@ -1,4 +1,0 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""
-This packages contains affiliated package tests.
-"""

--- a/regions/tests/helpers.py
+++ b/regions/tests/helpers.py
@@ -1,14 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import astropy.units as u
+import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
-import astropy.units as u
 from astropy.wcs import WCS
-import numpy as np
-
 from numpy.testing import assert_allclose
 
-from ..core import Region, PixCoord
+from ..core import PixCoord, Region
 
 
 def make_simple_wcs(skycoord, resolution, size):

--- a/regions/tests/helpers.py
+++ b/regions/tests/helpers.py
@@ -7,7 +7,7 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy.wcs import WCS
 from numpy.testing import assert_allclose
 
-from ..core import PixCoord, Region
+from regions.core import PixCoord, Region
 
 
 def make_simple_wcs(skycoord, resolution, size):

--- a/setup.py
+++ b/setup.py
@@ -73,10 +73,10 @@ except Exception:
 
 # Import these after the above checks to ensure they are printed even if
 # extensions_helpers is not installed
-import os  # noqa
+import os  # noqa: E402
 
-from extension_helpers import get_extensions  # noqa
-from setuptools import setup  # noqa
+from extension_helpers import get_extensions  # noqa: E402
+from setuptools import setup  # noqa: E402
 
 setup(use_scm_version={'write_to': os.path.join('regions', 'version.py'),
                        'write_to_template': VERSION_TEMPLATE},

--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,9 @@ except Exception:
 # Import these after the above checks to ensure they are printed even if
 # extensions_helpers is not installed
 import os  # noqa
-from setuptools import setup  # noqa
+
 from extension_helpers import get_extensions  # noqa
+from setuptools import setup  # noqa
 
 setup(use_scm_version={'write_to': os.path.join('regions', 'version.py'),
                        'write_to_template': VERSION_TEMPLATE},


### PR DESCRIPTION
This PR makes the following changes to keep up with astropy core:
- uses `isort` to sort imports
- uses absolute imports (except for `__init__.py` files)
- adds codes to blank # noqa (and removes unnecessary # noqa)
- misc PEP8 fixes