### PR TITLE
Update Actions workflows

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -1,10 +1,23 @@
-name: Cron Tests
+name: Daily Cron Tests
 
 on:
   schedule:
     # run at 6am UTC on Tue-Fri (complete tests are run every Monday)
     - cron: '0 6 * * 2-5'
+  pull_request:
+    # We also want this workflow triggered if the 'Daily CI' label is added
+    # or present when PR is updated
+    types:
+      - synchronize
+      - labeled
+  push:
+    tags:
+      - '*'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   TOXARGS: '-v'
@@ -13,7 +26,8 @@ permissions:
   contents: read
 
 jobs:
-  cron-test:
+  tests:
+    if: (github.repository == 'astropy/regions' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Daily CI')))
     name: ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow_failure }}
@@ -27,13 +41,13 @@ jobs:
 
           - os: ubuntu-latest
             python: '3.11'
-            tox_env: 'py311-test-alldeps-devdeps'
+            tox_env: 'py311-test-devdeps'
             toxposargs: --remote-data=any
             allow_failure: false
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -1,0 +1,125 @@
+name: Weekly Cron Tests
+
+on:
+  schedule:
+    # run every Monday at 5am UTC
+    - cron: '0 5 * * 1'
+  pull_request:
+    # We also want this workflow triggered if the 'Weekly CI' label is added
+    # or present when PR is updated
+    types:
+      - synchronize
+      - labeled
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TOXARGS: '-v'
+  IS_CRON: 'true'
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    if: (github.repository == 'astropy/regions' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Weekly CI')))
+    name: ${{ matrix.os }}, ${{ matrix.tox_env }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow_failure }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python: '3.11'
+            tox_env: 'py311-test-alldeps-devinfra'
+            allow_failure: false
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install base dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+      - name: Print Python, pip, setuptools, and tox versions
+        run: |
+          python -c "import sys; print(f'Python {sys.version}')"
+          python -c "import pip; print(f'pip {pip.__version__}')"
+          python -c "import setuptools; print(f'setuptools {setuptools.__version__}')"
+          python -c "import tox; print(f'tox {tox.__version__}')"
+      - name: Run tests
+        run: tox -e ${{ matrix.tox_env }} -- ${{ matrix.toxposargs }}
+
+
+  test_more_architectures:
+    # The following architectures are emulated and are therefore slow, so
+    # we include them just in the weekly cron. These also serve as a test
+    # of using system libraries and using pytest directly.
+
+    runs-on: ubuntu-20.04
+    name: More architectures
+    if: (github.repository == 'astropy/regions' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Arch CI')))
+    env:
+      ARCH_ON_CI: ${{ matrix.arch }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+          - arch: s390x
+          - arch: ppc64le
+          - arch: armv7
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: uraimo/run-on-arch-action@v2
+        name: Run tests
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ubuntu_rolling
+
+          shell: /bin/bash
+          env: |
+            ARCH_ON_CI: ${{ env.ARCH_ON_CI }}
+            IS_CRON: ${{ env.IS_CRON }}
+
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y git \
+                                  g++ \
+                                  pkg-config \
+                                  python3 \
+                                  python3-configobj \
+                                  python3-numpy \
+                                  python3-astropy \
+                                  python3-ply \
+                                  python3-venv \
+                                  cython3 \
+                                  libwcs7 \
+                                  wcslib-dev \
+                                  liberfa1
+
+          run: |
+            echo "LONG_BIT="$(getconf LONG_BIT)
+            python3 -m venv --system-site-packages tests
+            source tests/bin/activate
+            ASTROPY_USE_SYSTEM_ALL=1 pip3 install -e .[test]
+            pip3 list
+            python3 -m pytest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -106,7 +106,7 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311}-test{,-alldeps,-devdeps,-oldestdeps}{,-cov}
+    py{38,39,310,311}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
     py{38,39,310,311}-test-numpy{118,119,120,121,122,123}
     py{38,39,310,311}-test-astropy{50,lts}
     build_docs
@@ -41,6 +41,7 @@ description =
     run tests
     alldeps: with all optional dependencies
     devdeps: with the latest developer version of key dependencies
+    devinfra: like devdeps but also dev version of infrastructure
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
     numpy118: with numpy 1.18.*
@@ -78,6 +79,15 @@ deps =
     devdeps: numpy>=0.0.dev0
     devdeps: matplotlib>=0.0.dev0
     devdeps: astropy>=0.0.dev0
+
+    # Latest developer version of infrastructure packages.
+    devinfra: git+https://github.com/pytest-dev/pytest.git
+    devinfra: git+https://github.com/astropy/extension-helpers.git
+    devinfra: git+https://github.com/astropy/pytest-doctestplus.git
+    devinfra: git+https://github.com/astropy/pytest-remotedata.git
+    devinfra: git+https://github.com/astropy/pytest-astropy-header.git
+    devinfra: git+https://github.com/astropy/pytest-filter-subpackage.git
+    devinfra: git+https://github.com/astropy/pytest-astropy.git
 
 # The following indicates which extras_require from setup.cfg will be
 # installed


### PR DESCRIPTION
Bumps actions/checkout from v3 to v4.  Update the daily cron workflow and adds a weekly cron workflow (with other architechtures), which can be also be run on PRs with the "Daily CI", "Weekly CI", and "Arch CI" labels.