### PR TITLE
Add weekly CI arch tests

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -60,3 +60,70 @@ jobs:
           python -c "import tox; print(f'tox {tox.__version__}')"
       - name: Run tests
         run: tox -e ${{ matrix.tox_env }} -- ${{ matrix.toxposargs }}
+
+
+  test_more_architectures:
+    # The following architectures are emulated and are therefore slow, so
+    # we include them just in the weekly cron. These also serve as a test
+    # of using system libraries and using pytest directly.
+
+    runs-on: ubuntu-20.04
+    name: More architectures
+    if: (github.repository == 'astropy/regions' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Arch CI')))
+    env:
+      ARCH_ON_CI: ${{ matrix.arch }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+          - arch: s390x
+          - arch: ppc64le
+          - arch: armv7
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: uraimo/run-on-arch-action@v2
+        name: Run tests
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ubuntu_rolling
+
+          shell: /bin/bash
+          env: |
+            ARCH_ON_CI: ${{ env.ARCH_ON_CI }}
+            IS_CRON: ${{ env.IS_CRON }}
+
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y --no-install-recommends \
+                                  git \
+                                  g++ \
+                                  pkg-config \
+                                  python3 \
+                                  python3-astropy \
+                                  python3-erfa \
+                                  python3-extension-helpers \
+                                  python3-numpy \
+                                  python3-pytest-astropy \
+                                  python3-setuptools-scm \
+                                  python3-scipy \
+                                  python3-venv \
+                                  python3-wheel \
+                                  wcslib-dev
+
+          run: |
+            uname -a
+            echo "LONG_BIT="$(getconf LONG_BIT)
+            python3 -m venv --system-site-packages tests
+            source tests/bin/activate
+            # cython and pyerfa versions in ubuntu repos are too old currently
+            pip install -U cython
+            pip install -U --no-build-isolation pyerfa
+            ASTROPY_USE_SYSTEM_ALL=1 pip3 install -v --no-build-isolation -e .[test]
+            pip3 list
+            python3 -m pytest


### PR DESCRIPTION
Re-adds the weekly CI arch tests (removed in #537 due to issues installing numpy).