### PR TITLE
Fix Arch CI in weekly cron tests

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -122,8 +122,8 @@ jobs:
             echo "LONG_BIT="$(getconf LONG_BIT)
             python3 -m venv --system-site-packages tests
             source tests/bin/activate
-            # cython and pyerfa versions in ubuntu repos are too old currently
-            pip install -U cython
+            # update older versions
+            pip install -U cython setuptools packaging
             pip install -U --no-build-isolation pyerfa
             ASTROPY_USE_SYSTEM_ALL=1 pip3 install -v --no-build-isolation -e .[test]
             pip3 list


### PR DESCRIPTION
The weekly cron tests are currently failing due to outdated versions of setuptools and packaging.