### PR TITLE
region __eq__ method uses all_close, like PixCoord

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,9 @@ Bug Fixes
   and ``to_pixel`` conversions so that they round-trip correctly with a
   sheared WCS. [#676]
 
+- Region equivalency operator now uses 'all_close' rather than checking for an
+  exact match when comparing regions, for behavior in line with PixCoord. [#677]
+
 API Changes
 -----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,8 +81,11 @@ Bug Fixes
   and ``to_pixel`` conversions so that they round-trip correctly with a
   sheared WCS. [#676]
 
-- Region equivalency operator now uses 'all_close' rather than checking for an
-  exact match when comparing regions, for behavior in line with PixCoord. [#677]
+- Fixed ``Region`` comparison behavior so that numeric
+  parameters (``PixCoord``, ``astropy.units.Quantity``, and
+  ``astropy.coordinates.SkyCoord``) are compared using ``np.allclose``
+  rather than exact equality, making equality checks more robust to
+  floating-point precision differences. [#677]
 
 API Changes
 -----------

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -166,20 +166,53 @@ class Region(abc.ABC):
     @staticmethod
     def _is_close(val1, val2):
         """
-        Helper to compare PixCoord, Quantity, SkyCoord, and other parameters.
+        Helper to compare PixCoord, Quantity, SkyCoord, and other
+        parameters.
+
+        For SkyCoord objects, both coordinates are converted to ICRS and
+        their RA/Dec values are compared using `numpy.allclose` with
+        default tolerances, enabling tolerance-based equivalency similar
+        to PixCoord and Quantity parameters.
+
+        SkyCoord objects must have equivalent frames to be considered
+        close.
+
+        Parameters
+        ----------
+        val1, val2 : object
+            Values to compare.
+
+        Returns
+        -------
+        bool
+            True if values are considered close/equal, False otherwise.
         """
         # PixCoord has its own __eq__ with built-in tolerances
         if isinstance(val1, PixCoord):
             return val1 == val2
 
+        # SkyCoord comparison using RA/DEC allclose
+        if isinstance(val1, SkyCoord) and isinstance(val2, SkyCoord):
+            try:
+                # Frames must be equivalent, convert to ICRS for comparison
+                if val1.frame.is_equivalent_frame(val2.frame):
+                    ra_close = np.allclose(val1.icrs.ra.deg,
+                                           val2.icrs.ra.deg)
+                    dec_close = np.allclose(val1.icrs.dec.deg,
+                                            val2.icrs.dec.deg)
+                    return ra_close and dec_close
+            except (AttributeError, ValueError):
+                pass
+            return False
+
+        # Try np.allclose for Quantities and arrays
         try:
-            # np.allclose handles Quantities with convertible units
             return np.allclose(val1, val2)
         except (TypeError, ValueError):
             try:
-                # Fallback for SkyCoord (which may return False if frames differ)
-                # or dicts/objects where np.allclose fails.
-                return not np.any(val1 != val2)
+                # Fallback for dicts/objects (e.g., empty dicts) where
+                # np.allclose fails.
+                return np.all(val1 == val2)
             except (TypeError, ValueError):
                 return False
 
@@ -187,23 +220,30 @@ class Region(abc.ABC):
         """
         Equality operator for Region.
 
-        All Region properties are compared for strict equality except
-        for Quantity parameters, which allow for different units if they
-        are directly convertible.
+        Regions are considered equal if all their properties are equal
+        or close.
+
+        - PixCoord centers use built-in tolerance (np.allclose with
+          defaults)
+        - Quantity parameters allow different units if directly
+          convertible
+        - SkyCoord centers are compared using allclose on RA/DEC values
+        - Other parameters use strict equality
         """
         if not isinstance(other, self.__class__):
             return False
 
         # Define the parameters to check
-        params = list(self._params) + ['meta', 'visual']
+        self_params = list(self._params) + ['meta', 'visual']
         other_params = list(other._params) + ['meta', 'visual']
 
         # Check that both have identical parameter sets
-        if params != other_params:
+        if self_params != other_params:
             return False
 
         # Check that all parameter values are close
-        return all(self._is_close(getattr(self, p), getattr(other, p)) for p in params)
+        return all(self._is_close(getattr(self, p), getattr(other, p))
+                   for p in self_params)
 
     def __ne__(self, other):
         """

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -163,6 +163,26 @@ class Region(abc.ABC):
         cls_info = [('Region', self.__class__.__name__)] + self._cls_info()
         return '\n'.join(f'{key}: {val}' for key, val in cls_info)
 
+    @staticmethod
+    def _is_close(val1, val2):
+        """
+        Helper to compare PixCoord, Quantity, SkyCoord, and other parameters.
+        """
+        # PixCoord has its own __eq__ with built-in tolerances
+        if isinstance(val1, PixCoord):
+            return val1 == val2
+
+        try:
+            # np.allclose handles Quantities with convertible units
+            return np.allclose(val1, val2)
+        except (TypeError, ValueError):
+            try:
+                # Fallback for SkyCoord (which may return False if frames differ)
+                # or dicts/objects where np.allclose fails.
+                return not np.any(val1 != val2)
+            except (TypeError, ValueError):
+                return False
+
     def __eq__(self, other):
         """
         Equality operator for Region.
@@ -174,40 +194,16 @@ class Region(abc.ABC):
         if not isinstance(other, self.__class__):
             return False
 
-        meta_params = ['meta', 'visual']
-        self_params = list(self._params) + meta_params
-        other_params = list(other._params) + meta_params
+        # Define the parameters to check
+        params = list(self._params) + ['meta', 'visual']
+        other_params = list(other._params) + ['meta', 'visual']
 
-        # check that both have identical parameters
-        if self_params != other_params:
+        # Check that both have identical parameter sets
+        if params != other_params:
             return False
 
-        # now check the parameter values
-        # Note that Quantity comparisons allow for different units
-        # if they directly convertible (e.g., 1. * u.deg == 60. * u.arcmin)
-
-        for param in self_params:
-            self_val = getattr(self, param)
-            other_val = getattr(other, param)
-
-            # compare PixCoord directly, the PixCoord __eq__ method also uses
-            # np.allclose with the default tolerances
-            if isinstance(self_val, PixCoord) and self_val != other_val:
-                return False
-            else:
-                try:
-                    if not np.allclose(self_val, other_val):  # also handles comparible units
-                        return False
-                except TypeError:
-                    # fallback direct comparison for empty dicts, or for
-                    # SkyCoord comparisons which return false when frames
-                    # are not equivalent
-                    try:
-                        if np.any(self_val != other_val):
-                            return False
-                    except TypeError:
-                        return False
-        return True
+        # Check that all parameter values are close
+        return all(self._is_close(getattr(self, p), getattr(other, p)) for p in params)
 
     def __ne__(self, other):
         """

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -185,17 +185,27 @@ class Region(abc.ABC):
         # now check the parameter values
         # Note that Quantity comparisons allow for different units
         # if they directly convertible (e.g., 1. * u.deg == 60. * u.arcmin)
-        try:
-            for param in self_params:
-                # np.any is used for SkyCoord array comparisons
-                if np.any(getattr(self, param) != getattr(other, param)):
-                    return False
-        except TypeError:
-            # TypeError is raised from SkyCoord comparison when they do
-            # not have equivalent frames. Here return False instead of
-            # the TypeError.
-            return False
 
+        for param in self_params:
+            self_val = getattr(self, param)
+            other_val = getattr(other, param)
+            # compare PixCoord directly, the PixCoord __eq__ method also uses
+            # np.allclose with the default tolerances
+            if isinstance(self_val, PixCoord) and self_val != other_val:
+                return False
+            else:
+                try:
+                    if not u.allclose(self_val, other_val):
+                        return False
+                except TypeError:
+                    # fallback direct comparison for empty dicts, or for
+                    # SkyCoord comparisons which return false when frames
+                    # are not equivalent
+                    try:
+                        if np.any(self_val != other_val):
+                            return False
+                    except TypeError:
+                        return False
         return True
 
     def __ne__(self, other):

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -189,13 +189,14 @@ class Region(abc.ABC):
         for param in self_params:
             self_val = getattr(self, param)
             other_val = getattr(other, param)
+
             # compare PixCoord directly, the PixCoord __eq__ method also uses
             # np.allclose with the default tolerances
             if isinstance(self_val, PixCoord) and self_val != other_val:
                 return False
             else:
                 try:
-                    if not u.allclose(self_val, other_val):
+                    if not np.allclose(self_val, other_val):  # also handles comparible units
                         return False
                 except TypeError:
                     # fallback direct comparison for empty dicts, or for

--- a/regions/core/tests/test_regions.py
+++ b/regions/core/tests/test_regions.py
@@ -4,10 +4,12 @@ Tests for the regions module.
 """
 
 import pytest
+from astropy.coordinates import SkyCoord
 from astropy.table import Table
+from astropy import units as u
 
 from regions.core import PixCoord, Regions
-from regions.shapes import CirclePixelRegion
+from regions.shapes import CirclePixelRegion, CircleSkyRegion
 
 
 def test_regions_inputs():
@@ -111,3 +113,24 @@ def test_regions_repr():
     regions_repr = f'<Regions([\n  {reg_repr}\n])>'
     assert str(regions) == regions_str
     assert repr(regions) == regions_repr
+
+
+def test_region_equivalency():
+    reg1 = CirclePixelRegion(PixCoord(0, 0), radius=1)
+    reg2 = CirclePixelRegion(PixCoord(0, 0), radius=1)
+    assert reg1 == reg2
+
+    # __eq__ uses np.allclose for comparing regions, so this should be True
+    reg3 = CirclePixelRegion(PixCoord(0, 0), radius=1 + 1e-10)
+    assert reg1 == reg3
+
+    # do the same for a SkyRegion
+    reg4 = CircleSkyRegion(SkyCoord(ra=0 * u.deg, dec=0 * u.deg),
+                           radius=1 * u.arcsec)
+    reg5 = CircleSkyRegion(SkyCoord(ra=0 * u.deg, dec=0 * u.deg),
+                           radius=1 * u.arcsec)
+    assert reg4 == reg5
+
+    reg6 = CircleSkyRegion(SkyCoord(ra=0 * u.deg, dec=0 * u.deg),
+                           radius=1 * u.arcsec + 1e-10 * u.arcsec)
+    assert reg4 == reg6

--- a/regions/core/tests/test_regions.py
+++ b/regions/core/tests/test_regions.py
@@ -4,11 +4,11 @@ Tests for the regions module.
 """
 
 import pytest
+from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
-from astropy import units as u
 
-from regions.core import PixCoord, Regions
+from regions.core import PixCoord, Region, Regions
 from regions.shapes import CirclePixelRegion, CircleSkyRegion
 
 
@@ -116,6 +116,11 @@ def test_regions_repr():
 
 
 def test_region_equivalency():
+    """
+    Test the __eq__ method of Region and its subclasses to ensure that
+    it correctly identifies when two regions are equal, and that it uses
+    np.allclose for comparing parameters that are numerical in nature.
+    """
     reg1 = CirclePixelRegion(PixCoord(0, 0), radius=1)
     reg2 = CirclePixelRegion(PixCoord(0, 0), radius=1)
     assert reg1 == reg2
@@ -124,7 +129,11 @@ def test_region_equivalency():
     reg3 = CirclePixelRegion(PixCoord(0, 0), radius=1 + 1e-10)
     assert reg1 == reg3
 
-    # do the same for a SkyRegion
+    # Different radius should not be equal
+    reg_diff = CirclePixelRegion(PixCoord(0, 0), radius=2)
+    assert reg1 != reg_diff
+
+    # Test SkyRegion equality
     reg4 = CircleSkyRegion(SkyCoord(ra=0 * u.deg, dec=0 * u.deg),
                            radius=1 * u.arcsec)
     reg5 = CircleSkyRegion(SkyCoord(ra=0 * u.deg, dec=0 * u.deg),
@@ -134,3 +143,84 @@ def test_region_equivalency():
     reg6 = CircleSkyRegion(SkyCoord(ra=0 * u.deg, dec=0 * u.deg),
                            radius=1 * u.arcsec + 1e-10 * u.arcsec)
     assert reg4 == reg6
+
+    # Different classes should not be equal
+    assert reg1 != reg4
+
+    # Test SkyCoord center allclose comparison
+    # Small coordinate differences should be considered equal
+    reg7 = CircleSkyRegion(SkyCoord(ra=0 * u.deg + 1e-10 * u.deg,
+                                    dec=0 * u.deg),
+                           radius=1 * u.arcsec)
+    assert reg4 == reg7
+
+    # Declination offset
+    reg8 = CircleSkyRegion(SkyCoord(ra=0 * u.deg,
+                                    dec=0 * u.deg + 1e-10 * u.deg),
+                           radius=1 * u.arcsec)
+    assert reg4 == reg8
+
+    # Both RA and Dec with small offsets
+    reg9 = CircleSkyRegion(SkyCoord(ra=0 * u.deg + 1e-10 * u.deg,
+                                    dec=0 * u.deg + 1e-10 * u.deg),
+                           radius=1 * u.arcsec)
+    assert reg4 == reg9
+
+    # Significantly different SkyCoord should not be equal
+    reg10 = CircleSkyRegion(SkyCoord(ra=0.01 * u.deg, dec=0 * u.deg),
+                            radius=1 * u.arcsec)
+    assert reg4 != reg10
+
+    # SkyCoord with different frames should not be equal
+    reg_gal = CircleSkyRegion(SkyCoord(l=0 * u.deg, b=0 * u.deg,
+                                       frame='galactic'),
+                              radius=1 * u.arcsec)
+    assert reg4 != reg_gal
+
+
+def test_is_close_skycoord_frame_error(monkeypatch):
+    """
+    Test that if the is_equivalent_frame method of the SkyCoord frame
+    raises a ValueError, then _is_close should catch that and return
+    False rather than propagating the exception.
+
+    This is to ensure that if the frames of the SkyCoords cannot be
+    compared for equivalency, we should not consider the coordinates to
+    be close, but we also should not raise an exception.
+    """
+    def raises_value_error(self, other):
+        raise ValueError
+
+    c1 = SkyCoord(ra=0 * u.deg, dec=0 * u.deg)
+    c2 = SkyCoord(ra=0 * u.deg, dec=0 * u.deg)
+    monkeypatch.setattr(type(c1.frame), 'is_equivalent_frame',
+                        raises_value_error)
+    assert not Region._is_close(c1, c2)
+
+
+def test_is_close_non_comparable():
+    """
+    Test that if the __eq__ method of the objects being compared
+    raises a TypeError, then _is_close should return False rather than
+    propagating the exception.
+    """
+    class BadCompare:
+        def __eq__(self, other):
+            raise TypeError
+
+    b = BadCompare()
+    assert not Region._is_close(b, b)
+
+
+def test_region_eq_param_mismatch():
+    """
+    Test that if two regions are of the same class but have mismatched _params,
+    then they should not be considered equal.
+
+    This is a sanity check to ensure that the __eq__ method is correctly
+    comparing the parameters of the regions.
+    """
+    reg1 = CirclePixelRegion(PixCoord(0, 0), radius=1)
+    reg2 = CirclePixelRegion(PixCoord(0, 0), radius=1)
+    reg2._params = ()  # simulate mismatched parameter set
+    assert reg1 != reg2


### PR DESCRIPTION
This PR updates Region's \_\_eq__ method to use allclose instead of checking for exact equality. 

This is presently how equivalency is checked for PixCoord, so there was a mismatch between looser requirements for closeness of pixel centers vs angles - angles were required to match exactly, while centers could have small numerical differences and still be equal.

This requires a follow up workaround for SkyCoord (see https://github.com/astropy/regions/issues/678)

Fixes #678 