### PR TITLE
Remove unused array_compare tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ norecursedirs = [
 astropy_header = true
 doctest_plus = 'enabled'
 text_file_format = 'rst'
-addopts = '--color=yes --doctest-rst'
+addopts = '--color=yes --doctest-rst --arraydiff'
 xfail_strict = true
 remote_data_strict = true
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ namespaces = false
 'regions' = [
     'CITATION.rst',
 ]
-'regions.shape.tests' = [
+'regions.shapes.tests' = [
     'reference/*.txt',
     'data/*.fits',
 ]

--- a/regions/shapes/tests/test_masks.py
+++ b/regions/shapes/tests/test_masks.py
@@ -42,7 +42,7 @@ def label(value):
                         for key, value in sorted(value.items()))
 
 
-@pytest.mark.array_compare(fmt='text', write_kwargs={'fmt': '%12.8e'})
+@pytest.mark.array_compare(file_format='text', write_kwargs={'fmt': '%12.8e'})
 @pytest.mark.parametrize(('region', 'mode'),
                          itertools.product(REGIONS, MODES), ids=label)
 def test_to_mask(region, mode):

--- a/regions/shapes/tests/test_masks.py
+++ b/regions/shapes/tests/test_masks.py
@@ -51,3 +51,4 @@ def test_to_mask(region, mode):
     except NotImplementedError:
         pytest.xfail()
     assert isinstance(mask, RegionMask)
+    return mask.data.astype(float)


### PR DESCRIPTION
In pytest >7.2 test functions can only return `None`.
Followup to https://github.com/astropy/regions/pull/480