### PR TITLE
Add as_ellipse keyword to circle to_sky and to_pixel methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,14 @@ New Features
   more accurate transformations for directed regions such as ellipses and
   rectangles. [#650, #651]
 
+- Added an ``as_ellipse`` keyword to the ``to_pixel`` and ``to_sky``
+  methods of circular and circular annulus region classes that allows
+  the user to specify whether to return an elliptical region instead of
+  a circular region when converting between pixel and sky coordinates.
+  This is useful for cases where the WCS is distorted or has different
+  pixel scales along different axes and the circular region would be
+  significantly distorted in pixel or sky coordinates. [#652]
+
 - Improved the string representations of all ``Regions`` and ``Region``
   objects. [#653]
 

--- a/regions/_utils/tests/test_wcs_helpers.py
+++ b/regions/_utils/tests/test_wcs_helpers.py
@@ -16,8 +16,10 @@ from regions._utils.wcs_helpers import (compute_local_wcs_jacobian,
                                         jacobian_sky_to_pixel_mean_scale,
                                         pixel_shape_to_sky_svd,
                                         pixel_to_sky_mean_scale,
+                                        pixel_to_sky_svd_scales,
                                         sky_shape_to_pixel_svd,
                                         sky_to_pixel_mean_scale,
+                                        sky_to_pixel_svd_scales,
                                         wcs_pixel_scale_angle)
 from regions.tests.helpers import WCS_CDELT_ARCSEC, WCS_CENTER
 
@@ -716,3 +718,222 @@ class TestFlippedParityWCS:
         assert_allclose(rw, sky_w, rtol=1e-6)
         assert_allclose(rh, sky_h, rtol=1e-6)
         assert_allclose(ra.rad, sky_a, rtol=1e-4)
+
+
+def _make_sheared_wcs():
+    """
+    Build an anisotropic, sheared (non-orthogonal CD matrix) TAN WCS.
+
+    The unequal, non-orthogonal CD terms make the local Jacobian both
+    anisotropic and rotated, so the SVD principal axes have a nontrivial
+    orientation. This exercises the angle convention of the scale
+    helpers.
+    """
+    wcs = APWCS(naxis=2)
+    wcs.wcs.crpix = [50, 50]
+    wcs.wcs.crval = [WCS_CENTER.ra.deg, WCS_CENTER.dec.deg]
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    wcs.wcs.cd = np.array([[-0.0008, 0.0003],
+                           [0.0002, 0.0005]])
+    return wcs
+
+
+def _project_pixel_circle_to_sky_tangent(pixcoord, wcs, radius_pix,
+                                         npts=720):
+    """
+    Project a pixel circle boundary to tangent-plane sky offsets.
+
+    The boundary points of a pixel circle are converted to sky
+    coordinates and expressed as tangent-plane offsets (``xi`` = East,
+    ``eta`` = North) in arcsec relative to the circle center, using
+    great-circle separation and position angle. This is an independent
+    ground truth for the sky image of a pixel circle.
+    """
+    theta = np.linspace(0, 2 * np.pi, npts, endpoint=False)
+    cx, cy = pixcoord
+    x = cx + radius_pix * np.cos(theta)
+    y = cy + radius_pix * np.sin(theta)
+    center = wcs.pixel_to_world(cx, cy)
+    pts = wcs.pixel_to_world(x, y)
+    arcsec_per_rad = 3600.0 * np.degrees(1)
+    sep = center.separation(pts).rad
+    posang = center.position_angle(pts).rad
+    xi = sep * np.sin(posang) * arcsec_per_rad
+    eta = sep * np.cos(posang) * arcsec_per_rad
+    return np.asarray(xi, dtype=float), np.asarray(eta, dtype=float)
+
+
+def _sky_ellipse_implicit_residual(xi, eta, width, height, pa_rad):
+    """
+    Evaluate the implicit sky-ellipse equation in the tangent plane.
+
+    The major axis (of full length ``width``) is at position angle
+    ``pa_rad`` measured from North (``eta``) toward East (``xi``).
+    Points exactly on the ellipse boundary yield 1.
+    """
+    cos_pa = np.cos(pa_rad)
+    sin_pa = np.sin(pa_rad)
+    p_major = xi * sin_pa + eta * cos_pa
+    p_minor = xi * cos_pa - eta * sin_pa
+    return (p_major / (width / 2)) ** 2 + (p_minor / (height / 2)) ** 2
+
+
+class TestSVDScales:
+    """
+    Tests for `sky_to_pixel_svd_scales` and `pixel_to_sky_svd_scales`.
+    """
+
+    def test_sky_to_pixel_return_types(self, simple_wcs):
+        """
+        Should return (tuple, float, float, Angle).
+        """
+        center, smaj, smin, angle = sky_to_pixel_svd_scales(
+            WCS_CENTER, simple_wcs)
+        assert isinstance(center, tuple)
+        assert isinstance(smaj, (float, np.floating))
+        assert isinstance(smin, (float, np.floating))
+        assert isinstance(angle, Angle)
+
+    def test_pixel_to_sky_return_types(self, simple_wcs, center_xy_coord):
+        """
+        Should return (SkyCoord, float, float, Angle).
+        """
+        center, smaj, smin, angle = pixel_to_sky_svd_scales(
+            center_xy_coord, simple_wcs)
+        assert isinstance(center, SkyCoord)
+        assert isinstance(smaj, (float, np.floating))
+        assert isinstance(smin, (float, np.floating))
+        assert isinstance(angle, Angle)
+
+    def test_sky_to_pixel_simple_isotropic(self, simple_wcs):
+        """
+        For a non-distorted, square-pixel WCS the two scale factors are
+        equal and match 1 / WCS_CDELT_ARCSEC (pixels per arcsec).
+        """
+        _, smaj, smin, angle = sky_to_pixel_svd_scales(
+            WCS_CENTER, simple_wcs)
+        expected = 1.0 / WCS_CDELT_ARCSEC
+        assert_allclose(smaj, expected, rtol=1e-6)
+        assert_allclose(smin, expected, rtol=1e-6)
+        assert 0.0 <= angle.deg < 360.0
+
+    def test_pixel_to_sky_simple_isotropic(self, simple_wcs, center_xy_coord):
+        """
+        For a non-distorted, square-pixel WCS the two scale factors are
+        equal and match WCS_CDELT_ARCSEC (arcsec per pixel).
+        """
+        _, smaj, smin, angle = pixel_to_sky_svd_scales(
+            center_xy_coord, simple_wcs)
+        assert_allclose(smaj, WCS_CDELT_ARCSEC, rtol=1e-6)
+        assert_allclose(smin, WCS_CDELT_ARCSEC, rtol=1e-6)
+        assert 0.0 <= angle.deg < 360.0
+
+    def test_sky_to_pixel_nonsquare_anisotropic(self, nonsquare_wcs):
+        """
+        For non-square pixels the major scale exceeds the minor scale,
+        and both match the inverse of the corresponding pixel scales.
+        """
+        _, smaj, smin, _ = sky_to_pixel_svd_scales(WCS_CENTER, nonsquare_wcs)
+        assert smaj > smin
+        # cdelt = [-0.03, 0.05] deg; pixels/arcsec = 1 / (cdelt_arcsec)
+        assert_allclose(smaj, 1.0 / (0.03 * 3600), rtol=1e-5)
+        assert_allclose(smin, 1.0 / (0.05 * 3600), rtol=1e-5)
+
+    def test_pixel_to_sky_nonsquare_anisotropic(self, nonsquare_wcs):
+        """
+        For non-square pixels the major scale exceeds the minor scale,
+        and both match the corresponding pixel scales (arcsec/pixel).
+        """
+        center, smaj, smin, _ = pixel_to_sky_svd_scales((9.5, 9.5),
+                                                        nonsquare_wcs)
+        assert isinstance(center, SkyCoord)
+        assert smaj > smin
+        assert_allclose(smaj, 0.05 * 3600, rtol=1e-5)
+        assert_allclose(smin, 0.03 * 3600, rtol=1e-5)
+
+    def test_scales_descending(self, sip_wcs):
+        """
+        The returned scales are singular values in descending order, so
+        the major scale is always >= the minor scale.
+        """
+        _, smaj_s, smin_s, _ = sky_to_pixel_svd_scales(WCS_CENTER, sip_wcs)
+        _, smaj_p, smin_p, _ = pixel_to_sky_svd_scales((9.5, 9.5), sip_wcs)
+        assert smaj_s >= smin_s
+        assert smaj_p >= smin_p
+
+    @pytest.mark.parametrize('wcs_name', ['rotated_wcs', 'flipped_wcs'])
+    def test_sky_to_pixel_matches_projection(self, wcs_name, request):
+        """
+        A circular sky region converted with the SVD scales must match
+        the true projection of the sky circle boundary, including the
+        correct major-axis orientation and parity.
+        """
+        wcs = request.getfixturevalue(wcs_name)
+        radius = 5.0  # arcsec
+        center, smaj, smin, pixel_angle = sky_to_pixel_svd_scales(
+            WCS_CENTER, wcs)
+        x, y = _project_sky_ellipse_boundary(
+            WCS_CENTER, wcs, radius, radius, 0.0)
+        resid = _ellipse_implicit_residual(
+            x, y, center, 2 * radius * smaj, 2 * radius * smin,
+            pixel_angle.rad)
+        assert_allclose(resid, 1.0, atol=1e-3)
+
+    def test_sky_to_pixel_matches_projection_sheared(self):
+        """
+        For an anisotropic, sheared WCS the projected sky circle is an
+        ellipse whose principal axes and orientation must match the SVD
+        scales and pixel angle.
+        """
+        wcs = _make_sheared_wcs()
+        radius = 20.0  # arcsec
+        center, smaj, smin, pixel_angle = sky_to_pixel_svd_scales(
+            WCS_CENTER, wcs)
+        assert smaj > smin
+        x, y = _project_sky_ellipse_boundary(
+            WCS_CENTER, wcs, radius, radius, 0.0)
+        resid = _ellipse_implicit_residual(
+            x, y, center, 2 * radius * smaj, 2 * radius * smin,
+            pixel_angle.rad)
+        assert_allclose(resid, 1.0, atol=2e-3)
+
+    def test_pixel_to_sky_matches_projection_sheared(self):
+        """
+        For an anisotropic, sheared WCS the sky image of a pixel circle
+        is an ellipse whose principal axes and position angle must match
+        the SVD scales and sky angle.
+        """
+        wcs = _make_sheared_wcs()
+        pixcoord = (50.0, 50.0)
+        radius_pix = 10.0
+        _, smaj, smin, sky_angle = pixel_to_sky_svd_scales(pixcoord, wcs)
+        assert smaj > smin
+        xi, eta = _project_pixel_circle_to_sky_tangent(
+            pixcoord, wcs, radius_pix)
+        resid = _sky_ellipse_implicit_residual(
+            xi, eta, 2 * radius_pix * smaj, 2 * radius_pix * smin,
+            sky_angle.rad)
+        assert_allclose(resid, 1.0, atol=2e-3)
+
+    def test_inverse_scale_consistency(self):
+        """
+        The singular values of the Jacobian and its inverse are
+        reciprocals, so the pixel-to-sky major (minor) scale equals the
+        reciprocal of the sky-to-pixel minor (major) scale.
+        """
+        wcs = _make_sheared_wcs()
+        center_pix, smaj_p, smin_p, _ = sky_to_pixel_svd_scales(
+            WCS_CENTER, wcs)
+        _, smaj_s, smin_s, _ = pixel_to_sky_svd_scales(center_pix, wcs)
+        assert_allclose(smaj_s, 1.0 / smin_p, rtol=1e-6)
+        assert_allclose(smin_s, 1.0 / smaj_p, rtol=1e-6)
+
+    def test_angles_wrapped(self):
+        """
+        Both helpers return angles wrapped to [0, 360) degrees.
+        """
+        wcs = _make_sheared_wcs()
+        _, _, _, pixel_angle = sky_to_pixel_svd_scales(WCS_CENTER, wcs)
+        _, _, _, sky_angle = pixel_to_sky_svd_scales((50.0, 50.0), wcs)
+        assert 0.0 <= pixel_angle.deg < 360.0
+        assert 0.0 <= sky_angle.deg < 360.0

--- a/regions/_utils/wcs_helpers.py
+++ b/regions/_utils/wcs_helpers.py
@@ -604,6 +604,128 @@ def sky_shape_to_pixel_svd(skycoord, wcs, width_arcsec, height_arcsec,
     return center, pixel_width, pixel_height, pixel_angle
 
 
+def sky_to_pixel_svd_scales(skycoord, wcs):
+    """
+    Compute the pixel center, principal-axis scale factors, and pixel
+    angle for a sky-to-pixel conversion using SVD of the local Jacobian.
+
+    Uses the singular value decomposition (SVD) of the local Jacobian
+    ``J = d(pixel)/d(sky_arcsec)`` to find the natural principal axes
+    of the WCS transformation at the given sky position. The singular
+    values give the scale factors along the major and minor axes of the
+    ellipse that a unit circle in sky space maps to in pixel space. The
+    left singular vectors give the directions of those axes in pixel
+    coordinates.
+
+    This is the appropriate method for converting a circular sky region
+    to a pixel ellipse, as the resulting ellipse accurately represents
+    the true shape of the WCS mapping (i.e., the tightest-fitting pixel
+    ellipse that contains the sky circle).
+
+    Parameters
+    ----------
+    skycoord : `~astropy.coordinates.SkyCoord`
+        The sky coordinate of the region center.
+
+    wcs : WCS object
+        A world coordinate system (WCS) transformation that
+        supports the `astropy shared interface for WCS
+        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.,
+        `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
+
+    Returns
+    -------
+    center : tuple of float
+        The ``(x, y)`` pixel center position.
+
+    scale_major : float
+        The scale factor along the major (maximum-stretch) axis
+        (pixels per arcsec).
+
+    scale_minor : float
+        The scale factor along the minor (minimum-stretch) axis
+        (pixels per arcsec).
+
+    pixel_angle : `~astropy.coordinates.Angle`
+        The pixel rotation angle of the major axis, measured
+        counterclockwise from the positive x-axis, wrapped to
+        [0, 360) degrees.
+    """
+    center, jacobian, _ = _sky_to_pixel_jacobian(skycoord, wcs)
+    u_mat, s_vals, _vt = np.linalg.svd(jacobian)
+
+    # Pixel angle of the major axis: direction of u_mat[:, 0] in pixel
+    # space. No parity correction is needed because pixel space has no
+    # axis reflection.
+    pixel_angle = Angle(
+        np.rad2deg(np.arctan2(u_mat[1, 0], u_mat[0, 0])) * u.deg,
+    ).wrap_at(360 * u.deg)
+
+    return center, s_vals[0], s_vals[1], pixel_angle
+
+
+def pixel_to_sky_svd_scales(pixcoord, wcs):
+    """
+    Compute the sky center, principal-axis scale factors, and sky angle
+    for a pixel-to-sky conversion using SVD of the inverse Jacobian.
+
+    Uses the singular value decomposition (SVD) of the local inverse
+    Jacobian ``J^{-1} = d(sky)/d(pixel)`` to find the natural principal
+    axes of the WCS transformation at the given pixel position. The
+    singular values give the scale factors along the major and minor
+    axes of the ellipse that a unit circle in pixel space maps to in sky
+    space. The left singular vectors give the directions of those axes
+    in tangent-plane coordinates.
+
+    This is the appropriate method for converting a circular pixel
+    region to a sky ellipse, as the resulting ellipse accurately
+    represents the true shape of the WCS mapping (i.e., the
+    tightest-fitting sky ellipse that contains the pixel circle).
+
+    Parameters
+    ----------
+    pixcoord : tuple of float
+        The ``(x, y)`` pixel coordinate of the region center.
+
+    wcs : WCS object
+        A world coordinate system (WCS) transformation that
+        supports the `astropy shared interface for WCS
+        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.,
+        `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
+
+    Returns
+    -------
+    center : `~astropy.coordinates.SkyCoord`
+        The sky center position.
+
+    scale_major : float
+        The scale factor along the major (maximum-stretch) axis
+        (arcsec per pixel).
+
+    scale_minor : float
+        The scale factor along the minor (minimum-stretch) axis
+        (arcsec per pixel).
+
+    sky_angle : `~astropy.coordinates.Angle`
+        The sky position angle (PA) of the major axis, measured
+        counterclockwise from North (the latitude/Dec axis), wrapped to
+        [0, 360) degrees.
+    """
+    center, _, jacobian_inv, _ = _pixel_to_sky_jacobian(pixcoord, wcs)
+    u_mat, s_vals, _vt = np.linalg.svd(jacobian_inv)
+
+    # Sky position angle (PA) of the major axis, measured from North
+    # (eta/Dec) toward East (xi/RA). The columns of u_mat are
+    # tangent-plane vectors with components (xi=East, eta=North), so the
+    # PA is arctan2(xi, eta). The inverse Jacobian already encodes the
+    # WCS parity, so no manual parity correction is needed here.
+    sky_angle = Angle(
+        np.rad2deg(np.arctan2(u_mat[0, 0], u_mat[1, 0])) * u.deg,
+    ).wrap_at(360 * u.deg)
+
+    return center, s_vals[0], s_vals[1], sky_angle
+
+
 def wcs_pixel_scale_angle(skycoord, wcs):
     """
     Calculate the pixel coordinate, scale, and WCS rotation angle at the

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -11,8 +11,10 @@ import astropy.units as u
 
 from regions._utils.wcs_helpers import (pixel_shape_to_sky_svd,
                                         pixel_to_sky_mean_scale,
+                                        pixel_to_sky_svd_scales,
                                         sky_shape_to_pixel_svd,
-                                        sky_to_pixel_mean_scale)
+                                        sky_to_pixel_mean_scale,
+                                        sky_to_pixel_svd_scales)
 from regions.core.attributes import (PositiveScalar, PositiveScalarAngle,
                                      RegionMetaDescr, RegionVisualDescr,
                                      ScalarAngle, ScalarPixCoord,
@@ -192,7 +194,47 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
         return self._component_class(self.center, self.outer_radius,
                                      self.meta, self.visual)
 
-    def to_sky(self, wcs):
+    def to_sky(self, wcs, *, use_ellipse=False):
+        """
+        Return a sky region from this pixel region.
+
+        Parameters
+        ----------
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that
+            supports the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_
+            (e.g., `astropy.wcs.WCS`).
+
+        use_ellipse : bool, optional
+            If `True`, return an `~regions.EllipseAnnulusSkyRegion`
+            instead of a `~regions.CircleAnnulusSkyRegion`. An ellipse
+            annulus is generally a better approximation when the WCS has
+            distortions or different pixel scales along different axes.
+            Default is `False`.
+
+        Returns
+        -------
+        region : `~regions.CircleAnnulusSkyRegion` or `~regions.EllipseAnnulusSkyRegion`
+            The sky region. An ellipse annulus is returned if
+            ``use_ellipse`` is `True`.
+        """
+        if use_ellipse:
+            center, scale_major, scale_minor, angle = pixel_to_sky_svd_scales(
+                (self.center.x, self.center.y), wcs)
+            inner_width = 2 * self.inner_radius * scale_major * u.arcsec
+            outer_width = 2 * self.outer_radius * scale_major * u.arcsec
+            inner_height = 2 * self.inner_radius * scale_minor * u.arcsec
+            outer_height = 2 * self.outer_radius * scale_minor * u.arcsec
+            # The helper returns a position angle (PA) from North;
+            # regions measures the angle from the RA axis (90 deg
+            # offset).
+            angle = (angle + 90 * u.deg).wrap_at(360 * u.deg)
+            return EllipseAnnulusSkyRegion(
+                center, inner_width, outer_width,
+                inner_height, outer_height, angle=angle,
+                meta=self.meta.copy(), visual=self.visual.copy())
+
         center, mean_scale = pixel_to_sky_mean_scale(
             (self.center.x, self.center.y), wcs)
         inner_radius = self.inner_radius * mean_scale * u.arcsec
@@ -284,7 +326,45 @@ class CircleAnnulusSkyRegion(SkyRegion):
         if inner_radius >= outer_radius:
             raise ValueError('outer_radius must be greater than inner_radius')
 
-    def to_pixel(self, wcs):
+    def to_pixel(self, wcs, *, use_ellipse=False):
+        """
+        Return a pixel region from this sky region.
+
+        Parameters
+        ----------
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that
+            supports the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_
+            (e.g., `astropy.wcs.WCS`).
+
+        use_ellipse : bool, optional
+            If `True`, return an `~regions.EllipseAnnulusPixelRegion`
+            instead of a `~regions.CircleAnnulusPixelRegion`. An ellipse
+            annulus is generally a better approximation when the WCS has
+            distortions or different pixel scales along different axes.
+            Default is `False`.
+
+        Returns
+        -------
+        region : `~regions.CircleAnnulusPixelRegion` or `~regions.EllipseAnnulusPixelRegion`
+            The pixel region. An ellipse annulus is returned if
+            ``use_ellipse`` is `True`.
+        """
+        if use_ellipse:
+            center, scale_major, scale_minor, angle = sky_to_pixel_svd_scales(
+                self.center, wcs)
+            inner_radius_arcsec = self.inner_radius.to(u.arcsec).value
+            outer_radius_arcsec = self.outer_radius.to(u.arcsec).value
+            inner_width = 2 * inner_radius_arcsec * scale_major
+            outer_width = 2 * outer_radius_arcsec * scale_major
+            inner_height = 2 * inner_radius_arcsec * scale_minor
+            outer_height = 2 * outer_radius_arcsec * scale_minor
+            return EllipseAnnulusPixelRegion(
+                PixCoord(*center), inner_width, outer_width,
+                inner_height, outer_height, angle=angle,
+                meta=self.meta.copy(), visual=self.visual.copy())
+
         center, mean_scale = sky_to_pixel_mean_scale(self.center, wcs)
         inner_radius = self.inner_radius.to(u.arcsec).value * mean_scale
         outer_radius = self.outer_radius.to(u.arcsec).value * mean_scale

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -194,7 +194,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
         return self._component_class(self.center, self.outer_radius,
                                      self.meta, self.visual)
 
-    def to_sky(self, wcs, *, use_ellipse=False):
+    def to_sky(self, wcs, *, as_ellipse=False):
         """
         Return a sky region from this pixel region.
 
@@ -206,7 +206,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
             <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_
             (e.g., `astropy.wcs.WCS`).
 
-        use_ellipse : bool, optional
+        as_ellipse : bool, optional
             If `True`, return an `~regions.EllipseAnnulusSkyRegion`
             instead of a `~regions.CircleAnnulusSkyRegion`. An ellipse
             annulus is generally a better approximation when the WCS has
@@ -217,9 +217,9 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
         -------
         region : `~regions.CircleAnnulusSkyRegion` or `~regions.EllipseAnnulusSkyRegion`
             The sky region. An ellipse annulus is returned if
-            ``use_ellipse`` is `True`.
+            ``as_ellipse`` is `True`.
         """
-        if use_ellipse:
+        if as_ellipse:
             center, scale_major, scale_minor, angle = pixel_to_sky_svd_scales(
                 (self.center.x, self.center.y), wcs)
             inner_width = 2 * self.inner_radius * scale_major * u.arcsec
@@ -326,7 +326,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
         if inner_radius >= outer_radius:
             raise ValueError('outer_radius must be greater than inner_radius')
 
-    def to_pixel(self, wcs, *, use_ellipse=False):
+    def to_pixel(self, wcs, *, as_ellipse=False):
         """
         Return a pixel region from this sky region.
 
@@ -338,7 +338,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
             <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_
             (e.g., `astropy.wcs.WCS`).
 
-        use_ellipse : bool, optional
+        as_ellipse : bool, optional
             If `True`, return an `~regions.EllipseAnnulusPixelRegion`
             instead of a `~regions.CircleAnnulusPixelRegion`. An ellipse
             annulus is generally a better approximation when the WCS has
@@ -349,9 +349,9 @@ class CircleAnnulusSkyRegion(SkyRegion):
         -------
         region : `~regions.CircleAnnulusPixelRegion` or `~regions.EllipseAnnulusPixelRegion`
             The pixel region. An ellipse annulus is returned if
-            ``use_ellipse`` is `True`.
+            ``as_ellipse`` is `True`.
         """
-        if use_ellipse:
+        if as_ellipse:
             center, scale_major, scale_minor, angle = sky_to_pixel_svd_scales(
                 self.center, wcs)
             inner_radius_arcsec = self.inner_radius.to(u.arcsec).value

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -91,7 +91,7 @@ class CirclePixelRegion(PixelRegion):
         else:
             return np.logical_not(in_circle)
 
-    def to_sky(self, wcs, *, use_ellipse=False):
+    def to_sky(self, wcs, *, as_ellipse=False):
         """
         Return a sky region from this pixel region.
 
@@ -103,7 +103,7 @@ class CirclePixelRegion(PixelRegion):
             <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_
             (e.g., `astropy.wcs.WCS`).
 
-        use_ellipse : bool, optional
+        as_ellipse : bool, optional
             If `True`, return an `~regions.EllipseSkyRegion` instead
             of a `~regions.CircleSkyRegion`. An ellipse is generally
             a better approximation when the WCS has distortions or
@@ -113,10 +113,10 @@ class CirclePixelRegion(PixelRegion):
         Returns
         -------
         region : `~regions.CircleSkyRegion` or `~regions.EllipseSkyRegion`
-            The sky region. An ellipse is returned if ``use_ellipse``
+            The sky region. An ellipse is returned if ``as_ellipse``
             is `True`.
         """
-        if use_ellipse:
+        if as_ellipse:
             center, scale_major, scale_minor, angle = pixel_to_sky_svd_scales(
                 (self.center.x, self.center.y), wcs)
             width = Angle(2 * self.radius * scale_major, 'arcsec')
@@ -296,7 +296,7 @@ class CircleSkyRegion(SkyRegion):
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
 
-    def to_pixel(self, wcs, *, use_ellipse=False):
+    def to_pixel(self, wcs, *, as_ellipse=False):
         """
         Return a pixel region from this sky region.
 
@@ -308,7 +308,7 @@ class CircleSkyRegion(SkyRegion):
             <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_
             (e.g., `astropy.wcs.WCS`).
 
-        use_ellipse : bool, optional
+        as_ellipse : bool, optional
             If `True`, return an `~regions.EllipsePixelRegion` instead
             of a `~regions.CirclePixelRegion`. An ellipse is generally
             a better approximation when the WCS has distortions or
@@ -318,10 +318,10 @@ class CircleSkyRegion(SkyRegion):
         Returns
         -------
         region : `~regions.CirclePixelRegion` or `~regions.EllipsePixelRegion`
-            The pixel region. An ellipse is returned if ``use_ellipse``
+            The pixel region. An ellipse is returned if ``as_ellipse``
             is `True`.
         """
-        if use_ellipse:
+        if as_ellipse:
             center, scale_major, scale_minor, angle = sky_to_pixel_svd_scales(
                 self.center, wcs)
             radius_arcsec = self.radius.to(u.arcsec).value

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -13,7 +13,9 @@ from regions._geometry import circular_overlap_grid
 from regions._utils.spherical_helpers import (
     get_circle_latitude_tangent_limits, get_circle_longitude_tangent_limits)
 from regions._utils.wcs_helpers import (pixel_to_sky_mean_scale,
-                                        sky_to_pixel_mean_scale)
+                                        pixel_to_sky_svd_scales,
+                                        sky_to_pixel_mean_scale,
+                                        sky_to_pixel_svd_scales)
 from regions.core.attributes import (PositiveScalar, PositiveScalarAngle,
                                      RegionMetaDescr, RegionVisualDescr,
                                      ScalarPixCoord, ScalarSkyCoord)
@@ -22,6 +24,7 @@ from regions.core.core import PixelRegion, SkyRegion, SphericalSkyRegion
 from regions.core.mask import RegionMask
 from regions.core.metadata import RegionMeta, RegionVisual
 from regions.core.pixcoord import PixCoord
+from regions.shapes.ellipse import EllipsePixelRegion, EllipseSkyRegion
 from regions.shapes.polygon import PolygonPixelRegion
 
 __all__ = ['CirclePixelRegion', 'CircleSkyRegion', 'CircleSphericalSkyRegion']
@@ -88,7 +91,44 @@ class CirclePixelRegion(PixelRegion):
         else:
             return np.logical_not(in_circle)
 
-    def to_sky(self, wcs):
+    def to_sky(self, wcs, *, use_ellipse=False):
+        """
+        Return a sky region from this pixel region.
+
+        Parameters
+        ----------
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that
+            supports the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_
+            (e.g., `astropy.wcs.WCS`).
+
+        use_ellipse : bool, optional
+            If `True`, return an `~regions.EllipseSkyRegion` instead
+            of a `~regions.CircleSkyRegion`. An ellipse is generally
+            a better approximation when the WCS has distortions or
+            different pixel scales along different axes. Default is
+            `False`.
+
+        Returns
+        -------
+        region : `~regions.CircleSkyRegion` or `~regions.EllipseSkyRegion`
+            The sky region. An ellipse is returned if ``use_ellipse``
+            is `True`.
+        """
+        if use_ellipse:
+            center, scale_major, scale_minor, angle = pixel_to_sky_svd_scales(
+                (self.center.x, self.center.y), wcs)
+            width = Angle(2 * self.radius * scale_major, 'arcsec')
+            height = Angle(2 * self.radius * scale_minor, 'arcsec')
+            # The helper returns a position angle (PA) from North;
+            # regions measures the angle from the RA axis (90 deg
+            # offset).
+            angle = (angle + 90 * u.deg).wrap_at(360 * u.deg)
+            return EllipseSkyRegion(center, width, height, angle=angle,
+                                    meta=self.meta.copy(),
+                                    visual=self.visual.copy())
+
         center, mean_scale = pixel_to_sky_mean_scale(
             (self.center.x, self.center.y), wcs)
         radius = Angle(self.radius * mean_scale, 'arcsec')
@@ -256,7 +296,41 @@ class CircleSkyRegion(SkyRegion):
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
 
-    def to_pixel(self, wcs):
+    def to_pixel(self, wcs, *, use_ellipse=False):
+        """
+        Return a pixel region from this sky region.
+
+        Parameters
+        ----------
+        wcs : WCS object
+            A world coordinate system (WCS) transformation that
+            supports the `astropy shared interface for WCS
+            <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_
+            (e.g., `astropy.wcs.WCS`).
+
+        use_ellipse : bool, optional
+            If `True`, return an `~regions.EllipsePixelRegion` instead
+            of a `~regions.CirclePixelRegion`. An ellipse is generally
+            a better approximation when the WCS has distortions or
+            different pixel scales along different axes. Default is
+            `False`.
+
+        Returns
+        -------
+        region : `~regions.CirclePixelRegion` or `~regions.EllipsePixelRegion`
+            The pixel region. An ellipse is returned if ``use_ellipse``
+            is `True`.
+        """
+        if use_ellipse:
+            center, scale_major, scale_minor, angle = sky_to_pixel_svd_scales(
+                self.center, wcs)
+            radius_arcsec = self.radius.to(u.arcsec).value
+            width = 2 * radius_arcsec * scale_major
+            height = 2 * radius_arcsec * scale_minor
+            return EllipsePixelRegion(PixCoord(*center), width, height,
+                                      angle=angle, meta=self.meta.copy(),
+                                      visual=self.visual.copy())
+
         center, mean_scale = sky_to_pixel_mean_scale(self.center, wcs)
         radius = self.radius.to(u.arcsec).value * mean_scale
         return CirclePixelRegion(PixCoord(*center), radius,

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -294,6 +294,94 @@ class TestCircleAnnulusSphericalSkyRegion(BaseTestSphericalSkyRegion):
                                            -90 * u.deg + 30 * u.arcsec]))
 
 
+class TestCircleAnnulusPixelRegionToSkyEllipse:
+    """
+    Tests for CircleAnnulusPixelRegion.to_sky with use_ellipse=True.
+    """
+
+    def setup_method(self):
+        self.center = PixCoord(10, 10)
+        self.inner_radius = 3.0
+        self.outer_radius = 5.0
+        self.meta = RegionMeta({'text': 'test'})
+        self.visual = RegionVisual({'color': 'blue'})
+        self.reg = CircleAnnulusPixelRegion(
+            self.center, self.inner_radius, self.outer_radius,
+            meta=self.meta, visual=self.visual)
+        self.wcs = make_simple_wcs(SkyCoord(2 * u.deg, 3 * u.deg),
+                                   0.1 * u.deg, 20)
+
+    def test_to_sky_use_ellipse(self):
+        result = self.reg.to_sky(self.wcs, use_ellipse=True)
+        assert isinstance(result, EllipseAnnulusSkyRegion)
+        assert result.meta == self.meta
+        assert result.visual == self.visual
+
+    def test_to_sky_ellipse_roundtrip(self):
+        sky_ellipse = self.reg.to_sky(self.wcs, use_ellipse=True)
+        pix_ellipse = sky_ellipse.to_pixel(self.wcs)
+        assert_allclose(pix_ellipse.center.x, self.center.x, rtol=1e-5)
+        assert_allclose(pix_ellipse.center.y, self.center.y, rtol=1e-5)
+        assert_allclose(pix_ellipse.inner_width,
+                        2 * self.inner_radius, rtol=1e-4)
+        assert_allclose(pix_ellipse.outer_width,
+                        2 * self.outer_radius, rtol=1e-4)
+        assert_allclose(pix_ellipse.inner_height,
+                        2 * self.inner_radius, rtol=1e-4)
+        assert_allclose(pix_ellipse.outer_height,
+                        2 * self.outer_radius, rtol=1e-4)
+
+    def test_to_sky_use_ellipse_meta_copies(self):
+        result = self.reg.to_sky(self.wcs, use_ellipse=True)
+        result.meta['text'] = 'new'
+        result.visual['color'] = 'green'
+        assert result.meta['text'] != self.reg.meta['text']
+        assert result.visual['color'] != self.reg.visual['color']
+
+
+class TestCircleAnnulusSkyRegionToPixelEllipse:
+    """
+    Tests for CircleAnnulusSkyRegion.to_pixel with use_ellipse=True.
+    """
+
+    def setup_method(self):
+        self.center = SkyCoord(3 * u.deg, 4 * u.deg)
+        self.inner_radius = 20 * u.arcsec
+        self.outer_radius = 30 * u.arcsec
+        self.meta = RegionMeta({'text': 'test'})
+        self.visual = RegionVisual({'color': 'blue'})
+        self.reg = CircleAnnulusSkyRegion(
+            self.center, self.inner_radius, self.outer_radius,
+            meta=self.meta, visual=self.visual)
+        self.wcs = make_simple_wcs(SkyCoord(3 * u.deg, 4 * u.deg),
+                                   5 * u.arcsec, 20)
+
+    def test_to_pixel_use_ellipse(self):
+        result = self.reg.to_pixel(self.wcs, use_ellipse=True)
+        assert isinstance(result, EllipseAnnulusPixelRegion)
+        assert result.meta == self.meta
+        assert result.visual == self.visual
+
+    def test_to_pixel_ellipse_roundtrip(self):
+        pix_ellipse = self.reg.to_pixel(self.wcs, use_ellipse=True)
+        sky_ellipse = pix_ellipse.to_sky(self.wcs)
+        assert_quantity_allclose(sky_ellipse.inner_width,
+                                 2 * self.inner_radius, rtol=1e-4)
+        assert_quantity_allclose(sky_ellipse.outer_width,
+                                 2 * self.outer_radius, rtol=1e-4)
+        assert_quantity_allclose(sky_ellipse.inner_height,
+                                 2 * self.inner_radius, rtol=1e-4)
+        assert_quantity_allclose(sky_ellipse.outer_height,
+                                 2 * self.outer_radius, rtol=1e-4)
+
+    def test_to_pixel_use_ellipse_meta_copies(self):
+        result = self.reg.to_pixel(self.wcs, use_ellipse=True)
+        result.meta['text'] = 'new'
+        result.visual['color'] = 'green'
+        assert result.meta['text'] != self.reg.meta['text']
+        assert result.visual['color'] != self.reg.visual['color']
+
+
 class TestEllipseAnnulusPixelRegion(BaseTestPixelRegion):
     meta = RegionMeta({'text': 'test'})
     visual = RegionVisual({'color': 'blue'})

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -296,7 +296,7 @@ class TestCircleAnnulusSphericalSkyRegion(BaseTestSphericalSkyRegion):
 
 class TestCircleAnnulusPixelRegionToSkyEllipse:
     """
-    Tests for CircleAnnulusPixelRegion.to_sky with use_ellipse=True.
+    Tests for CircleAnnulusPixelRegion.to_sky with as_ellipse=True.
     """
 
     def setup_method(self):
@@ -311,14 +311,14 @@ class TestCircleAnnulusPixelRegionToSkyEllipse:
         self.wcs = make_simple_wcs(SkyCoord(2 * u.deg, 3 * u.deg),
                                    0.1 * u.deg, 20)
 
-    def test_to_sky_use_ellipse(self):
-        result = self.reg.to_sky(self.wcs, use_ellipse=True)
+    def test_to_sky_as_ellipse(self):
+        result = self.reg.to_sky(self.wcs, as_ellipse=True)
         assert isinstance(result, EllipseAnnulusSkyRegion)
         assert result.meta == self.meta
         assert result.visual == self.visual
 
     def test_to_sky_ellipse_roundtrip(self):
-        sky_ellipse = self.reg.to_sky(self.wcs, use_ellipse=True)
+        sky_ellipse = self.reg.to_sky(self.wcs, as_ellipse=True)
         pix_ellipse = sky_ellipse.to_pixel(self.wcs)
         assert_allclose(pix_ellipse.center.x, self.center.x, rtol=1e-5)
         assert_allclose(pix_ellipse.center.y, self.center.y, rtol=1e-5)
@@ -331,8 +331,8 @@ class TestCircleAnnulusPixelRegionToSkyEllipse:
         assert_allclose(pix_ellipse.outer_height,
                         2 * self.outer_radius, rtol=1e-4)
 
-    def test_to_sky_use_ellipse_meta_copies(self):
-        result = self.reg.to_sky(self.wcs, use_ellipse=True)
+    def test_to_sky_as_ellipse_meta_copies(self):
+        result = self.reg.to_sky(self.wcs, as_ellipse=True)
         result.meta['text'] = 'new'
         result.visual['color'] = 'green'
         assert result.meta['text'] != self.reg.meta['text']
@@ -341,7 +341,7 @@ class TestCircleAnnulusPixelRegionToSkyEllipse:
 
 class TestCircleAnnulusSkyRegionToPixelEllipse:
     """
-    Tests for CircleAnnulusSkyRegion.to_pixel with use_ellipse=True.
+    Tests for CircleAnnulusSkyRegion.to_pixel with as_ellipse=True.
     """
 
     def setup_method(self):
@@ -356,14 +356,14 @@ class TestCircleAnnulusSkyRegionToPixelEllipse:
         self.wcs = make_simple_wcs(SkyCoord(3 * u.deg, 4 * u.deg),
                                    5 * u.arcsec, 20)
 
-    def test_to_pixel_use_ellipse(self):
-        result = self.reg.to_pixel(self.wcs, use_ellipse=True)
+    def test_to_pixel_as_ellipse(self):
+        result = self.reg.to_pixel(self.wcs, as_ellipse=True)
         assert isinstance(result, EllipseAnnulusPixelRegion)
         assert result.meta == self.meta
         assert result.visual == self.visual
 
     def test_to_pixel_ellipse_roundtrip(self):
-        pix_ellipse = self.reg.to_pixel(self.wcs, use_ellipse=True)
+        pix_ellipse = self.reg.to_pixel(self.wcs, as_ellipse=True)
         sky_ellipse = pix_ellipse.to_sky(self.wcs)
         assert_quantity_allclose(sky_ellipse.inner_width,
                                  2 * self.inner_radius, rtol=1e-4)
@@ -374,8 +374,8 @@ class TestCircleAnnulusSkyRegionToPixelEllipse:
         assert_quantity_allclose(sky_ellipse.outer_height,
                                  2 * self.outer_radius, rtol=1e-4)
 
-    def test_to_pixel_use_ellipse_meta_copies(self):
-        result = self.reg.to_pixel(self.wcs, use_ellipse=True)
+    def test_to_pixel_as_ellipse_meta_copies(self):
+        result = self.reg.to_pixel(self.wcs, as_ellipse=True)
         result.meta['text'] = 'new'
         result.visual['color'] = 'green'
         assert result.meta['text'] != self.reg.meta['text']

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -14,6 +14,7 @@ from regions._utils.optional_deps import HAS_MATPLOTLIB
 from regions.core import PixCoord, RegionMeta, RegionVisual
 from regions.shapes.circle import (CirclePixelRegion, CircleSkyRegion,
                                    CircleSphericalSkyRegion)
+from regions.shapes.ellipse import EllipsePixelRegion, EllipseSkyRegion
 from regions.shapes.polygon import PolygonPixelRegion, PolygonSkyRegion
 from regions.shapes.tests.test_common import (BaseTestPixelRegion,
                                               BaseTestSkyRegion,
@@ -275,3 +276,98 @@ class TestCircleSphericalSkyRegion(BaseTestSphericalSkyRegion):
         assert_quantity_allclose(bounding_lonlat[1],
                                  Latitude([-2 * u.arcsec,
                                            2 * u.arcsec]))
+
+
+class TestCirclePixelRegionToSkyEllipse:
+    """
+    Tests for CirclePixelRegion.to_sky with use_ellipse=True.
+    """
+
+    def setup_method(self):
+        self.center = PixCoord(10, 10)
+        self.radius = 5.0
+        self.meta = RegionMeta({'text': 'test'})
+        self.visual = RegionVisual({'color': 'blue'})
+        self.reg = CirclePixelRegion(self.center, self.radius,
+                                     meta=self.meta, visual=self.visual)
+        self.wcs = make_simple_wcs(SkyCoord(2 * u.deg, 3 * u.deg),
+                                   0.1 * u.deg, 20)
+
+    def test_to_sky_use_ellipse(self):
+        result = self.reg.to_sky(self.wcs, use_ellipse=True)
+        assert isinstance(result, EllipseSkyRegion)
+        assert result.meta == self.meta
+        assert result.visual == self.visual
+
+    def test_to_sky_ellipse_roundtrip(self):
+        sky_ellipse = self.reg.to_sky(self.wcs, use_ellipse=True)
+        pix_ellipse = sky_ellipse.to_pixel(self.wcs)
+        # For a simple WCS without distortion, the roundtrip should
+        # recover the original diameter as width and height
+        assert_allclose(pix_ellipse.width, 2 * self.radius, rtol=1e-4)
+        assert_allclose(pix_ellipse.height, 2 * self.radius, rtol=1e-4)
+        assert_allclose(pix_ellipse.center.x, self.center.x, rtol=1e-5)
+        assert_allclose(pix_ellipse.center.y, self.center.y, rtol=1e-5)
+
+    def test_to_sky_ellipse_center_matches_circle(self):
+        sky_circle = self.reg.to_sky(self.wcs)
+        sky_ellipse = self.reg.to_sky(self.wcs, use_ellipse=True)
+        assert_quantity_allclose(sky_ellipse.center.ra,
+                                 sky_circle.center.ra)
+        assert_quantity_allclose(sky_ellipse.center.dec,
+                                 sky_circle.center.dec)
+
+    def test_to_sky_use_ellipse_meta_copies(self):
+        result = self.reg.to_sky(self.wcs, use_ellipse=True)
+        result.meta['text'] = 'new'
+        result.visual['color'] = 'green'
+        assert result.meta['text'] != self.reg.meta['text']
+        assert result.visual['color'] != self.reg.visual['color']
+
+
+class TestCircleSkyRegionToPixelEllipse:
+    """
+    Tests for CircleSkyRegion.to_pixel with use_ellipse=True.
+    """
+
+    def setup_method(self):
+        self.center = SkyCoord(3 * u.deg, 4 * u.deg)
+        self.radius = 20 * u.arcsec
+        self.meta = RegionMeta({'text': 'test'})
+        self.visual = RegionVisual({'color': 'blue'})
+        self.reg = CircleSkyRegion(self.center, self.radius,
+                                   meta=self.meta, visual=self.visual)
+        self.wcs = make_simple_wcs(SkyCoord(3 * u.deg, 4 * u.deg),
+                                   5 * u.arcsec, 20)
+
+    def test_to_pixel_use_ellipse(self):
+        result = self.reg.to_pixel(self.wcs, use_ellipse=True)
+        assert isinstance(result, EllipsePixelRegion)
+        assert result.meta == self.meta
+        assert result.visual == self.visual
+
+    def test_to_pixel_default_returns_circle(self):
+        result = self.reg.to_pixel(self.wcs)
+        assert isinstance(result, CirclePixelRegion)
+
+    def test_to_pixel_ellipse_roundtrip(self):
+        pix_ellipse = self.reg.to_pixel(self.wcs, use_ellipse=True)
+        sky_ellipse = pix_ellipse.to_sky(self.wcs)
+        # Roundtrip should recover the original diameter
+        assert_quantity_allclose(sky_ellipse.width,
+                                 2 * self.radius, rtol=1e-4)
+        assert_quantity_allclose(sky_ellipse.height,
+                                 2 * self.radius, rtol=1e-4)
+
+    def test_to_pixel_ellipse_center_matches_circle(self):
+        pix_circle = self.reg.to_pixel(self.wcs)
+        pix_ellipse = self.reg.to_pixel(self.wcs, use_ellipse=True)
+        assert_allclose(pix_ellipse.center.x, pix_circle.center.x)
+        assert_allclose(pix_ellipse.center.y, pix_circle.center.y)
+
+    def test_to_pixel_use_ellipse_meta_copies(self):
+        result = self.reg.to_pixel(self.wcs, use_ellipse=True)
+        result.meta['text'] = 'new'
+        result.visual['color'] = 'green'
+        assert result.meta['text'] != self.reg.meta['text']
+        assert result.visual['color'] != self.reg.visual['color']

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -280,7 +280,7 @@ class TestCircleSphericalSkyRegion(BaseTestSphericalSkyRegion):
 
 class TestCirclePixelRegionToSkyEllipse:
     """
-    Tests for CirclePixelRegion.to_sky with use_ellipse=True.
+    Tests for CirclePixelRegion.to_sky with as_ellipse=True.
     """
 
     def setup_method(self):
@@ -293,14 +293,14 @@ class TestCirclePixelRegionToSkyEllipse:
         self.wcs = make_simple_wcs(SkyCoord(2 * u.deg, 3 * u.deg),
                                    0.1 * u.deg, 20)
 
-    def test_to_sky_use_ellipse(self):
-        result = self.reg.to_sky(self.wcs, use_ellipse=True)
+    def test_to_sky_as_ellipse(self):
+        result = self.reg.to_sky(self.wcs, as_ellipse=True)
         assert isinstance(result, EllipseSkyRegion)
         assert result.meta == self.meta
         assert result.visual == self.visual
 
     def test_to_sky_ellipse_roundtrip(self):
-        sky_ellipse = self.reg.to_sky(self.wcs, use_ellipse=True)
+        sky_ellipse = self.reg.to_sky(self.wcs, as_ellipse=True)
         pix_ellipse = sky_ellipse.to_pixel(self.wcs)
         # For a simple WCS without distortion, the roundtrip should
         # recover the original diameter as width and height
@@ -311,14 +311,14 @@ class TestCirclePixelRegionToSkyEllipse:
 
     def test_to_sky_ellipse_center_matches_circle(self):
         sky_circle = self.reg.to_sky(self.wcs)
-        sky_ellipse = self.reg.to_sky(self.wcs, use_ellipse=True)
+        sky_ellipse = self.reg.to_sky(self.wcs, as_ellipse=True)
         assert_quantity_allclose(sky_ellipse.center.ra,
                                  sky_circle.center.ra)
         assert_quantity_allclose(sky_ellipse.center.dec,
                                  sky_circle.center.dec)
 
-    def test_to_sky_use_ellipse_meta_copies(self):
-        result = self.reg.to_sky(self.wcs, use_ellipse=True)
+    def test_to_sky_as_ellipse_meta_copies(self):
+        result = self.reg.to_sky(self.wcs, as_ellipse=True)
         result.meta['text'] = 'new'
         result.visual['color'] = 'green'
         assert result.meta['text'] != self.reg.meta['text']
@@ -327,7 +327,7 @@ class TestCirclePixelRegionToSkyEllipse:
 
 class TestCircleSkyRegionToPixelEllipse:
     """
-    Tests for CircleSkyRegion.to_pixel with use_ellipse=True.
+    Tests for CircleSkyRegion.to_pixel with as_ellipse=True.
     """
 
     def setup_method(self):
@@ -340,8 +340,8 @@ class TestCircleSkyRegionToPixelEllipse:
         self.wcs = make_simple_wcs(SkyCoord(3 * u.deg, 4 * u.deg),
                                    5 * u.arcsec, 20)
 
-    def test_to_pixel_use_ellipse(self):
-        result = self.reg.to_pixel(self.wcs, use_ellipse=True)
+    def test_to_pixel_as_ellipse(self):
+        result = self.reg.to_pixel(self.wcs, as_ellipse=True)
         assert isinstance(result, EllipsePixelRegion)
         assert result.meta == self.meta
         assert result.visual == self.visual
@@ -351,7 +351,7 @@ class TestCircleSkyRegionToPixelEllipse:
         assert isinstance(result, CirclePixelRegion)
 
     def test_to_pixel_ellipse_roundtrip(self):
-        pix_ellipse = self.reg.to_pixel(self.wcs, use_ellipse=True)
+        pix_ellipse = self.reg.to_pixel(self.wcs, as_ellipse=True)
         sky_ellipse = pix_ellipse.to_sky(self.wcs)
         # Roundtrip should recover the original diameter
         assert_quantity_allclose(sky_ellipse.width,
@@ -361,12 +361,12 @@ class TestCircleSkyRegionToPixelEllipse:
 
     def test_to_pixel_ellipse_center_matches_circle(self):
         pix_circle = self.reg.to_pixel(self.wcs)
-        pix_ellipse = self.reg.to_pixel(self.wcs, use_ellipse=True)
+        pix_ellipse = self.reg.to_pixel(self.wcs, as_ellipse=True)
         assert_allclose(pix_ellipse.center.x, pix_circle.center.x)
         assert_allclose(pix_ellipse.center.y, pix_circle.center.y)
 
-    def test_to_pixel_use_ellipse_meta_copies(self):
-        result = self.reg.to_pixel(self.wcs, use_ellipse=True)
+    def test_to_pixel_as_ellipse_meta_copies(self):
+        result = self.reg.to_pixel(self.wcs, as_ellipse=True)
         result.meta['text'] = 'new'
         result.visual['color'] = 'green'
         assert result.meta['text'] != self.reg.meta['text']


### PR DESCRIPTION
While I'm currently immersed in WCS transformations, here's one final (optional) improvement for circular region sky/pixel conversions.  This PR adds a ``use_ellipse`` keyword to the ``to_pixel`` and ``to_sky`` methods of circular and circular annulus region classes that allows the user to specify whether to return an elliptical region instead of a circular region when converting between pixel and sky coordinates. This is useful for cases where the WCS is distorted or has different pixel scales along different axes and the circular region would be significantly distorted in pixel or sky coordinates.

Example:
The polygon -> polygon conversion represents "truth", which matches the new optional circle -> ellipse conversion.

<img width="839" height="490" alt="circle" src="https://github.com/user-attachments/assets/2d4bc266-45e8-4c82-b47b-e31735b6372d" />
