### PR TITLE
Do not build free-threaded wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,10 @@ on:
       - '!*post*'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,14 +43,14 @@ jobs:
       test_command: pytest -p no:warnings --pyargs regions
       targets: |
         # Linux wheels
-        - cp*-manylinux_x86_64
+        - cp3*-manylinux_x86_64
 
         # MacOS X wheels
-        - cp*macosx_x86_64
-        - cp*macosx_arm64
+        - cp3*-macosx_x86_64
+        - cp3*-macosx_arm64
 
         # Windows wheels
-        - cp*win_amd64
+        - cp3*-win_amd64
 
       # Developer wheels
       upload_to_anaconda: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,10 @@ exclude_dirs = ['*/tests/test_casa_mask.py']
 [tool.bandit.assert_used]
 skips = ['*_test.py', '*/test_*.py', '*/tests/helpers.py']
 
+[tool.cibuildwheel]
+# explicitly skip free-threaded builds
+skip = ["cp314t-*"]
+
 [tool.repo-review]
 ignore = [
     'MY',  # ignore MyPy


### PR DESCRIPTION
`cibuildwheel` v3.1.0 now builds free-threaded wheels by default, so we need to exclude them.