### PR TITLE
Update wcs utils to use to_value instead of .value

### DIFF
--- a/regions/_utils/tests/conftest.py
+++ b/regions/_utils/tests/conftest.py
@@ -14,7 +14,7 @@ WCS_CENTER = SkyCoord(100 * u.deg, 30 * u.deg)
 WCS_CDELT_ARCSEC = 0.1
 
 
-def _make_simple_wcs(skycoord, resolution, size, rotation_deg=0.0):
+def _make_simple_wcs(skycoord, resolution, size, *, rotation_deg=0.0):
     """
     Create a simple TAN WCS with optional rotation.
 
@@ -37,7 +37,7 @@ def _make_simple_wcs(skycoord, resolution, size, rotation_deg=0.0):
     wcs : `~astropy.wcs.WCS`
         The WCS object.
     """
-    cdelt_deg = resolution.to(u.deg).value
+    cdelt_deg = resolution.to_value(u.deg)
     wcs = WCS(naxis=2)
     wcs.wcs.crpix = [size / 2 + 0.5, size / 2 + 0.5]
     wcs.wcs.crval = [skycoord.ra.deg, skycoord.dec.deg]

--- a/regions/_utils/tests/test_wcs_helpers.py
+++ b/regions/_utils/tests/test_wcs_helpers.py
@@ -604,13 +604,13 @@ class TestSVDShapeConversions:
         assert pw > 1.0
         assert ph > 1.0
         _, sw, sh, _ = pixel_shape_to_sky_svd(
-            center, wcs, pw, ph, pa.to(u.rad).value)
+            center, wcs, pw, ph, pa.to_value(u.radian))
         assert_allclose(sw, 2.0, rtol=1e-3)
         assert_allclose(sh, 1.0, rtol=1e-3)
 
 
-def _project_sky_ellipse_boundary(skycoord, wcs, a_arcsec, b_arcsec,
-                                  pa_rad, npts=720):
+def _project_sky_ellipse_boundary(skycoord, wcs, a_arcsec, b_arcsec, pa_rad, *,
+                                  npts=720):
     """
     Project the boundary of a sky ellipse to pixel coordinates.
 
@@ -738,7 +738,7 @@ def _make_sheared_wcs():
     return wcs
 
 
-def _project_pixel_circle_to_sky_tangent(pixcoord, wcs, radius_pix,
+def _project_pixel_circle_to_sky_tangent(pixcoord, wcs, radius_pix, *,
                                          npts=720):
     """
     Project a pixel circle boundary to tangent-plane sky offsets.

--- a/regions/_utils/wcs_helpers.py
+++ b/regions/_utils/wcs_helpers.py
@@ -90,7 +90,7 @@ def _pixel_to_sky_jacobian(pixcoord, wcs):
     return center, jacobian, jacobian_inv, parity
 
 
-def _svd_ellipse_from_composite(m_comp, width_col_idx=0, sky_angle=False,
+def _svd_ellipse_from_composite(m_comp, *, width_col_idx=0, sky_angle=False,
                                 input_circular=False):
     """
     Extract ellipse width, height, and angle from a composite matrix


### PR DESCRIPTION
Also enforces keyword-only args in wcs helpers.