### PR TITLE
Partial revert of limited API builds

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -112,6 +112,18 @@ jobs:
             allow_failure: true
             prefix: '(Allowed failure)'
 
+          - os: macos-latest
+            python: '3.13'
+            tox_env: 'py313-test-alldeps'
+            allow_failure: false
+            prefix: ''
+
+          - os: windows-latest
+            python: '3.13'
+            tox_env: 'py313-test-alldeps'
+            allow_failure: false
+            prefix: ''
+
     steps:
     - name: Check out repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,6 +255,3 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = 'numpy'
-
-[tool.distutils.bdist_wheel]
-py-limited-api = "cp311"


### PR DESCRIPTION
This PR disables the limited API builds introduced in https://github.com/astropy/regions/pull/598 but does not revert the updating of the minimum versions, the updates to the documentation in https://github.com/astropy/regions/pull/601, and also does not split out all the wheel builds again (i.e. does not revert https://github.com/astropy/regions/pull/598/commits/b71cdfb8f911ded0c9d936fe0eb444c3a8181ca9) because all those changes are sensible, and this is a small enough package that we don't need to split out the wheel builds in this way.

I've also added MacOS and Windows Python 3.13 builds to catch this kind of issue in future.