### PR TITLE
MNT: Drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,12 +31,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.8'
-            tox_env: 'py38-test-alldeps'
-            allow_failure: false
-            prefix: ''
-
-          - os: ubuntu-latest
             python: '3.9'
             tox_env: 'py39-test-alldeps'
             allow_failure: false
@@ -92,8 +86,8 @@ jobs:
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.8'
-            tox_env: 'py38-test-alldeps-astropylts-numpy118'
+            python: '3.9'
+            tox_env: 'py39-test-alldeps-astropylts-numpy122'
             allow_failure: false
             prefix: ''
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,6 @@ jobs:
       test_command: pytest -p no:warnings --pyargs regions
       targets: |
         # Linux wheels
-        - cp38-manylinux_x86_64
         - cp39-manylinux_x86_64
         - cp310-manylinux_x86_64
         - cp311-manylinux_x86_64
@@ -48,23 +47,15 @@ jobs:
         # MacOS X wheels
         # Note that the arm64 wheels are not actually tested so we rely
         # on local manual testing of these to make sure they are ok.
-        - cp38*macosx_x86_64
         - cp39*macosx_x86_64
         - cp310*macosx_x86_64
         - cp311*macosx_x86_64
 
-        - cp38*macosx_arm64
         - cp39*macosx_arm64
         - cp310*macosx_arm64
         - cp311*macosx_arm64
 
         # Windows wheels
-        - cp38*win32
-        - cp39*win32
-        - cp310*win32
-        - cp311*win32
-
-        - cp38*win_amd64
         - cp39*win_amd64
         - cp310*win_amd64
         - cp311*win_amd64

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     rev: v3.10.1
     hooks:
       - id: pyupgrade
-        args: ["--py38-plus"]
+        args: ["--py39-plus"]
         exclude: ".*(extern.*)$"
 
   - repo: https://github.com/pycqa/isort

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@
 General
 -------
 
+- The minimum required Python is now 3.9. [#517]
+
+- The minimum required NumPy is now 1.22. [#517]
+
+- The minimum required Matplotlib is now 3.5. [#517]
+
 New Features
 ------------
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,9 +7,9 @@ Requirements
 
 Regions has the following strict requirements:
 
-* `Python <https://www.python.org/>`_ 3.8 or later
+* `Python <https://www.python.org/>`_ 3.9 or later
 
-* `Numpy <https://numpy.org/>`_ 1.18 or later
+* `Numpy <https://numpy.org/>`_ 1.22 or later
 
 * `Astropy`_ 5.0 or later
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,16 +9,16 @@ Regions has the following strict requirements:
 
 * `Python <https://www.python.org/>`_ 3.9 or later
 
-* `Numpy <https://numpy.org/>`_ 1.22 or later
+* `NumPy <https://numpy.org/>`_ 1.22 or later
 
 * `Astropy`_ 5.0 or later
 
 Region also optionally depends on other packages for some features:
 
-* `matplotlib <https://matplotlib.org/>`_ 3.1 or later
+* `Matplotlib <https://matplotlib.org/>`_ 3.5 or later
 
 Regions depends on `pytest-astropy
-<https://github.com/astropy/pytest-astropy>`_ (0.4 or later) and
+<https://github.com/astropy/pytest-astropy>`_ (0.10 or later) and
 `pytest-arraydiff <https://github.com/astropy/pytest-arraydiff>`_ (0.3
 or later) to run the test suite.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ documentation = 'https://astropy-regions.readthedocs.io/en/stable/'
 
 [project.optional-dependencies]
 all = [
-    'matplotlib>=3.1',
+    'matplotlib>=3.5',
     'shapely',
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,9 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Astronomy',
 ]
 dynamic = ['version']
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 dependencies = [
-    'numpy>=1.18',
+    'numpy>=1.22',
     'astropy>=5.0',
 ]
 


### PR DESCRIPTION
Per [NEP-0029](https://numpy.org/neps/nep-0029-deprecation_policy.html), "On Apr 14, 2023 drop support for Python 3.8 (initially released on Oct 14, 2019)".

Also following NEP 29, the minimum required Numpy is now 1.22:
Per [NEP-0029](https://numpy.org/neps/nep-0029-deprecation_policy.html), "On Jun 23, 2023 drop support for NumPy 1.21 (initially released on Jun 22, 2021)".

Also, `numpy` stopped building wheels for 32-bit systems starting with `numpy 1.22`, so we no longer build those 32-bit wheels.

This PR also updates the minimum version of matplotlib to 3.5.