### PR TITLE
BLD: pin extension-helpers to 1.* following upstream recommendation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ requires = [
     'setuptools_scm>=6.2',
     'cython>=3.0.0,<3.1.0',
     'numpy',
-    'extension-helpers',
+    'extension-helpers==1.*',
 ]
 build-backend = 'setuptools.build_meta'
 


### PR DESCRIPTION
Following https://github.com/astropy/extension-helpers/pull/72