### PR TITLE
Re-enable Limited API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,3 +255,6 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = 'numpy'
+
+[tool.distutils.bdist_wheel]
+py-limited-api = "cp311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
 requires = [
     'setuptools >= 77.0',
     'setuptools_scm >= 8.0',
-    'cython >= 3.1.0,<4',
+    'cython >= 3.1.2,<4',
     'numpy >= 2.0.0',
     'extension-helpers >= 1.3,<2',
 ]


### PR DESCRIPTION
This re-enables the limited API now that Cython 3.1.2 is out.

Since last time, we also have Python 3.13 builds on MacOS X and Windows, but @larrybradley feel free to also check locally that everything works fine.