### PR TITLE
Add codespell to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,14 @@ repos:
     hooks:
       - id: yesqa
 
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        args: ["--write-changes",  "--ignore-words-list", "exten"]
+        additional_dependencies:
+          - tomli
+
   # - repo: https://github.com/MarcoGorelli/absolufy-imports
   #   rev: v0.3.1
   #   hooks:

--- a/docs/common_links.txt
+++ b/docs/common_links.txt
@@ -2,7 +2,7 @@
 .. (and docstrings) because they are added to ``docs/conf.py::rst_epilog``.
 
 .. ------------------------------------------------------------------
-.. RST SUBSITUTIONS
+.. RST SUBSTITUTIONS
 
 .. NumPy
 .. |ndarray| replace:: :class:`numpy.ndarray`

--- a/docs/masks.rst
+++ b/docs/masks.rst
@@ -93,7 +93,7 @@ Here are what the region masks produced by different modes look like:
 
 As we've seen above, the :class:`~regions.RegionMask` object has a
 ``data`` attribute that contains a Numpy array with the mask values.
-However, if you have, for example, a small circluar region with a radius
+However, if you have, for example, a small circular region with a radius
 of 3 pixels at a pixel position of (1000, 1000), it would be inefficient
 to store a large mask array that has a size to cover this position (most
 of the mask values would be zero). Instead, we store the mask using

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -310,7 +310,7 @@ def _parse_metadata(metadata_str):
     Returns
     -------
     metadata : dict
-        The reigon metadata as a dictionary.
+        The region metadata as a dictionary.
     """
     # {.*?}    # all chars in curly braces
     # \'.*?\'  # all chars in single quotes


### PR DESCRIPTION
The following words are ignored: 

- "exten" for "extension"