### PR TITLE
Strip whitespace from FITS region SHAPE values (fixes #637)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,11 @@ New Features
 Bug Fixes
 ---------
 
+- Fixed reading FITS region files whose ``SHAPE`` column values contain
+  leading or trailing whitespace (e.g. from fixed-width character-column
+  padding or cross-platform encoding quirks), which previously raised a
+  spurious ``FITSParserError``. [#674]
+
 API Changes
 -----------
 

--- a/regions/io/fits/read.py
+++ b/regions/io/fits/read.py
@@ -76,8 +76,15 @@ def get_shape(region_row):
         shape = 'point'
         return shape, include
 
-    shape = region_row[shape_key].lower()
-    if shape[0] == '!':
+    # Strip surrounding whitespace before matching the shape name. FITS
+    # character columns are fixed-width and space-padded, and some writers
+    # (or cross-platform/encoding quirks) leave trailing whitespace on the
+    # SHAPE value, which would otherwise fail the ``valid_shapes`` check
+    # below and raise a spurious FITSParserError (see GH #637). Using
+    # ``startswith`` instead of indexing also avoids an IndexError when the
+    # value is empty after stripping.
+    shape = region_row[shape_key].strip().lower()
+    if shape.startswith('!'):
         include = 0
         shape = shape[1:]
 

--- a/regions/io/fits/tests/test_fits.py
+++ b/regions/io/fits/tests/test_fits.py
@@ -104,6 +104,31 @@ def test_valid_row():
         Regions.parse(tbl3, format='fits')
 
 
+def test_shape_with_whitespace():
+    # FITS character columns are fixed-width and space-padded; some writers
+    # (e.g. CSCView output, or cross-platform/encoding quirks) leave trailing
+    # whitespace on the SHAPE value. Such a value must still be recognized
+    # instead of raising a spurious FITSParserError (see GH #637).
+    x = [1] * u.pix
+    y = [2] * u.pix
+    r = [3] * u.pix
+
+    tbl = QTable([x, y, r, ['circle  ']],
+                 names=('X', 'Y', 'R', 'SHAPE'))
+    regions = Regions.parse(tbl, format='fits')
+    assert len(regions) == 1
+    assert isinstance(regions[0], CirclePixelRegion)
+    assert_equal(regions[0].center.x, 1)
+    assert_equal(regions[0].radius, 3)
+
+    # The exclude prefix ('!') must still be honored after stripping.
+    tbl_excl = QTable([x, y, r, [' !circle ']],
+                      names=('X', 'Y', 'R', 'SHAPE'))
+    regions = Regions.parse(tbl_excl, format='fits')
+    assert len(regions) == 1
+    assert regions[0].meta.get('include') == 0
+
+
 def test_components():
     center = PixCoord(10, 10)
     regions = Regions((CirclePixelRegion(center, 3),


### PR DESCRIPTION
## Description

Reading a FITS region file whose `SHAPE` column values carry leading or trailing whitespace raises a spurious `FITSParserError`. This was reported in #637 for region files exported from the Chandra Source Catalog via CSCView (where, likely due to fixed-width character-column padding and/or cross-platform encoding, the shape token comes back with trailing whitespace).

`get_shape()` matched the raw column value against the list of valid shape names:

```python
shape = region_row['SHAPE'].lower()
if shape[0] == '!':
    ...
```

so a value such as `'circle  '` failed the `valid_shapes` membership check and raised:

```
FITSParserError: 'circle  ' is not a valid FITS region shape
```

## Fix

Strip surrounding whitespace from the `SHAPE` value before matching, and use `str.startswith('!')` instead of indexing `shape[0]` for the exclude prefix so that an empty value after stripping no longer raises an `IndexError`.

```python
shape = region_row['SHAPE'].strip().lower()
if shape.startswith('!'):
    ...
```

The change is a no-op for already-clean values, so existing files are unaffected.

## Reproduce

```python
import astropy.units as u
from astropy.table import QTable
from regions import Regions

tbl = QTable([[1] * u.pix, [2] * u.pix, [3] * u.pix, ['circle  ']],
             names=('X', 'Y', 'R', 'SHAPE'))
Regions.parse(tbl, format='fits')   # FITSParserError before, parses after
```

## Tests

Adds `test_shape_with_whitespace` covering a padded shape name and a whitespace-wrapped `'!'`-excluded shape. The new test fails on `main` (raising `FITSParserError`) and passes with the fix; the full `regions/io/fits` test suite passes (7 passed).

Fixes #637.