### PR TITLE
Update min versions of dependencies

### DIFF
--- a/.github/workflows/ci_cron_daily.yml
+++ b/.github/workflows/ci_cron_daily.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.11'
+            python: '3.12'
             tox_env: 'linkcheck'
             allow_failure: false
             prefix: ''
@@ -68,7 +68,7 @@ jobs:
       run: tox -e ${{ matrix.tox_env }} -- ${{ matrix.toxposargs }}
     - name: Upload coverage to codecov
       if: ${{ contains(matrix.tox_env, '-cov') }}
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         files: ./coverage.xml
         verbose: true

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -37,8 +37,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.11'
-            tox_env: 'py311-test-alldeps-devinfra'
+            python: '3.12'
+            tox_env: 'py312-test-alldeps-devinfra'
             allow_failure: false
 
     steps:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,12 +31,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.9'
-            tox_env: 'py39-test-alldeps'
-            allow_failure: false
-            prefix: ''
-
-          - os: ubuntu-latest
             python: '3.10'
             tox_env: 'py310-test-alldeps'
             allow_failure: false
@@ -44,56 +38,62 @@ jobs:
 
           - os: ubuntu-latest
             python: '3.11'
-            tox_env: 'py311-test-alldeps-cov'
+            tox_env: 'py311-test-alldeps'
+            allow_failure: false
+            prefix: ''
+
+          - os: ubuntu-latest
+            python: '3.12'
+            tox_env: 'py312-test-alldeps-cov'
             toxposargs: --remote-data=any
             allow_failure: false
             prefix: ''
 
           - os: macos-latest
-            python: '3.11'
-            tox_env: 'py311-test-alldeps'
+            python: '3.12'
+            tox_env: 'py312-test-alldeps'
             allow_failure: false
             prefix: ''
 
           - os: macos-14
-            python: '3.11'
-            tox_env: 'py311-test-alldeps'
+            python: '3.12'
+            tox_env: 'py312-test-alldeps'
             allow_failure: false
             prefix: 'M1'
 
           - os: windows-latest
-            python: '3.11'
-            tox_env: 'py311-test-alldeps'
+            python: '3.12'
+            tox_env: 'py312-test-alldeps'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.11'
-            tox_env: 'py311-test'
+            python: '3.12'
+            tox_env: 'py312-test'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.11'
+            python: '3.12'
             tox_env: 'codestyle'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.11'
+            python: '3.12'
             tox_env: 'pep517'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.11'
+            python: '3.12'
             tox_env: 'bandit'
             allow_failure: false
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.9'
-            tox_env: 'py39-test-oldestdeps'
+            python: '3.10'
+            tox_env: 'py310-test-oldestdeps'
             allow_failure: false
             prefix: ''
 
@@ -125,7 +125,7 @@ jobs:
       run: tox -e ${{ matrix.tox_env }} -- ${{ matrix.toxposargs }}
     - name: Upload coverage to codecov
       if: ${{ contains(matrix.tox_env, '-cov') }}
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         files: ./coverage.xml
         verbose: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,6 @@ jobs:
       test_command: pytest -p no:warnings --pyargs regions
       targets: |
         # Linux wheels
-        - cp39-manylinux_x86_64
         - cp310-manylinux_x86_64
         - cp311-manylinux_x86_64
         - cp312-manylinux_x86_64
@@ -51,18 +50,15 @@ jobs:
         # MacOS X wheels
         # Note that the arm64 wheels are not actually tested so we rely
         # on local manual testing of these to make sure they are ok.
-        - cp39*macosx_x86_64
         - cp310*macosx_x86_64
         - cp311*macosx_x86_64
         - cp312*macosx_x86_64
 
-        - cp39*macosx_arm64
         - cp310*macosx_arm64
         - cp311*macosx_arm64
         - cp312*macosx_arm64
 
         # Windows wheels
