### PR TITLE
Rename npoints to n_points

### DIFF
--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -160,7 +160,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
         return CircleAnnulusSkyRegion(center, inner_radius, outer_radius,
                                       self.meta.copy(), self.visual.copy())
 
-    def to_polygon(self, npoints=100):
+    def to_polygon(self, n_points=100):
         """
         Return a `~regions.CompoundPixelRegion` of two
         `~regions.PolygonPixelRegion` objects that approximates this
@@ -168,7 +168,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
 
         Parameters
         ----------
-        npoints : int, optional
+        n_points : int, optional
             The number of polygon vertices for each circle. Default
             is 100.
 
@@ -178,8 +178,8 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
             A compound region of two polygon regions approximating the
             annulus.
         """
-        inner_polygon = self._inner_region.to_polygon(npoints=npoints)
-        outer_polygon = self._outer_region.to_polygon(npoints=npoints)
+        inner_polygon = self._inner_region.to_polygon(n_points=n_points)
+        outer_polygon = self._outer_region.to_polygon(n_points=n_points)
         return CompoundPixelRegion(inner_polygon, outer_polygon,
                                    operator.xor, self.meta.copy(),
                                    self.visual.copy())
@@ -232,7 +232,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
                                         meta=self.meta.copy(),
                                         visual=self.visual.copy())
 
-    def to_polygon(self, wcs, npoints=100):
+    def to_polygon(self, wcs, n_points=100):
         """
         Return a `~regions.CompoundSkyRegion` of two
         `~regions.PolygonSkyRegion` objects that approximates this
@@ -242,7 +242,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
         ----------
         wcs : `~astropy.wcs.WCS`
             The WCS to use for the sky-to-pixel-to-sky conversion.
-        npoints : int, optional
+        n_points : int, optional
             The number of polygon vertices for each circle. Default
             is 100.
 
@@ -252,7 +252,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
             A compound region of two polygon regions approximating the
             annulus.
         """
-        return self.to_pixel(wcs).to_polygon(npoints=npoints).to_sky(wcs)
+        return self.to_pixel(wcs).to_polygon(n_points=n_points).to_sky(wcs)
 
 
 class AsymmetricAnnulusPixelRegion(AnnulusPixelRegion):
@@ -500,7 +500,7 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
                                        meta=self.meta.copy(),
                                        visual=self.visual.copy())
 
-    def to_polygon(self, npoints=100):
+    def to_polygon(self, n_points=100):
         """
         Return a `~regions.CompoundPixelRegion` of two
         `~regions.PolygonPixelRegion` objects that approximates this
@@ -508,7 +508,7 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
 
         Parameters
         ----------
-        npoints : int, optional
+        n_points : int, optional
             The number of polygon vertices for each ellipse. Default
             is 100.
 
@@ -518,8 +518,8 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
             A compound region of two polygon regions approximating the
             annulus.
         """
-        inner_polygon = self._inner_region.to_polygon(npoints=npoints)
-        outer_polygon = self._outer_region.to_polygon(npoints=npoints)
+        inner_polygon = self._inner_region.to_polygon(n_points=n_points)
+        outer_polygon = self._outer_region.to_polygon(n_points=n_points)
         return CompoundPixelRegion(inner_polygon, outer_polygon,
                                    operator.xor, self.meta.copy(),
                                    self.visual.copy())
@@ -582,7 +582,7 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
                                          meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
-    def to_polygon(self, wcs, npoints=100):
+    def to_polygon(self, wcs, n_points=100):
         """
         Return a `~regions.CompoundSkyRegion` of two
         `~regions.PolygonSkyRegion` objects that approximates this
@@ -592,7 +592,7 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
         ----------
         wcs : `~astropy.wcs.WCS`
             The WCS to use for the sky-to-pixel-to-sky conversion.
-        npoints : int, optional
+        n_points : int, optional
             The number of polygon vertices for each ellipse. Default
             is 100.
 
@@ -602,7 +602,7 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
             A compound region of two polygon regions approximating the
             annulus.
         """
-        return self.to_pixel(wcs).to_polygon(npoints=npoints).to_sky(wcs)
+        return self.to_pixel(wcs).to_polygon(n_points=n_points).to_sky(wcs)
 
 
 class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -180,14 +180,14 @@ class CirclePixelRegion(PixelRegion):
         center = self.center.rotate(center, angle)
         return self.copy(center=center)
 
-    def to_polygon(self, npoints=100):
+    def to_polygon(self, n_points=100):
         """
         Return a `~regions.PolygonPixelRegion` that approximates this
         circle.
 
         Parameters
         ----------
-        npoints : int, optional
+        n_points : int, optional
             The number of polygon vertices. Default is 100.
 
         Returns
@@ -195,7 +195,7 @@ class CirclePixelRegion(PixelRegion):
         polygon : `~regions.PolygonPixelRegion`
             A polygon region approximating the circle.
         """
