### PR TITLE
The PR updates redirected URLs and fixes the Sphinx warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -242,11 +242,11 @@ General
   APE 17 guidelines. The main changes are that the ``python setup.py
   test`` and ``python setup.py build_docs`` commands will no longer
   work. The easiest way to replicate these commands is to install the
-  tox (https://tox.readthedocs.io) package and run ``tox -e test`` and
-  ``tox -e build_docs``. It is also possible to run pytest and sphinx
-  directly. Other significant changes include switching to setuptools_scm
-  to manage the version number, and adding a ``pyproject.toml`` to opt in
-  to isolated builds as described in PEP 517/518. [#315]
+  tox package and run ``tox -e test`` and ``tox -e build_docs``. It is
+  also possible to run pytest and sphinx directly. Other significant
+  changes include switching to setuptools_scm to manage the version
+  number, and adding a ``pyproject.toml`` to opt in to isolated builds
+  as described in PEP 517/518. [#315]
 
 - Bump the minimum required version of Astropy to 3.2.
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -19,11 +19,12 @@ stack trace if it is necessary.
 Contributing
 ------------
 
-Like the `Astropy`_ project, this package is made both by and for its
-users. We accept contributions at all levels, spanning the gamut from
-fixing a typo in the documentation to developing a major new feature. We
-welcome contributors who will abide by the `Python Software Foundation
-Code of Conduct <https://www.python.org/psf/conduct/>`_.
+Like the `Astropy`_ project, this package is made both by
+and for its users. We accept contributions at all levels,
+spanning the gamut from fixing a typo in the documentation to
+developing a major new feature. We welcome contributors who
+will abide by the `Python Software Foundation Code of Conduct
+<https://policies.python.org/python.org/code-of-conduct/>`_.
 
 This package follows the same workflow and coding guidelines as
 `Astropy`_. Please read the `Astropy Development documentation

--- a/regions/core/metadata.py
+++ b/regions/core/metadata.py
@@ -50,6 +50,17 @@ class Meta(dict):
         return super().__getitem__(item)
 
     def update(self, *args, **kwargs):
+        """
+        Update the metadata with the input dictionary.
+
+        Parameters
+        ----------
+        *args : dict-like
+            A dictionary or other mapping object to update the metadata.
+
+        **kwargs : dict-like
+            Additional keyword arguments to update the metadata.
+        """
         if args:
             if len(args) > 1:
                 raise ValueError('Only one argument can be input')


### PR DESCRIPTION
Running `linkcheck` or `build_docs` with Python 3.12+ starting giving this warning:

`docstring of regions.core.metadata.Meta.update:1: WARNING: py:class reference target not found: None.  Update D from mapping/iterable E and F. [ref.class]`

The `Meta` class subclasses `dict` and it appears that type hints were added to the `dict.update` method:
```
update(...) method of builtins.dict instance
    D.update([E, ]**F) -> None.  Update D from mapping/iterable E and F.
```
For some reason, Sphinx is reporting the `None` return type reference target is not found.  In this PR, I explicitly add a docstring for the `Meta.update` method, which avoids the warning.