### PR TITLE
TST: Update URL for Scientific Python nightlies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ indexserver =
 # Suppress display of matplotlib plots generated during docs build
 setenv =
     MPLBACKEND=agg
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 
 # Pass through the following environment variables which may be needed
 # for the CI


### PR DESCRIPTION
Scientific Python packages have moved their nightly wheels to a new location. xref astropy/astropy#14869

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.