### PR TITLE
Enable limited API builds and bump minimum Python to 3.11

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,14 +31,8 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: '3.10'
-            tox_env: 'py310-test-oldestdeps'
-            allow_failure: false
-            prefix: ''
-
-          - os: ubuntu-latest
-            python: '3.10'
-            tox_env: 'py310-test-alldeps'
+            python: '3.11'
+            tox_env: 'py311-test-oldestdeps'
             allow_failure: false
             prefix: ''
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,6 @@ jobs:
       test_command: pytest -p no:warnings --pyargs regions
       targets: |
         # Linux wheels
-        - cp310-manylinux_x86_64
         - cp311-manylinux_x86_64
         - cp312-manylinux_x86_64
         - cp313-manylinux_x86_64
@@ -51,18 +50,15 @@ jobs:
         # MacOS X wheels
         # Note that the arm64 wheels are not actually tested so we rely
         # on local manual testing of these to make sure they are ok.
-        - cp310*macosx_x86_64
         - cp311*macosx_x86_64
         - cp312*macosx_x86_64
         - cp313*macosx_x86_64
 
-        - cp310*macosx_arm64
         - cp311*macosx_arm64
         - cp312*macosx_arm64
         - cp313*macosx_arm64
 
         # Windows wheels
-        - cp310*win_amd64
         - cp311*win_amd64
         - cp312*win_amd64
         - cp313*win_amd64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,26 +42,10 @@ jobs:
       test_extras: test
       test_command: pytest -p no:warnings --pyargs regions
       targets: |
-        # Linux wheels
-        - cp311-manylinux_x86_64
-        - cp312-manylinux_x86_64
-        - cp313-manylinux_x86_64
-
-        # MacOS X wheels
-        # Note that the arm64 wheels are not actually tested so we rely
-        # on local manual testing of these to make sure they are ok.
-        - cp311*macosx_x86_64
-        - cp312*macosx_x86_64
-        - cp313*macosx_x86_64
-
-        - cp311*macosx_arm64
-        - cp312*macosx_arm64
-        - cp313*macosx_arm64
-
-        # Windows wheels
-        - cp311*win_amd64
-        - cp312*win_amd64
-        - cp313*win_amd64
+        - cp*-manylinux_x86_64
+        - cp*macosx_x86_64
+        - cp*macosx_arm64
+        - cp*win_amd64
 
     secrets:
       pypi_token: ${{ secrets.pypi_token }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,7 +64,7 @@ repos:
     rev: v3.19.1
     hooks:
       - id: pyupgrade
-        args: ["--py310-plus"]
+        args: ["--py311-plus"]
         exclude: ".*(extern.*)$"
 
   - repo: https://github.com/scientific-python/cookie

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,14 +14,10 @@
 
 import os
 import sys
-from datetime import datetime, timezone
+import tomllib
+from datetime import UTC, datetime
 from importlib import metadata
 from pathlib import Path
-
-if sys.version_info < (3, 11):
-    import tomli as tomllib
-else:
-    import tomllib
 
 try:
     from sphinx_astropy.conf.v1 import *  # noqa: F403
@@ -66,7 +62,7 @@ with open('common_links.txt') as fh:
 # -- Project information ------------------------------------------------------
 project = project_meta['name']
 author = project_meta['authors'][0]['name']
-project_copyright = f'2015-{datetime.now(tz=timezone.utc).year}, {author}'
+project_copyright = f'2015-{datetime.now(tz=UTC).year}, {author}'
 github_project = 'astropy/regions'
 
 # The version info for the project you're documenting, acts as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 dynamic = ['version']
 requires-python = '>=3.11'
 dependencies = [
-    'numpy>=1.23',
-    'astropy>=5.1',
+    'numpy>=1.25',
+    'astropy>=6.0',
 ]
 
 [project.urls]
@@ -35,7 +35,7 @@ Documentation = 'https://astropy-regions.readthedocs.io/en/stable/'
 
 [project.optional-dependencies]
 all = [
-    'matplotlib>=3.5',
+    'matplotlib>=3.8',
     'shapely',
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Astronomy',
 ]
 dynamic = ['version']
-requires-python = '>=3.10'
+requires-python = '>=3.11'
 dependencies = [
     'numpy>=1.23',
     'astropy>=5.1',
@@ -52,9 +52,9 @@ docs = [
 requires = [
     'setuptools>=61.2',
     'setuptools_scm>=6.2',
-    'cython>=3.0.0,<3.1.0',
-    'numpy>=2.0.0rc1',
-    'extension-helpers==1.*',
+    'cython>=3.1.0,<3.2.0',
+    'numpy>=2',
+    'extension-helpers>=1.3,<2',
 ]
 build-backend = 'setuptools.build_meta'
 
@@ -253,3 +253,6 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = 'numpy'
+
+[tool.distutils.bdist_wheel]
+py-limited-api = "cp311"

--- a/tox.ini
+++ b/tox.ini
@@ -60,9 +60,9 @@ deps =
     casa: :NRAO:casatools
     casa: :NRAO:casatasks
 
-    oldestdeps: numpy==1.23
-    oldestdeps: astropy==5.1
-    oldestdeps: matplotlib==3.5
+    oldestdeps: numpy==1.25
+    oldestdeps: astropy==6.0
+    oldestdeps: matplotlib==3.8
     oldestdeps: pytest-astropy==0.11
 
     devdeps: numpy>=0.0.dev0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{310,311,312,313}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
-    py{310,311,312,313}-test-numpy{123,124,125,126,200}
+    py{311,312,313}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
+    py{311,312,313}-test-numpy{123,124,125,126,200}
     build_docs
     linkcheck
     codestyle


### PR DESCRIPTION
This enables builds against the limited Python API to make it possible to build a single wheel per platform - the wheel build on Python 3.11 then works for 3.12, 3.13, and future versions. This saves build time and also saves having to build wheels each time a new Python version is updated.

Note that cibuildwheel will still test the wheel on all supported Python 3 versions even though it will only build it on Python 3.11.

For this to work I had to bump the minimum version of Python to 3.11 which is in line with SPEC 0 anyway, and have updated the dependency versions accordingly.