### PR TITLE
Fix rectangle rotation corners test due to numpy sin/cos changes

### DIFF
--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -41,8 +41,8 @@ def test_corners():
     reg = RectanglePixelRegion(PixCoord(xc, yc), width=width, height=height,
                                angle=90 * u.deg)
     # simple case: rotate by 90
-    np.testing.assert_array_equal([(2.5, 1.), (2.5, 3.), (1.5, 3.), (1.5, 1.)],
-                                  reg.corners)
+    np.testing.assert_allclose([(2.5, 1.), (2.5, 3.), (1.5, 3.), (1.5, 1.)],
+                               reg.corners)
 
     reg = RectanglePixelRegion(center=PixCoord(xc, yc), width=width,
                                height=height, angle=0 * u.deg)


### PR DESCRIPTION
Due to an upstream change in numpy dev in the `sin` and `cos` functions (https://github.com/numpy/numpy/pull/23399), `np.sin(np.pi / 2)` no longer exactly equals 1.0.  👀 

This PR changes the test to use `allclose` instead of `equal`.

This should fix the currently-failing `devdeps` CI test.