### PR TITLE
MNT: Replace ubuntu-20.04 with ubuntu-22.04

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -67,7 +67,7 @@ jobs:
     # we include them just in the weekly cron. These also serve as a test
     # of using system libraries and using pytest directly.
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: More architectures
     if: (github.repository == 'astropy/regions' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Arch CI')))
     env:


### PR DESCRIPTION
As recommended by actions/runner-images#11101 , this PR replaces the deprecated ubuntu-20.04 runner with a newer version. This also replaces RTD workflow, if applicable, to future-proof the build in case it follows suit.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

[:ghost:](https://github.com/pllim/playpen/issues/63)