### PR TITLE
Add covers method and make contains boundary semantics consistent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,19 @@ New Features
   planar <-> spherical transformation (where well defined) may be added
   at a future date. [#618]
 
+- Added a ``covers`` method to all pixel region classes
+  (``CirclePixelRegion``, ``EllipsePixelRegion``,
+  ``RectanglePixelRegion``, ``PolygonPixelRegion``,
+  ``LinePixelRegion``, ``PointPixelRegion``, annulus pixel regions, and
+  ``CompoundPixelRegion``) and to the corresponding sky region classes
+  (``SkyRegion.covers``, ``SphericalSkyRegion.covers``, and all
+  spherical sky region subclasses including ``LuneSphericalSkyRegion``,
+  ``RangeSphericalSkyRegion``, ``WholeSphericalSkyRegion``,
+  ``PolygonSphericalSkyRegion``, and
+  ``CompoundSphericalSkyRegion``). This method checks whether points
+  fall inside or on the boundary of a region, consistent with Shapely's
+  ``covers`` function and DE-9IM semantics. [#680]
+
 Bug Fixes
 ---------
 
@@ -93,6 +106,18 @@ API Changes
 - The ``LinePixelRegion`` ``as_artist`` method now returns a
   ``matplotlib.lines.Line2D`` object instead of a
   ``matplotlib.patches.Arrow`` object. [#668]
+
+- The ``contains`` method now consistently excludes the region boundary
+  for all pixel regions, matching Shapely's ``contains`` function and
+  DE-9IM semantics. Previously, ``EllipsePixelRegion.contains`` included
+  the boundary and ``PolygonPixelRegion.contains`` treated boundary
+  points inconsistently. Use the new ``covers`` method to include the
+  boundary. [#680]
+
+- The ``contains`` methods of all regions now ignore the ``'include'``
+  metadata attribute (which was previously used to invert evaluation
+  results), making containment and covering behavior depend solely on the
+  geometric shape of the region. [#680]
 
 
 0.11 (2025-11-05)

--- a/docs/user_guide/contains.rst
+++ b/docs/user_guide/contains.rst
@@ -94,3 +94,46 @@ point(s) lie inside or outside the region::
     >>> skycoord = SkyCoord([50, 50], [10, 60], unit='deg')
     >>> sph_sky_region.contains(skycoord)
     array([False, True])
+
+
+Boundary Behavior: ``contains`` versus ``covers``
+-------------------------------------------------
+
+The ``contains`` method excludes the region boundary: a point that lies
+exactly on an edge or vertex is considered to be *outside* the region.
+This is consistent with `Shapely's
+<https://shapely.readthedocs.io/>`_ ``contains`` predicate and the
+`DE-9IM <https://en.wikipedia.org/wiki/DE-9IM>`_ semantics used by most
+GIS tools.
+
+If you instead want boundary points to be treated as *inside* the
+region, use the ``covers`` method. It is available on pixel regions
+(`regions.PixelRegion.covers`), planar sky regions
+(`regions.SkyRegion.covers`), and spherical sky regions
+(`regions.SphericalSkyRegion.covers`), and takes the same arguments as
+the corresponding ``contains`` method.
+
+For example, the point ``(84, 43)`` lies exactly on the boundary of our
+circular pixel region (centered at ``(42, 43)`` with a radius of
+``42``), so it is excluded by ``contains`` but included by ``covers``::
+
+    >>> boundary_point = PixCoord(84, 43)
+    >>> pixel_region.contains(boundary_point)
+    np.False_
+    >>> pixel_region.covers(boundary_point)
+    np.True_
+
+For points strictly inside or strictly outside the region, the two
+methods return identical results::
+
+    >>> pixel_region.contains(PixCoord(42, 43))
+    np.True_
+    >>> pixel_region.covers(PixCoord(42, 43))
+    np.True_
+
+.. note::
+
+    The ``covers`` method is currently implemented for circle, ellipse,
+    rectangle, polygon, and annulus regions (and their sky and
+    spherical-sky equivalents); calling it on a region type that does
+    not support it raises a `NotImplementedError`.

--- a/regions/_geometry/pnpoly.pxd
+++ b/regions/_geometry/pnpoly.pxd
@@ -8,3 +8,5 @@ cimport numpy as np
 ctypedef np.float64_t DTYPE_t
 
 cdef int point_in_polygon(double x, double y, np.ndarray[DTYPE_t, ndim=1] vx, np.ndarray[DTYPE_t, ndim=1] vy)
+cdef int point_in_polygon_covers(double x, double y, np.ndarray[DTYPE_t, ndim=1] vx, np.ndarray[DTYPE_t, ndim=1] vy)
+cdef int point_in_polygon_even_odd(double x, double y, np.ndarray[DTYPE_t, ndim=1] vx, np.ndarray[DTYPE_t, ndim=1] vy)

--- a/regions/_geometry/pnpoly.pyx
+++ b/regions/_geometry/pnpoly.pyx
@@ -75,7 +75,25 @@ def points_in_polygon(np.ndarray[DTYPE_t, ndim=1] x,
                       np.ndarray[DTYPE_t, ndim=1] y,
                       np.ndarray[DTYPE_t, ndim=1] vx,
                       np.ndarray[DTYPE_t, ndim=1] vy):
+    """
+    Determine whether points are strictly inside a polygon (excluding
+    boundary).
 
+    This is consistent with Shapely's ``contains`` function and DE-9IM
+    semantics.
+
+    Parameters
+    ----------
+    x, y : ndarray
+        The x and y coordinates of the test points.
+    vx, vy : ndarray
+        The x and y coordinates of the polygon vertices.
+
+    Returns
+    -------
+    result : ndarray of bool
+        True if the point is strictly inside the polygon, False otherwise.
+    """
     cdef int i, n
     cdef np.ndarray[np.uint8_t, ndim=1, cast=True] result
 
@@ -89,24 +107,114 @@ def points_in_polygon(np.ndarray[DTYPE_t, ndim=1] x,
     return result
 
 
-cdef int point_in_polygon(double x, double y,
-                          np.ndarray[DTYPE_t, ndim=1] vx,
-                          np.ndarray[DTYPE_t, ndim=1] vy):
+def points_in_polygon_covers(np.ndarray[DTYPE_t, ndim=1] x,
+                             np.ndarray[DTYPE_t, ndim=1] y,
+                             np.ndarray[DTYPE_t, ndim=1] vx,
+                             np.ndarray[DTYPE_t, ndim=1] vy):
     """
-    Determine whether a test point (x, y) is within a polygon defined by a set
-    of vertices (vx, vy).
+    Determine whether points are inside or on the boundary of a polygon.
+
+    This is consistent with Shapely's ``covers`` function and DE-9IM
+    semantics.
+
+    Parameters
+    ----------
+    x, y : ndarray
+        The x and y coordinates of the test points.
+    vx, vy : ndarray
+        The x and y coordinates of the polygon vertices.
+
+    Returns
+    -------
+    result : ndarray of bool
+        True if the point is inside or on the boundary of the polygon,
+        False otherwise.
+    """
+    cdef int i, n
+    cdef np.ndarray[np.uint8_t, ndim=1, cast=True] result
+
+    n = x.shape[0]
+
+    result = np.zeros(n, DTYPE_BOOL)
+
+    for i in range(n):
+        result[i] = point_in_polygon_covers(x[i], y[i], vx, vy)
+
+    return result
+
+
+cdef inline int point_on_segment(double px, double py,
+                                  double x1, double y1,
+                                  double x2, double y2) noexcept nogil:
+    """
+    Check whether the point (px, py) lies on the line segment from
+    (x1, y1) to (x2, y2).
+
+    The collinearity tolerance is expressed as a perpendicular
+    distance from the point to the segment so that the test behaves
+    consistently regardless of the segment length or the magnitude of
+    the coordinates.
+
+    The tolerance is an absolute distance in pixel units (1e-10 px), not
+    a relative tolerance, so it is most appropriate for the pixel-scale
+    coordinates used by the region classes.
+    """
+    cdef double x_min, x_max, y_min, y_max, cross, seg_len_sq
+    cdef double tol = 1e-10  # perpendicular distance tolerance (pixels)
+
+    # Check bounding box
+    if x1 < x2:
+        x_min = x1
+        x_max = x2
+    else:
+        x_min = x2
+        x_max = x1
+
+    if y1 < y2:
+        y_min = y1
+        y_max = y2
+    else:
+        y_min = y2
+        y_max = y1
+
+    if px < x_min or px > x_max or py < y_min or py > y_max:
+        return 0
+
+    seg_len_sq = (x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1)
+    if seg_len_sq == 0:
+        # Degenerate segment (duplicate vertices); treat it as a point.
+        return 1 if (px == x1 and py == y1) else 0
+
+    # The cross product magnitude equals perpendicular_distance times
+    # segment_length, so comparing its square to tol**2 * seg_len_sq
+    # tests the perpendicular distance against tol independently of the
+    # segment length.
+    cross = (px - x1) * (y2 - y1) - (py - y1) * (x2 - x1)
+    if cross * cross > tol * tol * seg_len_sq:
+        return 0
+
+    return 1
+
+
+cdef int point_in_polygon_even_odd(double x, double y,
+                                   np.ndarray[DTYPE_t, ndim=1] vx,
+                                   np.ndarray[DTYPE_t, ndim=1] vy):
+    """
+    Determine whether the point (x, y) is inside a polygon using the
+    even-odd (ray-casting) rule, ignoring the polygon boundary.
+
+    Boundary behavior is undefined here; callers that need well-defined
+    boundary semantics should use `point_in_polygon` (boundary excluded)
+    or `point_in_polygon_covers` (boundary included).
 
     This uses the even-odd rule, as described here:
 
         https://en.wikipedia.org/wiki/Even–odd_rule
     """
-
-    cdef int i, j, k, m, n
-    cdef int result
+    cdef int i, j, n
+    cdef int result = 0
 
     n = vx.shape[0]
-
-    result = 0
 
     for i in range(n):
         j = (i + n - 1) % n
@@ -115,3 +223,63 @@ cdef int point_in_polygon(double x, double y,
             result += 1
 
     return result % 2
+
+
+cdef int point_in_polygon(double x, double y,
+                          np.ndarray[DTYPE_t, ndim=1] vx,
+                          np.ndarray[DTYPE_t, ndim=1] vy):
+    """
+    Determine whether a test point (x, y) is strictly inside a polygon
+    defined by a set of vertices (vx, vy).
+
+    Points on the boundary (edges and vertices) are NOT considered
+    inside, consistent with Shapely's ``contains`` function and DE-9IM
+    semantics.
+    """
+    cdef int i, j, n
+
+    # The even-odd (ray-casting) rule is reliable for points that are
+    # strictly inside or strictly outside; it is only ambiguous on the
+    # boundary. Points reported as outside are not inside and are not
+    # strictly inside even if they lie on an edge, so no edge scan is
+    # needed for them. Only points reported as inside require an edge
+    # scan to exclude boundary points.
+    if point_in_polygon_even_odd(x, y, vx, vy) == 0:
+        return 0
+
+    n = vx.shape[0]
+    for i in range(n):
+        j = (i + n - 1) % n
+        if point_on_segment(x, y, vx[i], vy[i], vx[j], vy[j]):
+            return 0
+
+    return 1
+
+
+cdef int point_in_polygon_covers(double x, double y,
+                                 np.ndarray[DTYPE_t, ndim=1] vx,
+                                 np.ndarray[DTYPE_t, ndim=1] vy):
+    """
+    Determine whether a test point (x, y) is inside or on the boundary
+    of a polygon defined by a set of vertices (vx, vy).
+
+    Points on the boundary (edges and vertices) ARE considered inside,
+    consistent with Shapely's ``covers`` function and DE-9IM semantics.
+    """
+    cdef int i, j, n
+
+    # The even-odd (ray-casting) rule is reliable for points that are
+    # strictly inside or strictly outside; it is only ambiguous on the
+    # boundary. Points reported as inside are covered regardless of the
+    # boundary, so no edge scan is needed for them. Only points reported
+    # as outside require an edge scan to include boundary points.
+    if point_in_polygon_even_odd(x, y, vx, vy) == 1:
+        return 1
+
+    n = vx.shape[0]
+    for i in range(n):
+        j = (i + n - 1) % n
+        if point_on_segment(x, y, vx[i], vy[i], vx[j], vy[j]):
+            return 1
+
+    return 0

--- a/regions/_geometry/polygonal_overlap.pyx
+++ b/regions/_geometry/polygonal_overlap.pyx
@@ -3,7 +3,7 @@
 import numpy as np
 cimport numpy as np
 
-from .pnpoly cimport point_in_polygon
+from .pnpoly cimport point_in_polygon_even_odd
 
 __all__ = ['polygonal_overlap_grid']
 
@@ -105,7 +105,7 @@ cdef double polygonal_overlap_single_subpixel(double x0, double y0,
         y = y0 - 0.5 * dy
         for j in range(subpixels):
             y += dy
-            if point_in_polygon(x, y, vx, vy) == 1:
+            if point_in_polygon_even_odd(x, y, vx, vy) == 1:
                 frac += 1.
 
     return frac / (subpixels * subpixels)

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -62,6 +62,10 @@ class CompoundPixelRegion(PixelRegion):
         return self.operator(self.region1.contains(pixcoord),
                              self.region2.contains(pixcoord))
 
+    def covers(self, pixcoord):
+        return self.operator(self.region1.covers(pixcoord),
+                             self.region2.covers(pixcoord))
+
     def to_mask(self, mode='center', subpixels=1):
         if mode != 'center':
             raise NotImplementedError
@@ -260,6 +264,10 @@ class CompoundSkyRegion(SkyRegion):
         return self.operator(self.region1.contains(skycoord, wcs),
                              self.region2.contains(skycoord, wcs))
 
+    def covers(self, skycoord, wcs):
+        return self.operator(self.region1.covers(skycoord, wcs),
+                             self.region2.covers(skycoord, wcs))
+
     def to_pixel(self, wcs):
         pixreg1 = self.region1.to_pixel(wcs=wcs)
         pixreg2 = self.region2.to_pixel(wcs=wcs)
@@ -440,6 +448,11 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
     def contains(self, coord):
         return self.operator(
             self.region1.contains(coord), self.region2.contains(coord),
+        )
+
+    def covers(self, coord):
+        return self.operator(
+            self.region1.covers(coord), self.region2.covers(coord),
         )
 
     def transform_to(self, frame, merge_attributes=True):

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -59,12 +59,8 @@ class CompoundPixelRegion(PixelRegion):
         return self._operator
 
     def contains(self, pixcoord):
-        in_reg = self.operator(self.region1.contains(pixcoord),
-                               self.region2.contains(pixcoord))
-        if self.meta.get('include', True):
-            return in_reg
-        else:
-            return np.logical_not(in_reg)
+        return self.operator(self.region1.contains(pixcoord),
+                             self.region2.contains(pixcoord))
 
     def to_mask(self, mode='center', subpixels=1):
         if mode != 'center':
@@ -261,12 +257,8 @@ class CompoundSkyRegion(SkyRegion):
         return self._operator
 
     def contains(self, skycoord, wcs):
-        in_reg = self.operator(self.region1.contains(skycoord, wcs),
-                               self.region2.contains(skycoord, wcs))
-        if self.meta.get('include', True):
-            return in_reg
-        else:
-            return np.logical_not(in_reg)
+        return self.operator(self.region1.contains(skycoord, wcs),
+                             self.region2.contains(skycoord, wcs))
 
     def to_pixel(self, wcs):
         pixreg1 = self.region1.to_pixel(wcs=wcs)
@@ -446,13 +438,9 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
         raise NotImplementedError
 
     def contains(self, coord):
-        in_reg = self.operator(
+        return self.operator(
             self.region1.contains(coord), self.region2.contains(coord),
         )
-        if self.meta.get('include', True):
-            return in_reg
-        else:
-            return np.logical_not(in_reg)
 
     def transform_to(self, frame, merge_attributes=True):
         # Transform the consitituent regions then recompose:

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -978,14 +978,44 @@ class SphericalSkyRegion(Region):
     def contains(self, coord):
         """
         Check whether a sky coordinate falls inside the spherical sky
-        region.
+        region, excluding the boundary.
+
+        This method considers points on the boundary as outside the
+        region, consistent with Shapely's ``contains`` function and
+        DE-9IM semantics.
 
         Parameters
         ----------
         coord : `~astropy.coordinates.SkyCoord`
             The position or positions to check.
+
+        See Also
+        --------
+        covers : Check if points are inside or on the boundary.
         """
         raise NotImplementedError
+
+    def covers(self, coord):
+        """
+        Check whether a sky coordinate falls inside the spherical sky
+        region, including the boundary.
+
+        This method considers points on the boundary as inside the
+        region, consistent with Shapely's ``covers`` function and DE-9IM
+        semantics.
+
+        Parameters
+        ----------
+        coord : `~astropy.coordinates.SkyCoord`
+            The position or positions to check.
+
+        See Also
+        --------
+        contains : Check if points are strictly inside (excludes boundary).
+        """
+        msg = ("The 'covers' method is not supported for "
+               f'{self.__class__.__name__}.')
+        raise NotImplementedError(msg)
 
     @abc.abstractmethod
     def transform_to(self, frame, merge_attributes=True):

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -438,14 +438,31 @@ class PixelRegion(Region):
     @abc.abstractmethod
     def contains(self, pixcoord):
         """
-        Check whether a position or positions fall inside the region.
+        Check whether a position or positions fall inside the region,
+        excluding the boundary.
+
+        This method considers points on the boundary as outside the
+        region, consistent with Shapely's ``contains`` function and
+        DE-9IM semantics.
 
         Parameters
         ----------
         pixcoord : `~regions.PixCoord`
             The position or positions to check.
+
+        Returns
+        -------
+        result : bool or `~numpy.ndarray`
+            A boolean or boolean array indicating whether the position(s)
+            are inside the region.
+
+        See Also
+        --------
+        covers : Check if points are inside or on the boundary.
         """
-        raise NotImplementedError
+        msg = ("The 'contains' method is not supported for "
+               f'{self.__class__.__name__}.')
+        raise NotImplementedError(msg)
 
     def __contains__(self, coord):
         if not coord.isscalar:
@@ -477,7 +494,7 @@ class PixelRegion(Region):
         contains : Check if points are strictly inside (excludes boundary).
         """
         msg = ("The 'covers' method is not supported for "
-               '{self.__class__.__name__}.')
+               f'{self.__class__.__name__}.')
         raise NotImplementedError(msg)
 
     @abc.abstractmethod

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -452,6 +452,34 @@ class PixelRegion(Region):
             raise ValueError(f'coord must be scalar. coord={coord}')
         return self.contains(coord)
 
+    def covers(self, pixcoord):
+        """
+        Check whether a position or positions fall inside the region,
+        including the boundary.
+
+        This method considers points on the boundary as inside the
+        region, consistent with Shapely's ``covers`` function and DE-9IM
+        semantics.
+
+        Parameters
+        ----------
+        pixcoord : `~regions.PixCoord`
+            The position or positions to check.
+
+        Returns
+        -------
+        result : bool or `~numpy.ndarray`
+            A boolean or boolean array indicating whether the position(s)
+            are inside or on the boundary of the region.
+
+        See Also
+        --------
+        contains : Check if points are strictly inside (excludes boundary).
+        """
+        msg = ("The 'covers' method is not supported for "
+               '{self.__class__.__name__}.')
+        raise NotImplementedError(msg)
+
     @abc.abstractmethod
     def to_sky(self, wcs):
         """
@@ -713,6 +741,38 @@ class SkyRegion(Region):
         pixel_region = self.to_pixel(wcs)
         pixcoord = PixCoord.from_sky(skycoord, wcs)
         return pixel_region.contains(pixcoord)
+
+    def covers(self, skycoord, wcs):
+        """
+        Check whether a sky coordinate falls inside or on the boundary
+        of the region.
+
+        This method considers points on the boundary as inside the
+        region, consistent with Shapely's ``covers`` function and DE-9IM
+        semantics.
+
+        Parameters
+        ----------
+        skycoord : `~astropy.coordinates.SkyCoord`
+            The position or positions to check.
+        wcs : `~astropy.wcs.WCS`
+            The world coordinate system transformation to use to convert
+            between sky and pixel coordinates.
+
+        See Also
+        --------
+        contains : Check if points are strictly inside (excludes boundary).
+
+        Notes
+        -----
+        This method requires the pixel region returned by ``to_pixel``
+        to implement a ``covers`` method. It is currently available
+        for circle, ellipse, rectangle, and polygon regions; for other
+        regions a `NotImplementedError` is raised.
+        """
+        pixel_region = self.to_pixel(wcs)
+        pixcoord = PixCoord.from_sky(skycoord, wcs)
+        return pixel_region.covers(pixcoord)
 
     @abc.abstractmethod
     def to_pixel(self, wcs):

--- a/regions/core/tests/test_regions.py
+++ b/regions/core/tests/test_regions.py
@@ -8,8 +8,8 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 
+from regions import CirclePixelRegion, CircleSkyRegion, RectanglePixelRegion
 from regions.core import PixCoord, Region, Regions
-from regions.shapes import CirclePixelRegion, CircleSkyRegion
 
 
 def test_regions_inputs():
@@ -208,14 +208,14 @@ def test_is_close_non_comparable():
         def __eq__(self, other):
             raise TypeError
 
-    b = BadCompare()
-    assert not Region._is_close(b, b)
+    bad = BadCompare()
+    assert not Region._is_close(bad, bad)
 
 
 def test_region_eq_param_mismatch():
     """
-    Test that if two regions are of the same class but have mismatched _params,
-    then they should not be considered equal.
+    Test that if two regions are of the same class but have mismatched
+    _params, then they should not be considered equal.
 
     This is a sanity check to ensure that the __eq__ method is correctly
     comparing the parameters of the regions.
@@ -224,3 +224,15 @@ def test_region_eq_param_mismatch():
     reg2 = CirclePixelRegion(PixCoord(0, 0), radius=1)
     reg2._params = ()  # simulate mismatched parameter set
     assert reg1 != reg2
+
+
+def test_compound_covers():
+    """
+    Test covers method on compound regions.
+    """
+    rect = RectanglePixelRegion(center=PixCoord(1, 1), width=2, height=2)
+    comp_union = rect.union(rect)
+    assert comp_union.covers(PixCoord(1, 1))
+
+    comp_inter = rect.intersection(rect)
+    assert comp_inter.covers(PixCoord(2, 2))  # on the boundary

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -8,6 +8,7 @@ import math
 import operator
 
 import astropy.units as u
+import numpy as np
 
 from regions._utils.wcs_helpers import (pixel_shape_to_sky_svd,
                                         pixel_to_sky_mean_scale,
@@ -56,6 +57,11 @@ class AnnulusPixelRegion(PixelRegion, abc.ABC):
 
     def contains(self, pixcoord):
         return self._compound_region.contains(pixcoord)
+
+    def covers(self, pixcoord):
+        outer_cov = self._outer_region.covers(pixcoord)
+        inner_con = self._inner_region.contains(pixcoord)
+        return np.logical_and(outer_cov, np.logical_not(inner_con))
 
     def as_artist(self, origin=(0, 0), **kwargs):
         return self._compound_region.as_artist(origin, **kwargs)
@@ -123,6 +129,9 @@ class AnnulusSphericalSkyRegion(SphericalSkyRegion, abc.ABC):
 
     def contains(self, coord):
         return self._compound_region.contains(coord)
+
+    def covers(self, coord):
+        return self._compound_region.covers(coord)
 
 
 class CircleAnnulusPixelRegion(AnnulusPixelRegion):

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -85,11 +85,7 @@ class CirclePixelRegion(PixelRegion):
 
     def contains(self, pixcoord):
         pixcoord = PixCoord._validate(pixcoord, name='pixcoord')
-        in_circle = self.center.separation(pixcoord) < self.radius
-        if self.meta.get('include', True):
-            return in_circle
-        else:
-            return np.logical_not(in_circle)
+        return self.center.separation(pixcoord) < self.radius
 
     def to_sky(self, wcs, *, as_ellipse=False):
         """
@@ -410,11 +406,7 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
         self.visual = visual or RegionVisual()
 
     def contains(self, coord):
-        in_circle = self.center.separation(coord) < self.radius
-        if self.meta.get('include', True):
-            return in_circle
-        else:
-            return np.logical_not(in_circle)
+        return self.center.separation(coord) < self.radius
 
     @property
     def bounding_circle(self):

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -83,9 +83,23 @@ class CirclePixelRegion(PixelRegion):
     def area(self):
         return math.pi * self.radius ** 2
 
-    def contains(self, pixcoord):
+    def _containment(self, pixcoord, covers=False):
+        """
+        Helper method for circle containment checks.
+        """
         pixcoord = PixCoord._validate(pixcoord, name='pixcoord')
-        return self.center.separation(pixcoord) < self.radius
+        sep = self.center.separation(pixcoord)
+
+        if covers:
+            return sep <= self.radius
+
+        return sep < self.radius
+
+    def contains(self, pixcoord):
+        return self._containment(pixcoord, covers=False)
+
+    def covers(self, pixcoord):
+        return self._containment(pixcoord, covers=True)
 
     def to_sky(self, wcs, *, as_ellipse=False):
         """
@@ -405,8 +419,17 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
 
+    def _containment(self, coord, covers=False):
+        sep = self.center.separation(coord)
+        if covers:
+            return sep <= self.radius
+        return sep < self.radius
+
     def contains(self, coord):
-        return self.center.separation(coord) < self.radius
+        return self._containment(coord, covers=False)
+
+    def covers(self, coord):
+        return self._containment(coord, covers=True)
 
     @property
     def bounding_circle(self):

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -96,15 +96,25 @@ class EllipsePixelRegion(PixelRegion):
     def area(self):
         return math.pi / 4 * self.width * self.height
 
-    def contains(self, pixcoord):
+    def _containment(self, pixcoord, covers=False):
         pixcoord = PixCoord._validate(pixcoord, name='pixcoord')
         cos_angle = np.cos(self.angle)
         sin_angle = np.sin(self.angle)
         dx = pixcoord.x - self.center.x
         dy = pixcoord.y - self.center.y
-        return ((2 * (cos_angle * dx + sin_angle * dy) / self.width) ** 2
-                + (2 * (sin_angle * dx - cos_angle * dy)
-                   / self.height) ** 2 <= 1.)
+        value = ((2 * (cos_angle * dx + sin_angle * dy) / self.width) ** 2
+                 + (2 * (sin_angle * dx - cos_angle * dy) / self.height) ** 2)
+
+        if covers:
+            return value <= 1.0
+
+        return value < 1.0
+
+    def contains(self, pixcoord):
+        return self._containment(pixcoord, covers=False)
+
+    def covers(self, pixcoord):
+        return self._containment(pixcoord, covers=True)
 
     def to_sky(self, wcs):
         # The photutils helpers measure the sky rotation as a position

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -102,13 +102,9 @@ class EllipsePixelRegion(PixelRegion):
         sin_angle = np.sin(self.angle)
         dx = pixcoord.x - self.center.x
         dy = pixcoord.y - self.center.y
-        in_ell = ((2 * (cos_angle * dx + sin_angle * dy) / self.width) ** 2
-                  + (2 * (sin_angle * dx - cos_angle * dy)
-                     / self.height) ** 2 <= 1.)
-        if self.meta.get('include', True):
-            return in_ell
-        else:
-            return np.logical_not(in_ell)
+        return ((2 * (cos_angle * dx + sin_angle * dy) / self.width) ** 2
+                + (2 * (sin_angle * dx - cos_angle * dy)
+                   / self.height) ** 2 <= 1.)
 
     def to_sky(self, wcs):
         # The photutils helpers measure the sky rotation as a position

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -70,13 +70,8 @@ class LinePixelRegion(PixelRegion):
         return 0
 
     def contains(self, pixcoord):
-        in_reg = (False if pixcoord.isscalar
-                  else np.zeros(pixcoord.x.shape, dtype=bool))
-
-        if self.meta.get('include', True):
-            return in_reg
-        else:
-            return np.logical_not(in_reg)
+        return (False if pixcoord.isscalar
+                else np.zeros(pixcoord.x.shape, dtype=bool))
 
     def to_sky(self, wcs):
         start = wcs.pixel_to_world(self.start.x, self.start.y)

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -70,6 +70,12 @@ class LinePixelRegion(PixelRegion):
         return 0
 
     def contains(self, pixcoord):
+        # Lines never contain anything
+        return (False if pixcoord.isscalar
+                else np.zeros(pixcoord.x.shape, dtype=bool))
+
+    def covers(self, pixcoord):
+        # Lines never cover anything
         return (False if pixcoord.isscalar
                 else np.zeros(pixcoord.x.shape, dtype=bool))
 
@@ -178,7 +184,12 @@ class LineSkyRegion(SkyRegion):
         self.visual = visual or RegionVisual()
 
     def contains(self, skycoord, wcs):  # pylint: disable=unused-argument
-        # lines never contain anything
+        # Lines never contain anything
+        return (False if skycoord.isscalar
+                else np.zeros(skycoord.shape, dtype=bool))
+
+    def covers(self, skycoord, wcs):  # pylint: disable=unused-argument
+        # Lines never cover anything
         return (False if skycoord.isscalar
                 else np.zeros(skycoord.shape, dtype=bool))
 

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -179,7 +179,8 @@ class LineSkyRegion(SkyRegion):
 
     def contains(self, skycoord, wcs):  # pylint: disable=unused-argument
         # lines never contain anything
-        return not self.meta.get('include', True)
+        return (False if skycoord.isscalar
+                else np.zeros(skycoord.shape, dtype=bool))
 
     def to_pixel(self, wcs):
         start_x, start_y = wcs.world_to_pixel(self.start)

--- a/regions/shapes/lune.py
+++ b/regions/shapes/lune.py
@@ -171,6 +171,9 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
     def contains(self, coord):
         return self._compound_region.contains(coord)
 
+    def covers(self, coord):
+        return self._compound_region.covers(coord)
+
     def transform_to(self, frame, merge_attributes=True):
         frame = self._validate_frame_transformation(frame)
 

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -75,14 +75,8 @@ class PointPixelRegion(PixelRegion):
         return 0.0
 
     def contains(self, pixcoord):
-        in_reg = (False if pixcoord.isscalar
-                  else np.zeros(pixcoord.x.shape, dtype=bool))
-
-        if self.meta.get('include', True):
-            # in_reg = False, always.  Points do not include anything.
-            return in_reg
-        else:
-            return np.logical_not(in_reg)
+        return (False if pixcoord.isscalar
+                else np.zeros(pixcoord.x.shape, dtype=bool))
 
     def to_sky(self, wcs):
         center = wcs.pixel_to_world(self.center.x, self.center.y)

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -176,7 +176,8 @@ class PointSkyRegion(SkyRegion):
 
     def contains(self, skycoord, wcs):  # pylint: disable=unused-argument
         # points never include anything
-        return not self.meta.get('include', True)
+        return (False if skycoord.isscalar
+                else np.zeros(skycoord.shape, dtype=bool))
 
     def to_pixel(self, wcs):
         center_x, center_y = wcs.world_to_pixel(self.center)

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -75,6 +75,12 @@ class PointPixelRegion(PixelRegion):
         return 0.0
 
     def contains(self, pixcoord):
+        # Points never contain anything
+        return (False if pixcoord.isscalar
+                else np.zeros(pixcoord.x.shape, dtype=bool))
+
+    def covers(self, pixcoord):
+        # Points never cover anything
         return (False if pixcoord.isscalar
                 else np.zeros(pixcoord.x.shape, dtype=bool))
 
@@ -175,7 +181,12 @@ class PointSkyRegion(SkyRegion):
         self.visual = visual or RegionVisual()
 
     def contains(self, skycoord, wcs):  # pylint: disable=unused-argument
-        # points never include anything
+        # Points never contain anything
+        return (False if skycoord.isscalar
+                else np.zeros(skycoord.shape, dtype=bool))
+
+    def covers(self, skycoord, wcs):  # pylint: disable=unused-argument
+        # Points never cover anything
         return (False if skycoord.isscalar
                 else np.zeros(skycoord.shape, dtype=bool))
 

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -10,7 +10,8 @@ from astropy.coordinates import SkyCoord
 from astropy.stats import circmean
 
 from regions._geometry import polygonal_overlap_grid
-from regions._geometry.pnpoly import points_in_polygon
+from regions._geometry.pnpoly import (points_in_polygon,
+                                      points_in_polygon_covers)
 from regions._utils.spherical_helpers import (
     cross_product_skycoord2skycoord, cross_product_sum_skycoord2skycoord,
     discretize_all_edge_boundaries, get_edge_raw_lonlat_bounds_circ_edges)
@@ -99,16 +100,28 @@ class PolygonPixelRegion(PixelRegion):
         area_last = x_[-1] * y_[0] - y_[-1] * x_[0]
         return 0.5 * np.abs(area_main + area_last)
 
-    def contains(self, pixcoord):
-        pixcoord = PixCoord._validate(pixcoord, 'pixcoord')
+    def _containment(self, pixcoord, covers=False):
+        pixcoord = PixCoord._validate(pixcoord, name='pixcoord')
         x = np.atleast_1d(np.asarray(pixcoord.x, dtype=float))
         y = np.atleast_1d(np.asarray(pixcoord.y, dtype=float))
         vx = np.asarray(self.vertices.x, dtype=float)
         vy = np.asarray(self.vertices.y, dtype=float)
 
         shape = x.shape
-        mask = points_in_polygon(x.flatten(), y.flatten(), vx, vy).astype(bool)
+        if covers:
+            mask = points_in_polygon_covers(x.flatten(), y.flatten(),
+                                            vx, vy).astype(bool)
+        else:
+            mask = points_in_polygon(x.flatten(), y.flatten(),
+                                     vx, vy).astype(bool)
+
         return mask.reshape(shape)
+
+    def contains(self, pixcoord):
+        return self._containment(pixcoord, covers=False)
+
+    def covers(self, pixcoord):
+        return self._containment(pixcoord, covers=True)
 
     def to_sky(self, wcs):
         vertices_sky = wcs.pixel_to_world(self.vertices.x, self.vertices.y)

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -498,9 +498,11 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
 
     @property
     def _compound_region(self):
-        # Need N great circles to define boundaries for an N-sided polygon.
-        # verts are in CW order: Cross product to get bounding great circle centers
-        # Compute GCs and stack into a compound set:
+        # Need N great circles to define boundaries for an N-sided
+        # polygon.
+        # verts are in CW order: Cross product to get bounding great
+        # circle centers.
+        # Compute GCs and stack into a compound set.
         compreg = None
         gcs = self._edge_circs
         for gc in gcs:
@@ -523,9 +525,8 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
         However, if this is not contained within the polygon, instead
         use the average of the vertices' positions.
         """
-        # Calculate from cross products of vertices with cartesian representation
-        # verts are in CW order:
-        # Minimum distance
+        # Calculate from cross products of vertices with cartesian
+        # representation verts are in CW order
         centroid_mindist = self.centroid_mindist
 
         if not self.contains(centroid_mindist):
@@ -539,9 +540,8 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
         Region centroid, defined as the point equidistant from all
         vertices (minimum distance).
         """
-        # Calculate from cross products of vertices with cartesian representation
-        # verts are in CW order:
-        # Minimum distance
+        # Calculate from cross products of vertices with cartesian
+        # representation verts are in CW order
         return cross_product_sum_skycoord2skycoord(self.vertices)
 
     @property
@@ -579,11 +579,15 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
     def contains(self, coord):
         return self._compound_region.contains(coord)
 
+    def covers(self, coord):
+        return self._compound_region.covers(coord)
+
     def transform_to(self, frame, merge_attributes=True):
         frame = self._validate_frame_transformation(frame)
 
         # Only center transforms, radii preserved
-        verts_transf = self.vertices.transform_to(frame, merge_attributes=merge_attributes)
+        verts_transf = self.vertices.transform_to(
+            frame, merge_attributes=merge_attributes)
 
         return PolygonSphericalSkyRegion(
             verts_transf,

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -108,11 +108,7 @@ class PolygonPixelRegion(PixelRegion):
 
         shape = x.shape
         mask = points_in_polygon(x.flatten(), y.flatten(), vx, vy).astype(bool)
-        in_poly = mask.reshape(shape)
-        if self.meta.get('include', True):
-            return in_poly
-        else:
-            return np.logical_not(in_poly)
+        return mask.reshape(shape)
 
     def to_sky(self, wcs):
         vertices_sky = wcs.pixel_to_world(self.vertices.x, self.vertices.y)

--- a/regions/shapes/range.py
+++ b/regions/shapes/range.py
@@ -700,19 +700,20 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         if bound_nverts == 6:
             raise NotImplementedError
 
-    def contains(self, coord):
+    def _containment(self, coord, covers=False):
         if self._is_original_frame:
-            # Just compute directly from lon/lat ranges:
+            # Just compute directly from lon/lat ranges
 
-            # Ensure coordinate is in same frame:
+            # Ensure coordinate is in same frame
             c_repr = coord.represent_as('spherical')
 
-            # Longitude range constraints:
+            # Longitude range constraints
             if self.longitude_range is not None:
-                # Ensure lon range is wrapped at 360, matching internal SkyCoord convention
-                # To handle possible cases of lon ranges "wrapping around" across
-                # the standard 360->0 wrap, wrap lon ranges + coord values
-                # around the first entry angle
+                # Ensure lon range is wrapped at 360, matching internal
+                # SkyCoord convention. To handle possible cases of lon
+                # ranges "wrapping around" across the standard 360->0
+                # wrap, wrap lon ranges + coord values around the first
+                # entry angle
                 wrap_ang = self.longitude_range[0]
                 coord_lons = c_repr.lon.wrap_at(wrap_ang)
                 in_range_lon = (
@@ -725,12 +726,12 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
             else:
                 in_range_lon = np.ones(coord.shape, dtype=bool)
 
-            # Latitude range constraints:
+            # Latitude range constraints
             if self.latitude_range is not None:
                 coord_lat = c_repr.lat
 
-                # Check if latitude ranges are "simpler":
-                # Equivalent to no constraints, or simpler circles:
+                # Check if latitude ranges are "simpler".
+                # Equivalent to no constraints, or simpler circles.
                 if (
                     (self.latitude_range[1] == Angle(90 * u.deg))
                     & (self.latitude_range[0] == Angle(-90 * u.deg))
@@ -765,7 +766,16 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
             return in_range_lon & in_range_lat
 
         # If transformed: must use boundary compound region logic:
+        if covers:
+            return self._compound_region.covers(coord)
+
         return self._compound_region.contains(coord)
+
+    def contains(self, coord):
+        return self._containment(coord, covers=False)
+
+    def covers(self, coord):
+        return self._containment(coord, covers=True)
 
     def transform_to(self, frame, merge_attributes=True):
         frame = self._validate_frame_transformation(frame)

--- a/regions/shapes/range.py
+++ b/regions/shapes/range.py
@@ -762,12 +762,7 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
             else:
                 in_range_lat = np.ones(coord.shape, dtype=bool)
 
-            in_range = in_range_lon & in_range_lat
-
-            if self.meta.get('include', True):
-                return in_range
-            else:
-                return np.logical_not(in_range)
+            return in_range_lon & in_range_lat
 
         # If transformed: must use boundary compound region logic:
         return self._compound_region.contains(coord)

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -101,12 +101,8 @@ class RectanglePixelRegion(PixelRegion):
         dy = pixcoord.y - self.center.y
         dx_rot = cos_angle * dx + sin_angle * dy
         dy_rot = sin_angle * dx - cos_angle * dy
-        in_rect = ((np.abs(dx_rot) < self.width * 0.5)
-                   & (np.abs(dy_rot) < self.height * 0.5))
-        if self.meta.get('include', True):
-            return in_rect
-        else:
-            return np.logical_not(in_rect)
+        return ((np.abs(dx_rot) < self.width * 0.5)
+                & (np.abs(dy_rot) < self.height * 0.5))
 
     def to_sky(self, wcs):
         # The photutils SVD helpers measure the sky rotation as a

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -94,15 +94,27 @@ class RectanglePixelRegion(PixelRegion):
     def area(self):
         return self.width * self.height
 
-    def contains(self, pixcoord):
+    def _containment(self, pixcoord, covers=False):
+        pixcoord = PixCoord._validate(pixcoord, name='pixcoord')
         cos_angle = np.cos(self.angle)
         sin_angle = np.sin(self.angle)
         dx = pixcoord.x - self.center.x
         dy = pixcoord.y - self.center.y
         dx_rot = cos_angle * dx + sin_angle * dy
         dy_rot = sin_angle * dx - cos_angle * dy
+
+        if covers:
+            return ((np.abs(dx_rot) <= self.width * 0.5)
+                    & (np.abs(dy_rot) <= self.height * 0.5))
+
         return ((np.abs(dx_rot) < self.width * 0.5)
                 & (np.abs(dy_rot) < self.height * 0.5))
+
+    def contains(self, pixcoord):
+        return self._containment(pixcoord, covers=False)
+
+    def covers(self, pixcoord):
+        return self._containment(pixcoord, covers=True)
 
     def to_sky(self, wcs):
         # The photutils SVD helpers measure the sky rotation as a

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -8,7 +8,7 @@ from astropy.io import fits
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 from regions.core import PixCoord, RegionMeta, RegionVisual
 from regions.core.compound import CompoundPixelRegion, CompoundSkyRegion
@@ -108,6 +108,22 @@ class TestCircleAnnulusPixelRegion(BaseTestPixelRegion):
         assert reg == self.reg
         reg.inner_radius = 3
         assert reg != self.reg
+
+    def test_covers(self):
+        # Point at center (inside inner)
+        assert not self.reg.covers(PixCoord(3, 4))
+        # Point on inner boundary
+        assert self.reg.covers(PixCoord(3, 2))
+        # Point in body of the annulus
+        assert self.reg.covers(PixCoord(3, 1.5))
+        # Point on outer boundary
+        assert self.reg.covers(PixCoord(3, 7))
+        # Point outside the annulus
+        assert not self.reg.covers(PixCoord(3, 8))
+
+        # Multiple points check together
+        pts = PixCoord([3, 3, 3, 3, 3], [4, 2, 1.5, 7, 8])
+        assert_equal(self.reg.covers(pts), [False, True, True, True, False])
 
 
 class TestCircleAnnulusSkyRegion(BaseTestSkyRegion):

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -10,7 +10,7 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
 from numpy.testing import assert_allclose, assert_equal
 
-from regions._utils.optional_deps import HAS_MATPLOTLIB
+from regions._utils.optional_deps import HAS_MATPLOTLIB, HAS_SHAPELY
 from regions.core import PixCoord, RegionMeta, RegionVisual
 from regions.shapes.circle import (CirclePixelRegion, CircleSkyRegion,
                                    CircleSphericalSkyRegion)
@@ -401,3 +401,85 @@ class TestCircleSkyRegionToPixelEllipse:
         result.visual['color'] = 'green'
         assert result.meta['text'] != self.reg.meta['text']
         assert result.visual['color'] != self.reg.visual['color']
+
+
+class TestCircleCovers:
+    """
+    Test CirclePixelRegion contains and covers boundary semantics using
+    explicit expected values.
+    """
+
+    @staticmethod
+    def setup_circle():
+        """
+        Create a circle centered at (5, 5) with radius 3.
+        """
+        return CirclePixelRegion(PixCoord(5, 5), radius=3)
+
+    @pytest.mark.parametrize(('method', 'expected'),
+                             [('contains',
+                               [True, False, False, False, False]),
+                              ('covers',
+                               [True, True, False, True, True])])
+    def test_array(self, method, expected):
+        """
+        Test contains/covers boundary semantics for an array mixing
+        interior, boundary, and exterior points.
+        """
+        reg = self.setup_circle()
+        # Center (in), right boundary, beyond right (out), top boundary,
+        # left boundary
+        x = np.array([5, 8, 9, 5, 2])
+        y = np.array([5, 5, 5, 8, 5])
+        result = getattr(reg, method)(PixCoord(x, y))
+        assert_equal(result, np.array(expected))
+
+
+@pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
+class TestCircleShapelyComparison:
+    """
+    Test that CirclePixelRegion contains and covers match Shapely's
+    contains and covers functions (DE-9IM semantics).
+    """
+
+    # Test points grouped by location relative to the circle.
+    # Shapely approximates a circle with a polygonal ``buffer``, whose
+    # vertices land exactly on the cardinal axes. The boundary points
+    # below are therefore restricted to the axes (distance 3 from the
+    # center) so that they lie on both the true circle and Shapely's
+    # polygonal approximation; off-axis boundary points would fall
+    # slightly inside the inscribed polygon and disagree.
+    boundary_points = [(8, 5), (2, 5), (5, 8), (5, 2)]
+    interior_points = [(5, 5), (6, 5), (5, 6), (4, 4)]
+    exterior_points = [(9, 5), (1, 5), (5, 9), (5, 1), (0, 0)]
+    all_points = boundary_points + interior_points + exterior_points
+
+    @staticmethod
+    def setup_circle():
+        """
+        Create a circle centered at (5, 5) with radius 3.
+        """
+        return CirclePixelRegion(PixCoord(5, 5), radius=3)
+
+    @staticmethod
+    def shapely_circle():
+        """
+        Create an equivalent Shapely circle (buffer around the center).
+        """
+        from shapely.geometry import Point as ShapelyPoint
+        return ShapelyPoint(5, 5).buffer(3)
+
+    @pytest.mark.parametrize('method', ['contains', 'covers'])
+    @pytest.mark.parametrize('point', all_points)
+    def test_matches_shapely(self, method, point):
+        """
+        Test that contains/covers match Shapely for points on the
+        boundary, interior, and exterior of the circle.
+        """
+        from shapely import Point, contains, covers
+
+        shp_func = {'contains': contains, 'covers': covers}[method]
+        x, y = point
+        reg_result = bool(getattr(self.setup_circle(), method)(PixCoord(x, y)))
+        shp_result = bool(shp_func(self.shapely_circle(), Point(x, y)))
+        assert reg_result == shp_result

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -8,7 +8,7 @@ from astropy.io import fits
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 from regions._utils.optional_deps import HAS_MATPLOTLIB
 from regions.core import PixCoord, RegionMeta, RegionVisual
@@ -97,6 +97,36 @@ class TestCirclePixelRegion(BaseTestPixelRegion):
     def test_zero_size(self):
         with pytest.raises(ValueError):
             CirclePixelRegion(PixCoord(50, 50), radius=0)
+
+
+def test_contains_covers_ignore_include_metadata():
+    """
+    Test that contains and covers ignore the 'include' metadata key, and
+    depend strictly on the geometric shape.
+    """
+    meta = RegionMeta({'include': False})
+    circle_exclude = CirclePixelRegion(PixCoord(10, 10), radius=5, meta=meta)
+    circle_include = CirclePixelRegion(PixCoord(10, 10), radius=5)
+
+    inside_pt = PixCoord(10, 10)
+    boundary_pt = PixCoord(15, 10)
+    outside_pt = PixCoord(20, 10)
+
+    # Should be completely identical regardless of 'include' metadata
+    assert_equal(circle_exclude.contains(inside_pt),
+                 circle_include.contains(inside_pt))
+    assert_equal(circle_exclude.contains(boundary_pt),
+                 circle_include.contains(boundary_pt))
+    assert_equal(circle_exclude.contains(outside_pt),
+                 circle_include.contains(outside_pt))
+
+    # Should be completely identical regardless of 'include' metadata
+    assert_equal(circle_exclude.covers(inside_pt),
+                 circle_include.covers(inside_pt))
+    assert_equal(circle_exclude.covers(boundary_pt),
+                 circle_include.covers(boundary_pt))
+    assert_equal(circle_exclude.covers(outside_pt),
+                 circle_include.covers(outside_pt))
 
 
 class TestCircleSkyRegion(BaseTestSkyRegion):

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -10,7 +10,7 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
 from numpy.testing import assert_allclose, assert_equal
 
-from regions._utils.optional_deps import HAS_MATPLOTLIB
+from regions._utils.optional_deps import HAS_MATPLOTLIB, HAS_SHAPELY
 from regions.core import PixCoord, RegionMeta, RegionVisual
 from regions.shapes.ellipse import EllipsePixelRegion, EllipseSkyRegion
 from regions.shapes.tests.test_common import (BaseTestPixelRegion,
@@ -334,3 +334,116 @@ class TestEllipseSkyRegion(BaseTestSkyRegion):
         assert reg == self.reg
         reg.width = 3 * u.deg
         assert reg != self.reg
+
+
+class TestEllipseCovers:
+    """
+    Test EllipsePixelRegion contains and covers boundary semantics using
+    explicit expected values.
+    """
+
+    @staticmethod
+    def setup_ellipse():
+        """
+        Create an axis-aligned ellipse centered at (5, 5).
+        """
+        # width=6 (semi-major=3 along x), height=4 (semi-minor=2 along y)
+        return EllipsePixelRegion(PixCoord(5, 5), width=6, height=4,
+                                  angle=0 * u.deg)
+
+    @pytest.mark.parametrize(('method', 'expected'),
+                             [('contains',
+                               [True, False, False, False, False]),
+                              ('covers',
+                               [True, True, False, True, True])])
+    def test_array(self, method, expected):
+        """
+        Test contains/covers boundary semantics for an array mixing
+        interior, boundary, and exterior points.
+        """
+        reg = self.setup_ellipse()
+        # Center (in), right boundary, beyond right (out), top boundary,
+        # left boundary
+        x = np.array([5, 8, 9, 5, 2])
+        y = np.array([5, 5, 5, 7, 5])
+        result = getattr(reg, method)(PixCoord(x, y))
+        assert_equal(result, np.array(expected))
+
+    @pytest.mark.parametrize('method', ['contains', 'covers'])
+    def test_rotated_ellipse(self, method):
+        """
+        Test boundary semantics for an ellipse rotated by 90 degrees,
+        which swaps the effect of the semi-major and semi-minor axes.
+        """
+        # After 90 deg rotation, the semi-major axis (3) is vertical and
+        # the semi-minor axis (2) is horizontal, so the boundary points
+        # are (5, 8), (5, 2) (top/bottom) and (7, 5), (3, 5) (left/right).
+        reg = EllipsePixelRegion(PixCoord(5, 5), width=6, height=4,
+                                 angle=90 * u.deg)
+        boundary = [(5, 8), (5, 2), (7, 5), (3, 5)]
+        # Boundary points are excluded by contains but included by covers.
+        on_boundary = (method == 'covers')
+
+        for x, y in boundary:
+            assert bool(getattr(reg, method)(PixCoord(x, y))) is on_boundary
+
+        # Interior points are always inside; exterior points never are.
+        assert getattr(reg, method)(PixCoord(5, 5))  # center
+        assert getattr(reg, method)(PixCoord(5, 7))  # inside vertically
+        assert not getattr(reg, method)(PixCoord(5, 9))  # beyond top
+        assert not getattr(reg, method)(PixCoord(8, 5))  # beyond right
+
+
+@pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
+class TestEllipseShapelyComparison:
+    """
+    Test that EllipsePixelRegion contains and covers match Shapely's
+    contains and covers functions (DE-9IM semantics).
+    """
+
+    # Test points grouped by location relative to the ellipse.
+    # Shapely approximates the ellipse with a scaled polygonal
+    # ``buffer``, whose vertices land on the semi-major/semi-minor axes.
+    # The boundary points below are therefore restricted to those axes
+    # so that they lie on both the true ellipse and Shapely's polygonal
+    # approximation; off-axis boundary points would fall slightly inside
+    # the inscribed polygon and disagree.
+    boundary_points = [(8, 5), (2, 5), (5, 7), (5, 3)]
+    interior_points = [(5, 5), (6, 5), (5, 6), (4, 4), (7, 5)]
+    exterior_points = [(9, 5), (1, 5), (5, 8), (5, 2), (0, 0), (8, 6)]
+    all_points = boundary_points + interior_points + exterior_points
+
+    @staticmethod
+    def setup_ellipse():
+        """
+        Create an axis-aligned ellipse centered at (5, 5).
+        """
+        return EllipsePixelRegion(PixCoord(5, 5), width=6, height=4,
+                                  angle=0 * u.deg)
+
+    @staticmethod
+    def shapely_ellipse():
+        """
+        Create an equivalent Shapely ellipse by scaling a unit circle.
+        """
+        from shapely import affinity
+        from shapely.geometry import Point as ShapelyPoint
+
+        # width=6 -> semi-major a=3, height=4 -> semi-minor b=2
+        circle = ShapelyPoint(5, 5).buffer(1)
+        return affinity.scale(circle, xfact=3, yfact=2)
+
+    @pytest.mark.parametrize('method', ['contains', 'covers'])
+    @pytest.mark.parametrize('point', all_points)
+    def test_matches_shapely(self, method, point):
+        """
+        Test that contains/covers match Shapely for points on the
+        boundary, interior, and exterior of the ellipse.
+        """
+        from shapely import Point, contains, covers
+
+        shp_func = {'contains': contains, 'covers': covers}[method]
+        x, y = point
+        reg_result = bool(getattr(self.setup_ellipse(), method)(PixCoord(x, y)))
+        shp_result = bool(shp_func(self.shapely_ellipse(), Point(x, y)))
+        assert reg_result == shp_result

--- a/regions/shapes/tests/test_line.py
+++ b/regions/shapes/tests/test_line.py
@@ -8,7 +8,7 @@ from astropy.io import fits
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 from regions._utils.optional_deps import HAS_MATPLOTLIB
 from regions.core import PixCoord, RegionMeta, RegionVisual
@@ -119,9 +119,15 @@ class TestLineSkyRegion(BaseTestSkyRegion):
 
     def test_contains(self, wcs):
         position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
-        # lines do not contain things
-        assert all(self.reg.contains(position, wcs)
-                   == np.array([False, False], dtype='bool'))
+        # Lines do not contain things
+        result = self.reg.contains(position, wcs)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2,)
+        assert_equal(result, [False, False])
+
+        scalar_position = SkyCoord(1 * u.deg, 3 * u.deg)
+        result_scalar = self.reg.contains(scalar_position, wcs)
+        assert result_scalar is False
 
     def test_eq(self):
         reg = self.reg.copy()

--- a/regions/shapes/tests/test_lune.py
+++ b/regions/shapes/tests/test_lune.py
@@ -106,9 +106,14 @@ class TestLuneSphericalSkyRegion(BaseTestSphericalSkyRegion):
     def test_bounding_circle(self):
         skycoord = SkyCoord(90.5 * u.deg, 0 * u.deg)
         reg = CircleSphericalSkyRegion(skycoord, 90 * u.deg)
+        assert self.reg.bounding_circle == reg
 
-        bc = self.reg.bounding_circle
-        assert bc == reg
+    def test_covers(self):
+        skycoord = SkyCoord([90, 75] * u.deg, [0, 0] * u.deg)
+        actual = self.reg.covers(skycoord)
+        assert actual[0]
+        assert not actual[1]
+        assert self.reg.covers(SkyCoord(90 * u.deg, 0 * u.deg))
 
     def test_bounding_lonlat(self):
         bounding_lonlat = self.reg.bounding_lonlat

--- a/regions/shapes/tests/test_point.py
+++ b/regions/shapes/tests/test_point.py
@@ -7,7 +7,7 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 from regions._utils.optional_deps import HAS_MATPLOTLIB
 from regions.core import PixCoord, RegionMeta, RegionVisual
@@ -94,9 +94,15 @@ class TestPointSkyRegion(BaseTestSkyRegion):
 
     def test_contains(self, wcs):
         position = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
-        # points do not contain things
-        assert all(self.reg.contains(position, wcs)
-                   == np.array([False, False], dtype='bool'))
+        # Points do not contain things
+        result = self.reg.contains(position, wcs)
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2,)
+        assert_equal(result, [False, False])
+
+        scalar_position = SkyCoord(1 * u.deg, 3 * u.deg)
+        result_scalar = self.reg.contains(scalar_position, wcs)
+        assert result_scalar is False
 
     def test_eq(self):
         reg = self.reg.copy()

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -10,7 +10,7 @@ from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_allclose, assert_equal
 
 from regions._utils.examples import make_example_dataset
-from regions._utils.optional_deps import HAS_MATPLOTLIB
+from regions._utils.optional_deps import HAS_MATPLOTLIB, HAS_SHAPELY
 from regions.core import PixCoord, RegionBoundingBox, RegionMeta, RegionVisual
 from regions.shapes.circle import CircleSphericalSkyRegion
 from regions.shapes.polygon import (PolygonPixelRegion, PolygonSkyRegion,
@@ -150,6 +150,45 @@ class TestPolygonPixelRegion(BaseTestPixelRegion):
         assert reg == self.reg
         reg.vertices = PixCoord([1, 3, 1], [1, 1, 6])
         assert reg != self.reg
+
+    @staticmethod
+    def rect_from_two_points(p1, p2):
+        """
+        Build a |PixCoord| of the four axis-aligned rectangle corners
+        defined by two opposite points.
+        """
+        x1, y1 = p1
+        x2, y2 = p2
+        minx = min(x1, x2)
+        maxx = max(x1, x2)
+        miny = min(y1, y2)
+        maxy = max(y1, y2)
+        corners = np.array([
+            [minx, miny],
+            [minx, maxy],
+            [maxx, maxy],
+            [maxx, miny],
+        ])
+        pc = PixCoord(corners[:, 0], corners[:, 1])
+        return pc
+
+    def test_pix_covers_boundary(self):
+        """
+        Regression test that points coinciding with polygon vertices
+        and edges are covered (boundary included), while ``contains``
+        excludes the boundary points.
+        """
+        verts = np.array([(7, 1), (11, 1), (11, 7), (9, 7), (9, 5),
+                          (2, 5), (2, 3), (7, 3)])
+
+        reg = PolygonPixelRegion(PixCoord(verts[:, 0], verts[:, 1]))
+        rect = self.rect_from_two_points((9, 5), (2, 3))
+
+        # Corners (2, 3), (2, 5), (9, 5) coincide with polygon vertices
+        # (on the boundary); (9, 3) is strictly interior.
+        assert np.all(reg.covers(rect))
+        assert_equal(reg.contains(rect),
+                     np.array([False, False, False, True]))
 
 
 class TestPolygonSkyRegion(BaseTestSkyRegion):
@@ -433,3 +472,72 @@ class TestPolygonSphericalSkyRegion(BaseTestSphericalSkyRegion):
                                                  [3, 4, 5] * u.deg))
 
         assert reg.centroid == reg.centroid_mindist
+
+
+@pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
+class TestPolygonShapelyComparison:
+    """
+    Test that PolygonPixelRegion contains and covers match Shapely's
+    contains and covers functions (DE-9IM semantics).
+    """
+
+    # L-shaped polygon vertices and test points grouped by location.
+    vertex_points = [(7, 1), (11, 1), (11, 7), (9, 7), (9, 5),
+                     (2, 5), (2, 3), (7, 3)]
+    edge_points = [(9, 1), (11, 4), (10, 7), (9, 6),
+                   (5, 5), (2, 4), (5, 3), (7, 2)]
+    interior_points = [(8, 2), (10, 3), (9, 5.5), (5, 4), (3, 4), (10, 6)]
+    exterior_points = [(1, 1), (12, 5), (0, 4), (5, 0), (10, 8),
+                       (3, 2), (5, 2), (6, 4)]
+    all_points = (vertex_points + edge_points + interior_points
+                  + exterior_points)
+
+    @classmethod
+    def setup_polygon(cls):
+        """
+        Create an L-shaped polygon for testing.
+        """
+        verts = np.array(cls.vertex_points)
+        return PolygonPixelRegion(PixCoord(verts[:, 0], verts[:, 1]))
+
+    @classmethod
+    def shapely_polygon(cls):
+        """
+        Create an equivalent Shapely polygon.
+        """
+        from shapely import Polygon
+        return Polygon(cls.vertex_points)
+
+    @pytest.mark.parametrize('method', ['contains', 'covers'])
+    @pytest.mark.parametrize('point', all_points)
+    def test_matches_shapely(self, method, point):
+        """
+        Test that contains/covers match Shapely for points on the
+        vertices, edges, interior, and exterior of the polygon.
+        """
+        from shapely import Point, contains, covers
+
+        shp_func = {'contains': contains, 'covers': covers}[method]
+        x, y = point
+        reg_result = bool(getattr(self.setup_polygon(), method)(PixCoord(x, y)))
+        shp_result = bool(shp_func(self.shapely_polygon(), Point(x, y)))
+        assert reg_result == shp_result
+
+    @pytest.mark.parametrize('method', ['contains', 'covers'])
+    def test_array_matches_shapely(self, method):
+        """
+        Test that contains/covers match Shapely for an array mixing
+        vertex, edge, interior, and exterior points.
+        """
+        from shapely import Point, contains, covers
+
+        shp_func = {'contains': contains, 'covers': covers}[method]
+        points = [(7, 1), (9, 1), (8, 2), (1, 1),
+                  (11, 7), (5, 5), (5, 4), (3, 2)]
+        x = np.array([p[0] for p in points], dtype=float)
+        y = np.array([p[1] for p in points], dtype=float)
+        reg_results = getattr(self.setup_polygon(), method)(PixCoord(x, y))
+        expected = np.array([bool(shp_func(self.shapely_polygon(),
+                                           Point(px, py)))
+                             for px, py in points])
+        assert_equal(reg_results, expected)

--- a/regions/shapes/tests/test_range.py
+++ b/regions/shapes/tests/test_range.py
@@ -156,6 +156,18 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
 
         assert reg2.contains(skycoord[0])
 
+    def test_covers(self):
+        reg = RangeSphericalSkyRegion(longitude_range=[0, 10] * u.deg,
+                                      latitude_range=[-4, 4] * u.deg,
+                                      frame='icrs')
+        coords = self.inside + self.outside
+        lon, lat = zip(*coords)
+        skycoord = SkyCoord(list(lon), list(lat))
+        actual = reg.covers(skycoord)
+        assert_equal(actual[:len(self.inside)], True)
+        assert_equal(actual[len(self.inside):], False)
+        assert reg.covers(skycoord[0])
+
     def test_lat_only(self):
         reg = RangeSphericalSkyRegion(latitude_range=[-4, 4] * u.deg,
                                       frame='icrs')

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -10,7 +10,7 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
 from numpy.testing import assert_allclose, assert_equal
 
-from regions._utils.optional_deps import HAS_MATPLOTLIB
+from regions._utils.optional_deps import HAS_MATPLOTLIB, HAS_SHAPELY
 from regions.core import PixCoord, RegionMeta, RegionVisual
 from regions.shapes.rectangle import RectanglePixelRegion, RectangleSkyRegion
 from regions.shapes.tests.test_common import (BaseTestPixelRegion,
@@ -361,3 +361,108 @@ class TestRectangleSkyRegion(BaseTestSkyRegion):
         assert reg == self.reg
         reg.angle = 10 * u.deg
         assert reg != self.reg
+
+
+class TestRectangleCovers:
+    """
+    Test RectanglePixelRegion contains and covers boundary semantics
+    using explicit expected values.
+    """
+
+    @staticmethod
+    def setup_rectangle():
+        """
+        Create an axis-aligned rectangle centered at (5, 5).
+        """
+        # width=6, height=4, so corners at (2, 3), (8, 3), (8, 7), (2, 7)
+        return RectanglePixelRegion(PixCoord(5, 5), width=6, height=4,
+                                    angle=0 * u.deg)
+
+    @pytest.mark.parametrize(('method', 'expected'),
+                             [('contains', [True, False, False, False, False]),
+                              ('covers', [True, True, False, True, True])])
+    def test_array(self, method, expected):
+        """
+        Test contains/covers boundary semantics for an array mixing
+        interior, boundary, and exterior points.
+        """
+        reg = self.setup_rectangle()
+        # Center (in), vertex, beyond right (out), bottom edge, right edge
+        x = np.array([5, 2, 9, 5, 8])
+        y = np.array([5, 3, 5, 3, 5])
+        result = getattr(reg, method)(PixCoord(x, y))
+        assert_equal(result, np.array(expected))
+
+    @pytest.mark.parametrize('method', ['contains', 'covers'])
+    def test_rotated_rectangle(self, method):
+        """
+        Test boundary semantics for a rectangle rotated by 45 degrees.
+
+        Exact-boundary comparisons are sensitive to floating-point
+        rounding, so points are nudged just inside and just outside the
+        corner along the center-corner direction.
+        """
+        reg = RectanglePixelRegion(PixCoord(5, 5), width=4, height=2,
+                                   angle=45 * u.deg)
+
+        # Center is always inside; a far point is always outside.
+        assert getattr(reg, method)(PixCoord(5, 5))
+        assert not getattr(reg, method)(PixCoord(10, 10))
+
+        cos45 = np.cos(np.radians(45))
+        sin45 = np.sin(np.radians(45))
+        hw, hh = 2, 1  # half width, half height
+        cx = 5 + cos45 * hw - sin45 * hh
+        cy = 5 + sin45 * hw + cos45 * hh
+
+        inside = PixCoord(5 + 0.99 * (cx - 5), 5 + 0.99 * (cy - 5))
+        outside = PixCoord(5 + 1.01 * (cx - 5), 5 + 1.01 * (cy - 5))
+        assert getattr(reg, method)(inside)
+        assert not getattr(reg, method)(outside)
+
+
+@pytest.mark.skipif(not HAS_SHAPELY, reason='shapely is required')
+class TestRectangleShapelyComparison:
+    """
+    Test that RectanglePixelRegion contains and covers match Shapely's
+    contains and covers functions (DE-9IM semantics).
+    """
+
+    # Test points grouped by location relative to the rectangle
+    vertices = [(2, 3), (8, 3), (8, 7), (2, 7)]
+    edge_points = [(5, 3), (8, 5), (5, 7), (2, 5)]
+    interior_points = [(5, 5), (3, 4), (7, 6), (4, 5)]
+    exterior_points = [(0, 0), (1, 5), (9, 5), (5, 2), (5, 8)]
+    all_points = vertices + edge_points + interior_points + exterior_points
+
+    @staticmethod
+    def setup_rectangle():
+        """
+        Create an axis-aligned rectangle centered at (5, 5).
+        """
+        return RectanglePixelRegion(PixCoord(5, 5), width=6, height=4,
+                                    angle=0 * u.deg)
+
+    @staticmethod
+    def shapely_rectangle():
+        """
+        Create an equivalent Shapely rectangle polygon.
+        """
+        from shapely import Polygon
+        return Polygon([(2, 3), (8, 3), (8, 7), (2, 7)])
+
+    @pytest.mark.parametrize('method', ['contains', 'covers'])
+    @pytest.mark.parametrize('point', all_points)
+    def test_matches_shapely(self, method, point):
+        """
+        Test that contains/covers match Shapely for points on the
+        vertices, edges, interior, and exterior of the rectangle.
+        """
+        from shapely import Point, contains, covers
+
+        shp_func = {'contains': contains, 'covers': covers}[method]
+        x, y = point
+        reg = self.setup_rectangle()
+        reg_result = bool(getattr(reg, method)(PixCoord(x, y)))
+        shp_result = bool(shp_func(self.shapely_rectangle(), Point(x, y)))
+        assert reg_result == shp_result

--- a/regions/shapes/tests/test_whole_sky.py
+++ b/regions/shapes/tests/test_whole_sky.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import astropy.units as u
+import numpy as np
 import pytest
+from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
@@ -66,3 +68,13 @@ class TestWholeSphericalSkyRegion(BaseTestSphericalSkyRegion):
     def test_bounding_lonlat(self):
         bounding_lonlat = self.reg.bounding_lonlat
         assert bounding_lonlat is None
+
+    def test_covers(self):
+        """
+        Test that whole sky covers points.
+        """
+        coord = SkyCoord(1 * u.deg, 2 * u.deg)
+        assert self.reg.covers(coord) is True
+
+        coords = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+        assert np.all(self.reg.covers(coords) == [True, True])

--- a/regions/shapes/whole_sky.py
+++ b/regions/shapes/whole_sky.py
@@ -30,11 +30,17 @@ class WholeSphericalSkyRegion(SphericalSkyRegion):
         self.meta = meta or RegionMeta()
         self.visual = visual or RegionVisual()
 
-    def contains(self, coord):
+    def _containment(self, coord):
         if coord.isscalar:
             return True
         else:
             return np.ones(coord.shape, dtype=bool)
+
+    def contains(self, coord):
+        return self._containment(coord)
+
+    def covers(self, coord):
+        return self._containment(coord)
 
     @property
     def bounding_circle(self):


### PR DESCRIPTION
Region ``contains`` methods were inconsistent at the boundary: ``EllipsePixelRegion.contains`` included it, ``Circle``/``Rectangle`` excluded it, and ``PolygonPixelRegion.contains`` was ambiguous on edges/vertices. 

This PR makes `contains` strictly exclude the boundary for all pixel regions (matching Shapely's ``contains`` and DE-9IM) and adds a new ``covers`` method that includes the boundary (matching Shapely's `covers`). The polygon implementation gains an explicit point-on-segment test, and the subpixel mask sampler uses the boundary-inclusive variant.

The ``contains`` methods of all regions now also ignore the ``'include'`` metadata attribute (which was previously used to invert evaluation results), making containment and covering behavior depend solely on the geometric shape of the region.