### PR TITLE
Use single quotes for consistency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-added-large-files
         # Prevent giant files from being committed.
@@ -54,7 +54,7 @@ repos:
         # Enforce that all noqa annotations always occur with specific codes.
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.11.1
+    rev: v3.15.0
     hooks:
       - id: pyupgrade
         args: ["--py39-plus"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,8 @@ repos:
         # source.
       - id: detect-private-key
         # Checks for the existence of private keys.
+      - id: double-quote-string-fixer
+        # Replace double-quoted strings with single-quoted strings.
       - id: end-of-file-fixer
         # Makes sure files end in a newline and only a newline.
         exclude: ".*(svg.*|extern.*|pkl.*|reg.*)$"

--- a/dev/regions_parse.py
+++ b/dev/regions_parse.py
@@ -21,7 +21,7 @@ def cli():
 
 @cli.command('list-files')
 def list_files():
-    print("Available files")
+    print('Available files')
     for ffile in TEST_FILE_DIR.glob('*.reg'):
         print(ffile.parts[-1])
 

--- a/dev/regions_pyregion_comparison.py
+++ b/dev/regions_pyregion_comparison.py
@@ -27,7 +27,7 @@ from regions import DS9RegionParserError, read_ds9
 TEST_FILE_DIR = Path('../regions/io/ds9/tests/data')
 REPETITIONS = 1
 
-p_region_count = re.compile(r"[^=\)]\(")
+p_region_count = re.compile(r'[^=\)]\(')
 
 results = list()
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,7 +166,7 @@ nitpick_ignore = []
 nitpick_filename = 'nitpick-exceptions.txt'
 if os.path.isfile(nitpick_filename):
     for line in open(nitpick_filename):
-        if line.strip() == "" or line.startswith("#"):
+        if line.strip() == '' or line.startswith('#'):
             continue
         dtype, target = line.split(None, 1)
         target = target.strip()

--- a/regions/__init__.py
+++ b/regions/__init__.py
@@ -23,7 +23,7 @@ def _get_bibtex():
         refs = citation.read().split('@software')[1:]
         if len(refs) == 0:
             return ''
-        bibtexreference = f"@software{refs[0]}"
+        bibtexreference = f'@software{refs[0]}'
     return bibtexreference
 
 

--- a/regions/conftest.py
+++ b/regions/conftest.py
@@ -15,7 +15,7 @@ except ImportError:
 
 
 # do not remove until we drop support for NumPy < 2.0
-if minversion(np, "2.0.0.dev0+git20230726"):
+if minversion(np, '2.0.0.dev0+git20230726'):
     np.set_printoptions(legacy='1.25')
 
 

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -38,7 +38,7 @@ class CompoundPixelRegion(PixelRegion):
 
     def __init__(self, region1, region2, operator, meta=None, visual=None):
         if not callable(operator):
-            raise TypeError("operator must be callable")
+            raise TypeError('operator must be callable')
 
         self.region1 = region1
         self.region2 = region2
@@ -220,7 +220,7 @@ class CompoundSkyRegion(SkyRegion):
 
     def __init__(self, region1, region2, operator, meta=None, visual=None):
         if not callable(operator):
-            raise TypeError("operator must be callable")
+            raise TypeError('operator must be callable')
 
         self.region1 = region1
         self.region2 = region2

--- a/regions/io/crtf/io_core.py
+++ b/regions/io/crtf/io_core.py
@@ -205,9 +205,9 @@ class _ShapeList(list):
             if 'range' in shape.meta:
                 shape.meta['range'] = [str(str(x).replace(' ', '')) for x in
                                        shape.meta['range']]
-                meta_str += f", range={shape.meta['range']}".replace("'", "")
+                meta_str += f", range={shape.meta['range']}".replace("'", '')
             if 'corr' in shape.meta:
-                meta_str += f", corr={shape.meta['corr']}".replace("'", "")
+                meta_str += f", corr={shape.meta['corr']}".replace("'", '')
 
             coord = []
             if coordsys not in ['image', 'physical']:
@@ -233,7 +233,7 @@ class _ShapeList(list):
             if shape.region_type == 'polygon':
                 vals = [f'[{x:{fmt}}deg, {y:{fmt}}deg]'
                         for x, y in zip(coord[::2], coord[1::2])]
-                coord = ", ".join(vals)
+                coord = ', '.join(vals)
                 line = crtf_strings['polygon'].format(include, coord)
 
             elif shape.region_type == 'point':
@@ -256,9 +256,9 @@ class _ShapeList(list):
                 line = crtf_strings[shape.region_type].format(include, *coord)
 
             if meta_str.strip():
-                output += f"{line}, {meta_str}\n"
+                output += f'{line}, {meta_str}\n'
             else:
-                output += f"{line}\n"
+                output += f'{line}\n'
 
         return output
 
@@ -446,7 +446,7 @@ class _Shape:
         elif isinstance(coords[0], PixCoord):
             reg = self.shape_to_pixel_region[self.region_type](*coords)
         else:
-            self._raise_error("No central coordinate")
+            self._raise_error('No central coordinate')
 
         reg.visual = RegionVisual()
         reg.meta = RegionMeta()
@@ -454,7 +454,7 @@ class _Shape:
         # both 'text' and 'label' should be set to the same value, where
         # we default to the 'text' value since that is the one used by
         # ds9 regions
-        label = self.meta.get('text', self.meta.get('label', ""))
+        label = self.meta.get('text', self.meta.get('label', ''))
         if label != '':
             reg.meta['label'] = label
         for key in self.meta:

--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -492,7 +492,7 @@ class _CRTFCoordinateParser:
         unit = u.deg
         if len(string_rep.split('.')) >= 3:
             string_rep = string_rep.replace('.', ':', 2)
-        elif string_rep.count(":") == 2:
+        elif string_rep.count(':') == 2:
             unit = u.hour
 
         return Angle(string_rep, unit)

--- a/regions/io/crtf/tests/test_crtf.py
+++ b/regions/io/crtf/tests/test_crtf.py
@@ -86,7 +86,7 @@ def test_valid_region_syntax():
         Regions.parse(reg_str1, format='crtf')
 
     estr = ("Not in proper format: ('2.3arcsec', '4.5arcsec') should be "
-            "a single length")
+            'a single length')
     assert estr in str(excinfo.value)
 
     reg_str2 = ('symbol[[32.1423deg, 12.1412deg], 12deg], linewidth=2, '
@@ -153,8 +153,8 @@ def test_file_crtf(filename, outname, coordsys, fmt):
 
     # since metadata is not required to preserve order, we have to do a more
     # complex comparison
-    desired_lines = [set(line.split(",")) for line in ref_output.split("\n")]
-    actual_lines = [set(line.split(",")) for line in actual_output.split("\n")]
+    desired_lines = [set(line.split(',')) for line in ref_output.split('\n')]
+    actual_lines = [set(line.split(',')) for line in actual_output.split('\n')]
     for split_line in actual_lines:
         assert split_line in desired_lines
 

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -104,8 +104,8 @@ class TestCircleAnnulusSkyRegion(BaseTestSkyRegion):
     def test_copy(self):
         reg = self.reg.copy()
         assert_allclose(reg.center.ra.deg, 3)
-        assert_allclose(reg.inner_radius.to_value("arcsec"), 20)
-        assert_allclose(reg.outer_radius.to_value("arcsec"), 30)
+        assert_allclose(reg.inner_radius.to_value('arcsec'), 20)
+        assert_allclose(reg.outer_radius.to_value('arcsec'), 30)
         assert reg.meta == self.meta
         assert reg.visual == self.visual
 
@@ -159,7 +159,7 @@ class TestEllipseAnnulusPixelRegion(BaseTestPixelRegion):
         assert reg.inner_height == 5
         assert reg.outer_width == 5
         assert reg.outer_height == 8
-        assert_allclose(reg.angle.to_value("deg"), 0)
+        assert_allclose(reg.angle.to_value('deg'), 0)
         assert reg.meta == self.meta
         assert reg.visual == self.visual
 
@@ -189,7 +189,7 @@ class TestEllipseAnnulusPixelRegion(BaseTestPixelRegion):
     def test_rotate(self):
         reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
         assert_allclose(reg.center.xy, (1, 4))
-        assert_allclose(reg.angle.to_value("deg"), 90)
+        assert_allclose(reg.angle.to_value('deg'), 90)
 
     def test_eq(self):
         reg = self.reg.copy()
@@ -225,11 +225,11 @@ class TestEllipseAnnulusSkyRegion(BaseTestSkyRegion):
     def test_copy(self):
         reg = self.reg.copy()
         assert_allclose(reg.center.ra.deg, 3)
-        assert_allclose(reg.inner_width.to_value("arcsec"), 20)
-        assert_allclose(reg.inner_height.to_value("arcsec"), 50)
-        assert_allclose(reg.outer_width.to_value("arcsec"), 50)
-        assert_allclose(reg.outer_height.to_value("arcsec"), 80)
-        assert_allclose(reg.angle.to_value("deg"), 0)
+        assert_allclose(reg.inner_width.to_value('arcsec'), 20)
+        assert_allclose(reg.inner_height.to_value('arcsec'), 50)
+        assert_allclose(reg.outer_width.to_value('arcsec'), 50)
+        assert_allclose(reg.outer_height.to_value('arcsec'), 80)
+        assert_allclose(reg.angle.to_value('deg'), 0)
         assert reg.meta == self.meta
         assert reg.visual == self.visual
 
@@ -313,7 +313,7 @@ class TestRectangleAnnulusPixelRegion(BaseTestPixelRegion):
     def test_rotate(self):
         reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
         assert_allclose(reg.center.xy, (1, 4))
-        assert_allclose(reg.angle.to_value("deg"), 90)
+        assert_allclose(reg.angle.to_value('deg'), 90)
 
     def test_eq(self):
         reg = self.reg.copy()
@@ -349,11 +349,11 @@ class TestRectangleAnnulusSkyRegion(BaseTestSkyRegion):
     def test_copy(self):
         reg = self.reg.copy()
         assert_allclose(reg.center.ra.deg, 3)
-        assert_allclose(reg.inner_width.to_value("arcsec"), 20)
-        assert_allclose(reg.inner_height.to_value("arcsec"), 50)
-        assert_allclose(reg.outer_width.to_value("arcsec"), 50)
-        assert_allclose(reg.outer_height.to_value("arcsec"), 80)
-        assert_allclose(reg.angle.to_value("deg"), 0)
+        assert_allclose(reg.inner_width.to_value('arcsec'), 20)
+        assert_allclose(reg.inner_height.to_value('arcsec'), 50)
+        assert_allclose(reg.outer_width.to_value('arcsec'), 50)
+        assert_allclose(reg.outer_height.to_value('arcsec'), 80)
+        assert_allclose(reg.angle.to_value('deg'), 0)
         assert reg.meta == self.meta
         assert reg.visual == self.visual
 

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -122,11 +122,11 @@ def test_attribute_validation_pixel_regions(region):
     invalid_values = dict(center=[PixCoord([1, 2], [2, 3]), 1,
                                   SkyCoord(1 * u.deg, 2 * u.deg),
                                   (10, 10), (10 * u.deg, 10 * u.deg)],
-                          radius=[u.Quantity("1deg"), [1], PixCoord(1, 2),
+                          radius=[u.Quantity('1deg'), [1], PixCoord(1, 2),
                                   3 * u.km, 0.0, -10.],
                           angle=[u.Quantity([1 * u.deg, 2 * u.deg]), 2,
                                  PixCoord(1, 2), 3 * u.km],
-                          vertices=[u.Quantity("1"), 2, PixCoord(1, 2),
+                          vertices=[u.Quantity('1'), 2, PixCoord(1, 2),
                                     PixCoord([[1, 2]], [[2, 3]]), 3 * u.km,
                                     (10, 10), (10 * u.deg, 10 * u.deg)])
     invalid_values['width'] = invalid_values['radius']
@@ -158,7 +158,7 @@ def test_attribute_validation_sky_regions(region):
                                   1, 3 * u.km, 0.0 * u.deg, -10. * u.deg],
                           angle=[u.Quantity([1 * u.deg, 2 * u.deg]), 2,
                                  SkyCoord(1 * u.deg, 2 * u.deg), 3. * u.km],
-                          vertices=[u.Quantity("1deg"), 2,
+                          vertices=[u.Quantity('1deg'), 2,
                                     SkyCoord(1 * u.deg, 2 * u.deg),
                                     SkyCoord([[1 * u.deg, 2 * u.deg]],
                                              [[2 * u.deg, 3 * u.deg]]),

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -95,7 +95,7 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
     def test_copy(self):
         reg = self.reg.copy()
         assert_allclose(reg.center.ra.deg, 3)
-        assert_allclose(reg.radius.to_value("arcsec"), 2)
+        assert_allclose(reg.radius.to_value('arcsec'), 2)
         assert reg.meta == self.meta
         assert reg.visual == self.visual
 

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -44,7 +44,7 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         assert reg.center.xy == (3, 4)
         assert reg.width == 4
         assert reg.height == 3
-        assert_allclose(reg.angle.to_value("deg"), 5)
+        assert_allclose(reg.angle.to_value('deg'), 5)
         assert reg.meta == self.meta
         assert reg.visual == self.visual
 
@@ -76,7 +76,7 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
     def test_rotate(self):
         reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
         assert_allclose(reg.center.xy, (1, 4))
-        assert_allclose(reg.angle.to_value("deg"), 95)
+        assert_allclose(reg.angle.to_value('deg'), 95)
 
     def test_eq(self):
         reg = self.reg.copy()
@@ -286,9 +286,9 @@ class TestEllipseSkyRegion(BaseTestSkyRegion):
     def test_copy(self):
         reg = self.reg.copy()
         assert_allclose(reg.center.ra.deg, 3)
-        assert_allclose(reg.width.to_value("deg"), 4)
-        assert_allclose(reg.height.to_value("deg"), 3)
-        assert_allclose(reg.angle.to_value("deg"), 5)
+        assert_allclose(reg.width.to_value('deg'), 4)
+        assert_allclose(reg.height.to_value('deg'), 3)
+        assert_allclose(reg.angle.to_value('deg'), 5)
         assert reg.meta == self.meta
         assert reg.visual == self.visual
 

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -73,7 +73,7 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
         assert reg.center.xy == (3, 4)
         assert reg.width == 4
         assert reg.height == 3
-        assert_allclose(reg.angle.to_value("deg"), 5)
+        assert_allclose(reg.angle.to_value('deg'), 5)
         assert reg.meta == self.meta
         assert reg.visual == self.visual
 

--- a/regions/shapes/tests/test_text.py
+++ b/regions/shapes/tests/test_text.py
@@ -25,21 +25,21 @@ def wcs_fixture():
 class TestTextPixelRegion(BaseTestPixelRegion):
     meta = RegionMeta({'text': 'test'})
     visual = RegionVisual({'color': 'blue'})
-    reg = TextPixelRegion(PixCoord(3, 4), "Sample Text", meta=meta,
+    reg = TextPixelRegion(PixCoord(3, 4), 'Sample Text', meta=meta,
                           visual=visual)
     sample_box = [-2, 8, -1, 9]
     inside = []
     outside = [(3.1, 4.2), (5, 4)]
     expected_area = 0
-    expected_repr = ("<TextPixelRegion(center=PixCoord(x=3, y=4), "
+    expected_repr = ('<TextPixelRegion(center=PixCoord(x=3, y=4), '
                      "text='Sample Text')>")
-    expected_str = ("Region: TextPixelRegion\ncenter: PixCoord(x=3, y=4)\n"
+    expected_str = ('Region: TextPixelRegion\ncenter: PixCoord(x=3, y=4)\n'
                     "text: 'Sample Text'")
 
     def test_copy(self):
         reg = self.reg.copy()
         assert reg.center.xy == (3, 4)
-        assert reg.text == "Sample Text"
+        assert reg.text == 'Sample Text'
         assert reg.meta == self.meta
         assert reg.visual == self.visual
 
@@ -71,17 +71,17 @@ class TestTextPixelRegion(BaseTestPixelRegion):
 class TestTextSkyRegion(BaseTestSkyRegion):
     meta = RegionMeta({'text': 'test'})
     visual = RegionVisual({'color': 'blue'})
-    reg = TextSkyRegion(SkyCoord(3, 4, unit='deg'), "Sample Text",
+    reg = TextSkyRegion(SkyCoord(3, 4, unit='deg'), 'Sample Text',
                         meta=meta, visual=visual)
-    expected_repr = ("<TextSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in "
+    expected_repr = ('<TextSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in '
                      "deg\n    (3., 4.)>, text='Sample Text')>")
-    expected_str = ("Region: TextSkyRegion\ncenter: <SkyCoord (ICRS): "
+    expected_str = ('Region: TextSkyRegion\ncenter: <SkyCoord (ICRS): '
                     "(ra, dec) in deg\n    (3., 4.)>\ntext: 'Sample Text'")
 
     def test_copy(self):
         reg = self.reg.copy()
         assert_allclose(reg.center.ra.deg, 3)
-        assert reg.text == "Sample Text"
+        assert reg.text == 'Sample Text'
         assert reg.meta == self.meta
         assert reg.visual == self.visual
 

--- a/regions/tests/helpers.py
+++ b/regions/tests/helpers.py
@@ -21,7 +21,7 @@ def make_simple_wcs(skycoord, resolution, size):
     wcs.wcs.crpix = [crpix, crpix]
     wcs.wcs.cdelt = np.array([-cdelt, cdelt])
     wcs.wcs.crval = [ra, dec]
-    wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
 
     return wcs
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from setuptools import setup  # noqa: E402
+from setuptools import setup
 
-from extension_helpers import get_extensions  # noqa: E402
+from extension_helpers import get_extensions
 
 setup(ext_modules=get_extensions())


### PR DESCRIPTION
This PR adds the `double-quote-string-fixer` hook to pre-commit to replace double-quoted strings with single-quoted strings.