### PR TITLE
Remove deepcopy of itertools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 requires = ['setuptools',
-            'setuptools_scm',
-            'wheel',
-            'cython>=0.29.30',
-            'oldest-supported-numpy',
+            'setuptools_scm>=6.2',
+            'cython==0.29.36',
+            'numpy<1.26.0b1; python_version<"3.12"',
+            'numpy>=1.26.0b1; python_version>="3.12"',
             'extension-helpers']
 build-backend = 'setuptools.build_meta'
 

--- a/regions/io/ds9/core.py
+++ b/regions/io/ds9/core.py
@@ -15,6 +15,14 @@ from regions.shapes import (CircleAnnulusPixelRegion, CircleAnnulusSkyRegion,
 __all__ = []
 
 
+def make_region_template():
+    return itertools.chain(('coord', 'coord'), itertools.cycle(('length',)))
+
+
+def make_polygon_template():
+    return itertools.cycle(('coord',))
+
+
 # mappings from DS9 frames to astropy coordinates frames
 ds9_frame_map = {'image': 'image',
                  'icrs': 'icrs',
@@ -56,14 +64,11 @@ ds9_shape_to_region['sky'] = sky_map
 ds9_params_template = {'point': ('coord', 'coord'),
                        'text': ('coord', 'coord'),
                        'circle': ('coord', 'coord', 'length'),
-                       'ellipse': itertools.chain(
-                           ('coord', 'coord'), itertools.cycle(('length',))),
-                       'box': itertools.chain(
-                           ('coord', 'coord'), itertools.cycle(('length',))),
-                       'polygon': itertools.cycle(('coord',)),
                        'line': ('coord', 'coord', 'coord', 'coord'),
-                       'annulus': itertools.chain(
-                           ('coord', 'coord'), itertools.cycle(('length',)))}
+                       'ellipse': make_region_template(),
+                       'annulus': make_region_template(),
+                       'box': make_region_template(),
+                       'polygon': make_polygon_template()}
 
 
 # mapping from regions shapes to ds9 shape formats

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -3,7 +3,6 @@
 import re
 import string
 import warnings
-from copy import deepcopy
 from dataclasses import dataclass
 
 import astropy.units as u
@@ -14,7 +13,8 @@ from astropy.utils.exceptions import AstropyUserWarning
 from regions.core import PixCoord, RegionMeta, Regions, RegionVisual
 from regions.core.registry import RegionsRegistry
 from regions.io.ds9.core import (DS9ParserError, ds9_frame_map,
-                                 ds9_params_template, ds9_shape_to_region)
+                                 ds9_params_template, ds9_shape_to_region,
+                                 make_region_template)
 from regions.io.ds9.meta import _split_raw_metadata, _translate_ds9_to_visual
 
 __all__ = []
@@ -543,8 +543,8 @@ def _parse_shape_params(region_data):
         n_annulus = nparams - 3
 
     if shape in ('ellipse', 'box', 'annulus'):
-        # deepcopy to "reset" the cycle iterators
-        shape_template = deepcopy(ds9_params_template[shape])
+        # reset the cycle iterators
+        shape_template = make_region_template()
     else:
         shape_template = ds9_params_template[shape]
 


### PR DESCRIPTION
This is deprecated in Python 3.12.