### PR TITLE
Update docformatter pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,14 +107,14 @@ repos:
     hooks:
       - id: numpydoc-validation
 
-  # temporarily disabled
+  # temporarily use commit from master branch until the next release
   # see https://github.com/PyCQA/docformatter/pull/287
-  # - repo: https://github.com/PyCQA/docformatter
-  #   rev: v1.7.5
-  #   hooks:
-  #     - id: docformatter
-  #       additional_dependencies: [tomli]
-  #       args: [--in-place, --config, ./pyproject.toml]
+  - repo: https://github.com/PyCQA/docformatter
+    rev: 06907d0267368b49b9180eed423fae5697c1e909
+    hooks:
+      - id: docformatter
+        additional_dependencies: [tomli]
+        args: [--in-place, --config, ./pyproject.toml]
 
   # - repo: https://github.com/MarcoGorelli/absolufy-imports
   #   rev: v0.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,12 +107,14 @@ repos:
     hooks:
       - id: numpydoc-validation
 
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.5
-    hooks:
-      - id: docformatter
-        additional_dependencies: [tomli]
-        args: [--in-place, --config, ./pyproject.toml]
+  # temporarily disabled
+  # see https://github.com/PyCQA/docformatter/pull/287
+  # - repo: https://github.com/PyCQA/docformatter
+  #   rev: v1.7.5
+  #   hooks:
+  #     - id: docformatter
+  #       additional_dependencies: [tomli]
+  #       args: [--in-place, --config, ./pyproject.toml]
 
   # - repo: https://github.com/MarcoGorelli/absolufy-imports
   #   rev: v0.3.1


### PR DESCRIPTION
pre-commit 4.0.0 removed language: python_venv, which breaks the docformatter hook.  This PR updates the hook to the fixed version on the `master` branch.  It should be updated for the next `docformatter` release.