### PR TITLE
Package infrastructure updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,13 +60,6 @@ repos:
       - id: ruff
         args: ["--fix", "--show-fixes"]
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
-    hooks:
-      - id: pyupgrade
-        args: ["--py311-plus"]
-        exclude: ".*(extern.*)$"
-
   - repo: https://github.com/scientific-python/cookie
     rev: 2025.05.02
     hooks:
@@ -88,11 +81,6 @@ repos:
     hooks:
       - id: flake8
         args: ["--ignore", "E501,W503"]
-
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.5.0
-    hooks:
-      - id: yesqa
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
-        args: ["--write-changes",  "--ignore-words-list", "exten"]
+        args: ["--write-changes", "--ignore-words-list", "exten"]
         additional_dependencies:
           - tomli
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ build:
   apt_packages:
     - graphviz
   tools:
-    python: "3.11"
+    python: "3.13"
   jobs:
     post_checkout:
       - git fetch --shallow-since=2022-10-01 || true

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py{311,312,313}-test{,-alldeps,-devdeps,-oldestdeps,-devinfra}{,-cov}
-    py{311,312,313}-test-numpy{123,124,125,126,200}
     build_docs
     linkcheck
     codestyle
@@ -40,37 +39,23 @@ description =
     devinfra: like devdeps but also dev version of infrastructure
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy123: with numpy 1.23.*
-    numpy124: with numpy 1.24.*
-    numpy125: with numpy 1.25.*
-    numpy126: with numpy 1.26.*
-    numpy200: with numpy 2.0.*
     casa: with casatools and casatasks
 
 # The following provides some specific pinnings for key packages
 deps =
     cov: pytest-cov
 
-    numpy123: numpy==1.23.*
-    numpy124: numpy==1.24.*
-    numpy125: numpy==1.25.*
-    numpy126: numpy==1.26.*
-    numpy200: numpy==2.0.*
+    oldestdeps: minimum_dependencies
 
     casa: :NRAO:casatools
     casa: :NRAO:casatasks
-
-    oldestdeps: numpy==1.25
-    oldestdeps: astropy==6.0
-    oldestdeps: matplotlib==3.8
-    oldestdeps: pytest-astropy==0.11
 
     devdeps: numpy>=0.0.dev0
     devdeps: matplotlib>=0.0.dev0
     devdeps: pyerfa>=0.0.dev0
     devdeps: astropy>=0.0.dev0
 
-    # Latest developer version of infrastructure packages.
+    # Latest developer version of infrastructure packages
     devinfra: git+https://github.com/pytest-dev/pytest.git
     devinfra: git+https://github.com/astropy/extension-helpers.git
     devinfra: git+https://github.com/astropy/pytest-doctestplus.git
@@ -91,10 +76,11 @@ install_command =
     !devdeps: python -I -m pip install
     devdeps: python -I -m pip install -v --pre
 
+commands_pre =
+    oldestdeps: minimum_dependencies regions --filename requirements-min.txt
+    oldestdeps: pip install -r requirements-min.txt
+
 commands =
-    # Force numpy-dev after matplotlib downgrades it
-    # (https://github.com/matplotlib/matplotlib/issues/26847)
-    devdeps: python -m pip install --pre --upgrade --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
     pip freeze
     pytest --pyargs regions {toxinidir}/docs \
     cov: --cov regions --cov-config={toxinidir}/pyproject.toml --cov-report xml:{toxinidir}/coverage.xml \


### PR DESCRIPTION
* Updates tox config; now uses `minimum_dependencies` for `oldestdeps`
* Update RTD to use 3.13
* Removes unnecessary pre-commit hooks (covered by ruff)