### PR TITLE
Remove setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-from setuptools import setup
-
-from extension_helpers import get_extensions
-
-setup(ext_modules=get_extensions())


### PR DESCRIPTION
With the `extension-helpers 1.1.1` release we can finally remove `setup.py`.