### PR TITLE
Recover the boolean mask associated to a region

### DIFF
--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -338,6 +338,26 @@ class PixelRegion(Region):
         """
         raise NotImplementedError
 
+    def to_boolean_array(self, shape):
+        """
+        Return a boolean array of the given shape with the region applied as a mask. In the output array, pixels that are within the region are equal to True and pixels that are outside the region are equal to False.
+
+        Parameters
+        ----------
+        shape : 2-tuple of int
+            The shape of the output array
+
+        Returns
+        -------
+        mask : `~numpy.ndarray` of dtype bool
+            A boolean array of the given shape with True for pixels within the region and False for pixels outside it.
+        """
+
+        if len(shape) != 2:
+            raise ValueError('input shape must have 2 elements.')
+
+        return self.to_mask().to_image(shape).astype(bool)
+
     @staticmethod
     def _validate_mode(mode, subpixels):
         valid_modes = ('center', 'exact', 'subpixels')

--- a/regions/core/regions.py
+++ b/regions/core/regions.py
@@ -278,3 +278,27 @@ class Regions:
         """
         return RegionsRegistry.serialize(self.regions, self.__class__,
                                          format=format, **kwargs)
+
+    def to_boolean_array(self, shape):
+        """
+        Return a boolean array of the given shape with all regions applied as masks. In the output array, pixels that are within the regions are equal to True and pixels that are outside the regions are equal to False.
+
+        Parameters
+        ----------
+        shape : 2-tuple of int
+            The shape of the output array
+
+        Returns
+        -------
+        mask : `~numpy.ndarray` of dtype bool
+            A boolean array of the given shape with True for pixels within the regions and False for pixels outside them.
+        """
+
+        # No need to check for correct shape of parameter 'shape'. This is done for each region individually.
+        # We need to apply a logical_or on all boolean arrays by looping.
+        out_arr = self.regions[0].to_boolean_array(shape)
+
+        for region in self.regions[1:]:
+            out_arr = out_arr | region.to_boolean_array(shape)
+
+        return out_arr


### PR DESCRIPTION
**This pull request is not associated to an issue. The pull request is not ready to be merged yet. Neither tests, nor documentations pages have been created for this pull request yet.**

This request implements a 'to_boolean_array' method in both PixelRegion and Regions classes that allows to transform one or multiple (pixel) regions into a boolean mask given an output array shape. A typical use-case would be to load a ds9 region as a boolean mask and be able to directly apply it to some data with a one-liner.

While it is currently possible to do so using either the bounding box attached to the region or, as implemented here, the to_mask and then to_image methods, this process is currently far from trivial. This pull request proposes to add a method that allows to do so with a single method call. The output boolean array will contain True values for pixels within the region(s) and False for pixels outside.

I implemented the 'to_boolean_array' method in PixelRegion because it seemed the easiest to do but it could probably also be implemented in SkyRegion by using the to_pixel method ?
Also, the 'to_boolean_array' method in the Regions class currently does not check whether the region is a Pixel or Sky one.