### PR TITLE
Misc infrastructure updates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,8 +43,10 @@ highlight_language = 'python3'
 needs_sphinx = '3.0'
 
 # Extend astropy intersphinx_mapping with packages we use here
-intersphinx_mapping['photutils'] = ('https://photutils.readthedocs.io/en/stable/', None)  # noqa: F405
-# intersphinx_mapping['shapely'] = ('https://shapely.readthedocs.io/en/stable/', None)
+intersphinx_mapping.update(  # noqa: F405
+    {'photutils': ('https://photutils.readthedocs.io/en/stable/', None),
+     # 'shapely': ('https://shapely.readthedocs.io/en/stable/', None),
+     })
 
 # Exclude astropy intersphinx_mapping for unused packages
 del intersphinx_mapping['scipy']  # noqa: F405

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,6 +76,7 @@ package = sys.modules[project]
 version = package.__version__.split('-', 1)[0]
 # The full version, including alpha/beta/rc tags.
 release = package.__version__
+dev = 'dev' in release
 
 # -- Options for HTML output --------------------------------------------------
 # The global astropy configuration uses a custom theme,
@@ -128,6 +129,23 @@ htmlhelp_basename = project + 'doc'
 # Static files to copy after template files
 # html_static_path = ['_static']
 # html_style = 'regions.css'
+
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get('READTHEDOCS_CANONICAL_URL', '')
+
+# A dictionary of values to pass into the template engine's context for
+# all pages.
+html_context = {
+    'default_mode': 'light',
+    'to_be_indexed': ['stable', 'latest'],
+    'is_development': dev,
+    'github_user': 'astropy',
+    'github_repo': 'regions',
+    'github_version': 'main',
+    'doc_path': 'docs',
+    # Tell Jinja2 templates the build is running on Read the Docs
+    'READTHEDOCS': os.environ.get('READTHEDOCS', '') == 'True',
+}
 
 # -- Options for LaTeX output -------------------------------------------------
 # Grouping the document tree into LaTeX files. List of tuples (source

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@
 import os
 import sys
 from datetime import datetime, timezone
+from importlib import metadata
 from pathlib import Path
 
 if sys.version_info < (3, 11):
@@ -32,8 +33,7 @@ except ImportError:
 
 # Get configuration information from pyproject.toml
 with (Path(__file__).parents[1] / 'pyproject.toml').open('rb') as fh:
-    conf = tomllib.load(fh)
-    project_meta = conf['project']
+    project_meta = tomllib.load(fh)['project']
 
 # -- General configuration ----------------------------------------------------
 # By default, highlight as Python 3.
@@ -64,18 +64,15 @@ with open('common_links.txt') as fh:
 # -- Project information ------------------------------------------------------
 project = project_meta['name']
 author = project_meta['authors'][0]['name']
-copyright = f'2015-{datetime.now(tz=timezone.utc).year}, {author}'
+project_copyright = f'2015-{datetime.now(tz=timezone.utc).year}, {author}'
+github_project = 'astropy/regions'
 
 # The version info for the project you're documenting, acts as
 # replacement for |version| and |release|, also used in various other
 # places throughout the built documents.
-__import__(project)
-package = sys.modules[project]
-
+release = metadata.version(project)
 # The short X.Y version.
-version = package.__version__.split('-', 1)[0]
-# The full version, including alpha/beta/rc tags.
-release = package.__version__
+version = '.'.join(release.split('.')[:2])
 dev = 'dev' in release
 
 # -- Options for HTML output --------------------------------------------------
@@ -161,7 +158,6 @@ man_pages = [('index', project.lower(), project + ' Documentation',
               [author], 1)]
 
 # -- Resolving issue number to links in changelog -----------------------------
-github_project = conf['tool']['build-sphinx']['github_project']
 github_issues_url = f'https://github.com/{github_project}/issues/'
 
 # -- Turn on nitpicky mode for sphinx (to warn about references not found) ----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,12 +15,6 @@ package.
 * Code : `GitHub repository`_
 * Contributors : https://github.com/astropy/regions/graphs/contributors
 
-.. warning::
-    This ``regions`` package is still in an early stage of development. It
-    is not yet feature complete but API should be stable enough by now. That said, please
-    have a look and try to use it for your applications. Feedback and
-    contributions are welcome!
-
 
 Getting Started
 ===============

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,9 +151,6 @@ exclude_lines = [
     'def _ipython_key_completions_',
 ]
 
-[tool.build-sphinx]
-github_project = 'astropy/regions'
-
 [tool.isort]
 skip_glob = [
     'regions/*__init__.py*',


### PR DESCRIPTION
This PR updates the RTD settings because they are removing Sphinx context injection at build time. See https://about.readthedocs.com/blog/2024/07/addons-by-default/

It also:

* improves package version info in `docs/conf.py`
* cleans up the intersphinx mapping
* removes the scary warning message on the main docs page