### PR TITLE
Change LinePixelRegion to use Line2D artist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,10 @@ Bug Fixes
 API Changes
 -----------
 
+- The ``LinePixelRegion`` ``as_artist`` method now returns a
+  ``matplotlib.lines.Line2D`` object instead of a
+  ``matplotlib.patches.Arrow`` object. [#668]
+
 
 0.11 (2025-11-05)
 =================

--- a/regions/core/metadata.py
+++ b/regions/core/metadata.py
@@ -140,7 +140,7 @@ class RegionVisual(Meta):
             # matplotlib defaults
             if artist == 'Patch':
                 kwargs['fill'] = False
-            elif artist == 'Line2D':
+            elif artist == 'point':  # Line2D with marker only
                 kwargs['fillstyle'] = 'none'
                 kwargs['marker'] = 'o'
             return kwargs
@@ -151,7 +151,7 @@ class RegionVisual(Meta):
             if artist == 'Text':
                 kwargs['ha'] = 'center'  # text horizontal alignment
                 kwargs['va'] = 'center'  # text vertical alignment
-            elif artist == 'Line2D':
+            elif artist == 'point':  # Line2D with marker only
                 from regions.io.ds9.core import ds9_valid_symbols
 
                 kwargs['marker'] = ds9_valid_symbols['boxcircle']
@@ -162,9 +162,6 @@ class RegionVisual(Meta):
                 kwargs['edgecolor'] = kwargs.pop('color')
                 kwargs['fill'] = False
 
-            else:
-                raise ValueError('invalid visual["default"] value')
-
         return kwargs
 
     def _to_mpl_kwargs(self, artist):
@@ -174,8 +171,9 @@ class RegionVisual(Meta):
 
         Parameters
         ----------
-        artist : {'Text', 'Line2D', 'Patch'}
-            The matplotlib artist type.
+        artist : {'Text', 'Line2D', 'Patch', 'point'}
+            The matplotlib artist type. 'point' is a special case for
+            Line2D with a marker only.
 
         Returns
         -------
@@ -190,14 +188,17 @@ class RegionVisual(Meta):
                       'textangle': 'rotation'}
 
         elif artist == 'Line2D':
-            keymap = {'symsize': 'markersize',
-                      'color': 'markeredgecolor',
-                      'linewidth': 'markeredgewidth',
-                      'fill': 'fillstyle'}
+            keymap = {}
 
         elif artist == 'Patch':
             keymap = {'color': 'edgecolor',
                       'fill': 'fill'}
+
+        elif artist == 'point':
+            keymap = {'symsize': 'markersize',
+                      'color': 'markeredgecolor',
+                      'linewidth': 'markeredgewidth',
+                      'fill': 'fillstyle'}
 
         else:
             raise ValueError('invalid artist type')
@@ -226,7 +227,7 @@ class RegionVisual(Meta):
 
         Parameters
         ----------
-        artist : {'Text', 'Line2D', 'Patch'}
+        artist : {'Text', 'Line2D', 'Patch', 'point'}
             The matplotlib artist type.
 
         Returns
