### PR TITLE
Fix pytest10 non-Collection iterable deprecation

### DIFF
--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -3,7 +3,6 @@
 The tests in this file simply check what functionality is currently
 implemented and doesn't check anything about correctness.
 """
-import itertools
 from collections import OrderedDict
 
 import astropy.units as u
@@ -89,9 +88,8 @@ def test_pix_to_sky(region):
         pytest.xfail()
 
 
-@pytest.mark.parametrize(('region', 'mode'),
-                         itertools.product(PIXEL_REGIONS, MASK_MODES),
-                         ids=ids_func)
+@pytest.mark.parametrize('region', PIXEL_REGIONS, ids=ids_func)
+@pytest.mark.parametrize('mode', MASK_MODES, ids=ids_func)
 def test_pix_to_mask(region, mode):
     try:
         mask = region.to_mask(mode=mode)

--- a/regions/shapes/tests/test_masks.py
+++ b/regions/shapes/tests/test_masks.py
@@ -3,8 +3,6 @@
 This file sets up detailed tests for computing masks with reference
 images.
 """
-import itertools
-
 import astropy.units as u
 import pytest
 
@@ -44,8 +42,8 @@ def label(value):
 
 
 @pytest.mark.array_compare(file_format='text', write_kwargs={'fmt': '%12.8e'})
-@pytest.mark.parametrize(('region', 'mode'),
-                         itertools.product(REGIONS, MODES), ids=label)
+@pytest.mark.parametrize('region', REGIONS, ids=label)
+@pytest.mark.parametrize('mode', MODES, ids=label)
 def test_to_mask(region, mode):
     try:
         mask = region.to_mask(**mode)


### PR DESCRIPTION
This fixes a deprecation warning for pytest 10 (dev) that was causing the weekly CI builds to fail.
https://github.com/astropy/regions/actions/runs/19623973639/job/56189360592