### PR TITLE
CI: adding python 3.13 (and np 2.0) to tox and CI

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -68,8 +68,8 @@ jobs:
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.12'
-            tox_env: 'py312-test'
+            python: '3.13'
+            tox_env: 'py313-test'
             allow_failure: false
             prefix: ''
 
@@ -98,8 +98,8 @@ jobs:
             prefix: ''
 
           - os: ubuntu-latest
-            python: '3.12'
-            tox_env: 'py312-test-devdeps'
+            python: '3.13'
+            tox_env: 'py313-test-devdeps'
             toxposargs: --remote-data=any
             allow_failure: true
             prefix: '(Allowed failure)'

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{310,311,312}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
-    py{310,311,312}-test-numpy{123,124,125,126}
+    py{310,311,312,313}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
+    py{310,311,312,313}-test-numpy{123,124,125,126,200}
     build_docs
     linkcheck
     codestyle
@@ -44,6 +44,7 @@ description =
     numpy124: with numpy 1.24.*
     numpy125: with numpy 1.25.*
     numpy126: with numpy 1.26.*
+    numpy200: with numpy 2.0.*
     casa: with casatools and casatasks
 
 # The following provides some specific pinnings for key packages
@@ -54,6 +55,7 @@ deps =
     numpy124: numpy==1.24.*
     numpy125: numpy==1.25.*
     numpy126: numpy==1.26.*
+    numpy200: numpy==2.0.*
 
     casa: :NRAO:casatools
     casa: :NRAO:casatasks


### PR DESCRIPTION
Tests pass locally, so this should close #566.

Not sure if you would like a changelog entry here, after all, previous release(s) should be likely 3.13 compatible, too.