-        theta = np.linspace(0, 2 * np.pi, npoints, endpoint=False)
+        theta = np.linspace(0, 2 * np.pi, n_points, endpoint=False)
         x = self.radius * np.cos(theta) + self.center.x
         y = self.radius * np.sin(theta) + self.center.y
         vertices = PixCoord(x=x, y=y)
@@ -239,7 +239,7 @@ class CircleSkyRegion(SkyRegion):
         return CirclePixelRegion(center, radius, meta=self.meta.copy(),
                                  visual=self.visual.copy())
 
-    def to_polygon(self, wcs, npoints=100):
+    def to_polygon(self, wcs, n_points=100):
         """
         Return a `~regions.PolygonSkyRegion` that approximates this
         circle.
@@ -248,7 +248,7 @@ class CircleSkyRegion(SkyRegion):
         ----------
         wcs : `~astropy.wcs.WCS`
             The WCS to use for the sky-to-pixel-to-sky conversion.
-        npoints : int, optional
+        n_points : int, optional
             The number of polygon vertices. Default is 100.
 
         Returns
@@ -256,4 +256,4 @@ class CircleSkyRegion(SkyRegion):
         polygon : `~regions.PolygonSkyRegion`
             A polygon region approximating the circle.
         """
-        return self.to_pixel(wcs).to_polygon(npoints=npoints).to_sky(wcs)
+        return self.to_pixel(wcs).to_polygon(n_points=n_points).to_sky(wcs)

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -319,14 +319,14 @@ class EllipsePixelRegion(PixelRegion):
         angle = self.angle + angle
         return self.copy(center=center, angle=angle)
 
-    def to_polygon(self, npoints=100):
+    def to_polygon(self, n_points=100):
         """
         Return a `~regions.PolygonPixelRegion` that approximates this
         ellipse.
 
         Parameters
         ----------
-        npoints : int, optional
+        n_points : int, optional
             The number of polygon vertices. Default is 100.
 
         Returns
@@ -334,7 +334,7 @@ class EllipsePixelRegion(PixelRegion):
         polygon : `~regions.PolygonPixelRegion`
             A polygon region approximating the ellipse.
         """
-        theta = np.linspace(0, 2 * np.pi, npoints, endpoint=False)
+        theta = np.linspace(0, 2 * np.pi, n_points, endpoint=False)
         x = 0.5 * self.width * np.cos(theta)
         y = 0.5 * self.height * np.sin(theta)
         cos_angle = np.cos(self.angle)
@@ -401,7 +401,7 @@ class EllipseSkyRegion(SkyRegion):
                                   meta=self.meta.copy(),
                                   visual=self.visual.copy())
 
-    def to_polygon(self, wcs, npoints=100):
+    def to_polygon(self, wcs, n_points=100):
         """
         Return a `~regions.PolygonSkyRegion` that approximates this
         ellipse.
@@ -410,7 +410,7 @@ class EllipseSkyRegion(SkyRegion):
         ----------
         wcs : `~astropy.wcs.WCS`
             The WCS to use for the sky-to-pixel-to-sky conversion.
-        npoints : int, optional
+        n_points : int, optional
             The number of polygon vertices. Default is 100.
 
         Returns
@@ -418,4 +418,4 @@ class EllipseSkyRegion(SkyRegion):
         polygon : `~regions.PolygonSkyRegion`
             A polygon region approximating the ellipse.
         """
-        return self.to_pixel(wcs).to_polygon(npoints=npoints).to_sky(wcs)
+        return self.to_pixel(wcs).to_polygon(n_points=n_points).to_sky(wcs)

--- a/regions/shapes/tests/test_to_polygon.py
+++ b/regions/shapes/tests/test_to_polygon.py
@@ -34,8 +34,8 @@ class TestCirclePixelRegionToPolygon:
         poly = self.reg.to_polygon()
         assert len(poly.vertices.x) == 100
 
-    def test_to_polygon_npoints(self):
-        poly = self.reg.to_polygon(npoints=50)
+    def test_to_polygon_n_points(self):
+        poly = self.reg.to_polygon(n_points=50)
         assert len(poly.vertices.x) == 50
 
     def test_to_polygon_meta(self):
@@ -49,13 +49,13 @@ class TestCirclePixelRegionToPolygon:
         assert poly.visual['color'] != self.visual['color']
 
     def test_to_polygon_vertices(self):
-        poly = self.reg.to_polygon(npoints=4)
+        poly = self.reg.to_polygon(n_points=4)
         # theta = [0, pi/2, pi, 3*pi/2]
         assert_allclose(poly.vertices.x, [5, 3, 1, 3], atol=1e-10)
         assert_allclose(poly.vertices.y, [4, 6, 4, 2], atol=1e-10)
 
     def test_to_polygon_area(self):
-        poly = self.reg.to_polygon(npoints=1000)
+        poly = self.reg.to_polygon(n_points=1000)
         assert_allclose(poly.area, self.reg.area, rtol=1e-4)
 
     def test_to_polygon_contains(self):
@@ -79,8 +79,8 @@ class TestCircleSkyRegionToPolygon:
         poly = self.reg.to_polygon(self.wcs)
         assert len(poly.vertices.ra) == 100
 