-        - cp39*win_amd64
         - cp310*win_amd64
         - cp311*win_amd64
         - cp312*win_amd64

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ General
 
 - The minimum required NumPy is now 1.23. [#547]
 
+- The minimum required Astropy is now 5.1. [#547]
+
 - The minimum required pytest-astropy is now 0.11. [#547]
 
 - The minimum required sphinx-astropy is now 1.9. [#547]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,14 @@ General
 
 - Added support for NumPy 2.0.
 
+- The minimum required Python is now 3.10. [#547]
+
+- The minimum required NumPy is now 1.23. [#547]
+
+- The minimum required pytest-astropy is now 0.11. [#547]
+
+- The minimum required sphinx-astropy is now 1.9. [#547]
+
 New Features
 ------------
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,9 +7,9 @@ Requirements
 
 Regions has the following strict requirements:
 
-* `Python <https://www.python.org/>`_ 3.9 or later
+* `Python <https://www.python.org/>`_ 3.10 or later
 
-* `NumPy <https://numpy.org/>`_ 1.22 or later
+* `NumPy <https://numpy.org/>`_ 1.23 or later
 
 * `Astropy`_ 5.0 or later
 
@@ -18,7 +18,7 @@ Region also optionally depends on other packages for some features:
 * `Matplotlib <https://matplotlib.org/>`_ 3.5 or later
 
 Regions depends on `pytest-astropy
-<https://github.com/astropy/pytest-astropy>`_ (0.10 or later) and
+<https://github.com/astropy/pytest-astropy>`_ (0.11 or later) and
 `pytest-arraydiff <https://github.com/astropy/pytest-arraydiff>`_ (0.3
 or later) to run the test suite.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,7 +11,7 @@ Regions has the following strict requirements:
 
 * `NumPy <https://numpy.org/>`_ 1.23 or later
 
-* `Astropy`_ 5.0 or later
+* `Astropy`_ 5.1 or later
 
 Region also optionally depends on other packages for some features:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,9 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Astronomy',
 ]
 dynamic = ['version']
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 dependencies = [
-    'numpy>=1.22',
+    'numpy>=1.23',
     'astropy>=5.0',
 ]
 
@@ -40,11 +40,11 @@ all = [
 ]
 test = [
     'pytest-arraydiff',
-    'pytest-astropy>=0.10',
+    'pytest-astropy>=0.11',
 ]
 docs = [
     'regions[all]',
-    'sphinx-astropy>=1.6',
+    'sphinx-astropy>=1.9',
     'tomli; python_version < "3.11"',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dynamic = ['version']
 requires-python = '>=3.10'
 dependencies = [
     'numpy>=1.23',
-    'astropy>=5.0',
+    'astropy>=5.1',
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{39,310,311,312}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
-    py{39,310,311,312}-test-numpy{122,123,124,125,126}
+    py{310,311,312}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
+    py{310,311,312}-test-numpy{123,124,125,126}
     build_docs
     linkcheck
     codestyle
@@ -40,7 +40,6 @@ description =
     devinfra: like devdeps but also dev version of infrastructure
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy122: with numpy 1.22.*
     numpy123: with numpy 1.23.*
     numpy124: with numpy 1.24.*
     numpy125: with numpy 1.25.*
@@ -51,7 +50,6 @@ description =
 deps =
     cov: pytest-cov
 
-    numpy122: numpy==1.22.*
     numpy123: numpy==1.23.*
     numpy124: numpy==1.24.*
     numpy125: numpy==1.25.*
@@ -60,10 +58,10 @@ deps =
     casa: :NRAO:casatools
     casa: :NRAO:casatasks
 
-    oldestdeps: numpy==1.22
+    oldestdeps: numpy==1.23
     oldestdeps: astropy==5.0
     oldestdeps: matplotlib==3.5
-    oldestdeps: pytest-astropy==0.10
+    oldestdeps: pytest-astropy==0.11
 
     devdeps: numpy>=0.0.dev0
     devdeps: matplotlib>=0.0.dev0

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ deps =
     casa: :NRAO:casatasks
 
     oldestdeps: numpy==1.23
-    oldestdeps: astropy==5.0
+    oldestdeps: astropy==5.1
     oldestdeps: matplotlib==3.5
     oldestdeps: pytest-astropy==0.11
 


### PR DESCRIPTION
Following NEP-29, the minimum supported Python version is 3.10. Also, the minimum NumPy is 1.23.

Other dependencies:

- astropy >= 5.1
- pytest-astropy >= 0.11
- sphinx-astropy >= 1.9
