### PR TITLE
Fix DS9 IO of Text regions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ New Features
 Bug Fixes
 ---------
 
+- Fixed a bug where the text string of ``TextPixelRegion`` and
+  ``TextSkyRegion`` was dropped when serializing or writing
+  to a DS9 file. [#548]
+
 API Changes
 -----------
 

--- a/regions/io/ds9/meta.py
+++ b/regions/io/ds9/meta.py
@@ -186,6 +186,9 @@ def _translate_metadata_to_ds9(region, shape):
     Translate region metadata to valid ds9 meta keys.
     """
     meta = {**region.meta, **region.visual}
+    # special case for Text regions
+    if 'text' in region._params:
+        meta = {'text': region.text, **meta}
 
     if 'annulus' in shape:
         # ds9 does not allow fill for annulus regions

--- a/regions/io/ds9/read.py
+++ b/regions/io/ds9/read.py
@@ -657,10 +657,12 @@ def _make_region(region_data):
 
     regions = []
     for shape_params in region_params:
-        # for Text region, we need to add meta['text'] to params;
-        # set to '' if the text meta value was not specified
+        # for Text region, we need to add meta['text'] to params and
+        # remove it from meta; set to '' if the text meta value was not
+        # specified
         if shape == 'text':
             shape_params.append(region_data.raw_meta.get('text', ''))
+            meta.pop('text', None)
 
         region = ds9_shape_to_region[region_type][shape](*shape_params)
 

--- a/regions/io/ds9/tests/test_ds9.py
+++ b/regions/io/ds9/tests/test_ds9.py
@@ -17,7 +17,8 @@ from numpy.testing import assert_allclose, assert_equal
 from regions._utils.optional_deps import HAS_MATPLOTLIB
 from regions.core import PixCoord, Regions, RegionVisual
 from regions.shapes import (CirclePixelRegion, CircleSkyRegion,
-                            PointPixelRegion, RegularPolygonPixelRegion)
+                            PointPixelRegion, RegularPolygonPixelRegion,
+                            TextPixelRegion)
 from regions.tests.helpers import assert_region_allclose
 
 
@@ -51,6 +52,22 @@ def test_serialize():
                 'circle(42.0000,43.0000,3.0000)\n')
     actual = region.serialize(format='ds9', precision=4)
     assert actual == expected
+
+
+def test_serialize_parse_text():
+    """
+    Test serialization of Text region.
+    """
+    text = 'Example Text'
+    region = TextPixelRegion(PixCoord(42, 43), text=text)
+    expected = ('# Region file format: DS9 astropy/regions\nglobal '
+                f'text={{{text}}}\nimage\ntext(43.0000,44.0000)\n')
+    actual = region.serialize(format='ds9', precision=4)
+    assert actual == expected
+
+    reg = Regions.parse(actual, format='ds9')[0]
+    assert reg.text == text
+    assert 'text' not in reg.meta
 
 
 def test_parse():

--- a/regions/io/ds9/write.py
+++ b/regions/io/ds9/write.py
@@ -157,7 +157,7 @@ def _get_region_params(region, shape_template, precision=8):
 
     param = {}
     for param_name in region._params:
-        if param_name in ('text'):
+        if param_name in ('text',):
             continue
 
         value = getattr(region, param_name)


### PR DESCRIPTION
This PR fixes an issue where writing Text regions (e.g., `TextPixelRegion`) to DS9 would drop the `text` field.  It also fixes an issue in the DS9 file reader/parser to have only one copy of the `text` field in the object instance (i.e., not duplicated in `meta`).