-    def test_to_polygon_npoints(self):
-        poly = self.reg.to_polygon(self.wcs, npoints=50)
+    def test_to_polygon_n_points(self):
+        poly = self.reg.to_polygon(self.wcs, n_points=50)
         assert len(poly.vertices.ra) == 50
 
 
@@ -98,8 +98,8 @@ class TestEllipsePixelRegionToPolygon:
         poly = self.reg.to_polygon()
         assert len(poly.vertices.x) == 100
 
-    def test_to_polygon_npoints(self):
-        poly = self.reg.to_polygon(npoints=50)
+    def test_to_polygon_n_points(self):
+        poly = self.reg.to_polygon(n_points=50)
         assert len(poly.vertices.x) == 50
 
     def test_to_polygon_meta(self):
@@ -112,7 +112,7 @@ class TestEllipsePixelRegionToPolygon:
         assert poly.visual['color'] != self.visual['color']
 
     def test_to_polygon_vertices_no_rotation(self):
-        poly = self.reg.to_polygon(npoints=4)
+        poly = self.reg.to_polygon(n_points=4)
         # Ellipse: width=6, height=4, center=(3,4), angle=0
         # theta = [0, pi/2, pi, 3*pi/2]
         # x = 0.5*6*cos(theta) + 3 = [6, 3, 0, 3]
@@ -123,13 +123,13 @@ class TestEllipsePixelRegionToPolygon:
     def test_to_polygon_vertices_rotated(self):
         reg = EllipsePixelRegion(PixCoord(0, 0), width=4, height=2,
                                  angle=90 * u.deg)
-        poly = reg.to_polygon(npoints=4)
+        poly = reg.to_polygon(n_points=4)
         # After 90 deg rotation, width along y and height along x
         assert_allclose(poly.vertices.x, [0, -1, 0, 1], atol=1e-10)
         assert_allclose(poly.vertices.y, [2, 0, -2, 0], atol=1e-10)
 
     def test_to_polygon_area(self):
-        poly = self.reg.to_polygon(npoints=1000)
+        poly = self.reg.to_polygon(n_points=1000)
         assert_allclose(poly.area, self.reg.area, rtol=1e-4)
 
     def test_to_polygon_contains(self):
@@ -154,8 +154,8 @@ class TestEllipseSkyRegionToPolygon:
         poly = self.reg.to_polygon(self.wcs)
         assert len(poly.vertices.ra) == 100
 
-    def test_to_polygon_npoints(self):
-        poly = self.reg.to_polygon(self.wcs, npoints=50)
+    def test_to_polygon_n_points(self):
+        poly = self.reg.to_polygon(self.wcs, n_points=50)
         assert len(poly.vertices.ra) == 50
 
 
@@ -259,8 +259,8 @@ class TestCircleAnnulusPixelRegionToPolygon:
         assert len(poly.region1.vertices.x) == 100
         assert len(poly.region2.vertices.x) == 100
 
-    def test_to_polygon_npoints(self):
-        poly = self.reg.to_polygon(npoints=50)
+    def test_to_polygon_n_points(self):
+        poly = self.reg.to_polygon(n_points=50)
         assert len(poly.region1.vertices.x) == 50
         assert len(poly.region2.vertices.x) == 50
 
@@ -291,8 +291,8 @@ class TestCircleAnnulusSkyRegionToPolygon:
         poly = self.reg.to_polygon(self.wcs)
         assert isinstance(poly, CompoundSkyRegion)
 
-    def test_to_polygon_npoints(self):
-        poly = self.reg.to_polygon(self.wcs, npoints=50)
+    def test_to_polygon_n_points(self):
+        poly = self.reg.to_polygon(self.wcs, n_points=50)
         assert isinstance(poly, CompoundSkyRegion)
 
 
@@ -314,8 +314,8 @@ class TestEllipseAnnulusPixelRegionToPolygon:
         assert len(poly.region1.vertices.x) == 100
         assert len(poly.region2.vertices.x) == 100
 
-    def test_to_polygon_npoints(self):
-        poly = self.reg.to_polygon(npoints=50)
+    def test_to_polygon_n_points(self):
+        poly = self.reg.to_polygon(n_points=50)
         assert len(poly.region1.vertices.x) == 50
         assert len(poly.region2.vertices.x) == 50
 
@@ -345,8 +345,8 @@ class TestEllipseAnnulusSkyRegionToPolygon:
         poly = self.reg.to_polygon(self.wcs)
         assert isinstance(poly, CompoundSkyRegion)
 
-    def test_to_polygon_npoints(self):
-        poly = self.reg.to_polygon(self.wcs, npoints=50)
+    def test_to_polygon_n_points(self):
+        poly = self.reg.to_polygon(self.wcs, n_points=50)
         assert isinstance(poly, CompoundSkyRegion)
 
 


### PR DESCRIPTION
These appear in the new `to_polygon` methods (see #649), which have not yet been released.

This makes the keyword name consistent with https://github.com/astropy/regions/pull/618#pullrequestreview-4182885634 (and also photutils keyword names with `n_` prefixes).