@@ -234,7 +235,7 @@ class RegionVisual(Meta):
         result : dict
             A dictionary of matplotlib keyword arguments.
         """
-        if artist not in ('Patch', 'Line2D', 'Text'):
+        if artist not in ('Patch', 'Line2D', 'Text', 'point'):
             raise ValueError(f'artist "{artist}" is not supported')
 
         kwargs = self._define_default_mpl_kwargs(artist)

--- a/regions/core/tests/test_metadata.py
+++ b/regions/core/tests/test_metadata.py
@@ -63,7 +63,7 @@ def test_region_visual_mpl_kwargs():
     expected = {'edgecolor': 'blue', 'fill': False}
     assert kwargs == expected
 
-    kwargs = meta.define_mpl_kwargs('Line2D')
+    kwargs = meta.define_mpl_kwargs('point')
     expected = {'markeredgecolor': 'blue', 'fillstyle': 'none',
                 'marker': 'o'}
     assert kwargs == expected

--- a/regions/io/ds9/tests/test_ds9.py
+++ b/regions/io/ds9/tests/test_ds9.py
@@ -7,10 +7,12 @@ import os
 import warnings
 
 import astropy.units as u
+import numpy as np
 import pytest
 from astropy.coordinates import Angle, SkyCoord
+from astropy.io import fits
 from astropy.tests.helper import assert_quantity_allclose
-from astropy.utils.data import get_pkg_data_filenames
+from astropy.utils.data import get_pkg_data_filename, get_pkg_data_filenames
 from astropy.utils.exceptions import AstropyUserWarning
 from numpy.testing import assert_allclose, assert_equal
 
@@ -20,6 +22,26 @@ from regions.shapes import (CirclePixelRegion, CircleSkyRegion,
                             PointPixelRegion, RegularPolygonPixelRegion,
                             TextPixelRegion)
 from regions.tests.helpers import assert_region_allclose
+
+
+@pytest.mark.remote_data
+@pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
+def test_example_plot():
+    import matplotlib.pyplot as plt
+
+    image_file = get_pkg_data_filename('tutorials/FITS-images/HorseHead.fits')
+    data = fits.getdata(image_file, ext=0, memmap=False)
+    data = np.rot90(data, k=-1)
+
+    _, ax = plt.subplots(figsize=(8, 8))
+    ax.imshow(data, cmap='gray', origin='lower')
+
+    region_file = get_pkg_data_filename('data/plot_image.reg',
+                                        package='regions.io.ds9.tests')
+    regions = Regions.read(region_file, format='ds9')
+    for _i, region in enumerate(regions):
+        region.plot(ax=ax)
+    plt.close()
 
 
 def test_roundtrip(tmpdir):

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -41,8 +41,8 @@ class LinePixelRegion(PixelRegion):
 
         fig, ax = plt.subplots()
 
-        start = PixCoord(x=15, y=10)
-        end = PixCoord(x=20, y=25)
+        start = PixCoord(x=5, y=8)
+        end = PixCoord(x=25, y=25)
         reg = LinePixelRegion(start=start, end=end)
         patch = reg.plot(ax=ax, color='red', lw=2, label='Line')
 
@@ -53,7 +53,7 @@ class LinePixelRegion(PixelRegion):
     """
 
     _params = ('start', 'end')
-    _mpl_artist = 'Patch'
+    _mpl_artist = 'Line2D'
     start = ScalarPixCoord('The start pixel position as a |PixCoord|.')
     end = ScalarPixCoord('The end pixel position as a |PixCoord|.')
     meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
@@ -122,21 +122,13 @@ class LinePixelRegion(PixelRegion):
         artist : `~matplotlib.patches.Arrow`
             A matplotlib line patch.
         """
-        # Note: Long term we want to support DS9 lines with arrow heads.
-        # We may want to use Line2D instead of arrow for lines because the
-        # width of the arrow is non-scalable in patches.
-        from matplotlib.patches import Arrow
-
-        x = self.start.x - origin[0]
-        y = self.start.y - origin[1]
-        dx = self.end.x - self.start.x
-        dy = self.end.y - self.start.y
-        kwargs.setdefault('width', 0.1)
+        from matplotlib.lines import Line2D
 
         mpl_kwargs = self.visual.define_mpl_kwargs(self._mpl_artist)
         mpl_kwargs.update(kwargs)
 
-        return Arrow(x, y, dx, dy, **mpl_kwargs)
+        return Line2D([self.start.x, self.end.x], [self.start.y, self.end.y],
+                      **mpl_kwargs)
 
     def rotate(self, center, angle):
         """

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -60,7 +60,7 @@ class PointPixelRegion(PixelRegion):
     """
 
     _params = ('center',)
-    _mpl_artist = 'Line2D'
+    _mpl_artist = 'point'  # custom Line2D with marker only
     center = ScalarPixCoord('The point pixel position as a |PixCoord|.')
     meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
     visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
@@ -123,6 +123,8 @@ class PointPixelRegion(PixelRegion):
         artist : `~matplotlib.lines.Line2D`
             A matplotlib Line2D object.
         """
+        # matplotlib does not have a "point" artist, so we use a Line2D
+        # with marker only
         from matplotlib.lines import Line2D
 
         mpl_kwargs = self.visual.define_mpl_kwargs(self._mpl_artist)

--- a/regions/shapes/tests/test_line.py
+++ b/regions/shapes/tests/test_line.py
@@ -64,8 +64,8 @@ class TestLinePixelRegion(BaseTestPixelRegion):
 
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     def test_as_artist(self):
-        patch = self.reg.as_artist()
-        assert 'Arrow' in str(patch)
+        line2d = self.reg.as_artist()
+        assert 'Line2D' in str(line2d)
 
     def test_rotate(self):
         reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)


### PR DESCRIPTION
With this PR, the ``LinePixelRegion`` ``as_artist`` method now returns a ``matplotlib.lines.Line2D`` object instead of a ``matplotlib.patches.Arrow`` object.

note the plot legends

Old:
<img width="338" height="333" alt="old" src="https://github.com/user-attachments/assets/f0ced7f3-5826-444e-900d-714a6aaea796" />

New
<img width="338" height="333" alt="new" src="https://github.com/user-attachments/assets/1775965a-e983-429d-b424-70c8a2526047" />

