### PR TITLE
Fix overly permissive regex range

### DIFF
--- a/regions/io/crtf/read.py
+++ b/regions/io/crtf/read.py
@@ -28,7 +28,7 @@ regex_comment = re.compile(r'^#.*$')
 regex_global = re.compile(r'^global\s+(?P<parameters>.*)?')
 
 # Coordinate Format : '[x, y]'
-regex_coordinate = re.compile(r'\[([\w.+-:]*?)\s*[,]\s*([\w.+-:]*?)\]')
+regex_coordinate = re.compile(r'\[([\w.+\-:]*?)\s*[,]\s*([\w.+\-:]*?)\]')
 
 # Single length format, e.g., helps extract the radius of a circle
 regex_length = re.compile(r'(?:\[[^=\]]*\])+[,]\s*([^\[]*)\]')


### PR DESCRIPTION
The regex intent was the match the +, -, and : characters (for coordinate strings).  This PR escapes the hyphen so the regex is not interpreted as a range.

This fixes CodeQL code scan alerts: 
* https://github.com/astropy/regions/security/code-scanning/3
* https://github.com/astropy/regions/security/code-scanning/4.