### PR TITLE
Rename n_points to n_vertices

### DIFF
--- a/docs/getting_started/examples.rst
+++ b/docs/getting_started/examples.rst
@@ -80,7 +80,7 @@ full sky image (seen in this `Astropy visualization demo
     circ.to_pixel(
         wcs=wcs,
         include_boundary_distortions=True,
-        n_points=1000,
+        n_vertices=1000,
     ).plot(ax=ax, edgecolor='red',
            facecolor='none', lw=2)
 
@@ -92,6 +92,6 @@ full sky image (seen in this `Astropy visualization demo
     lon_lat_range.to_pixel(
         wcs=wcs,
         include_boundary_distortions=True,
-        n_points=250,
+        n_vertices=250,
     ).plot(ax=ax, edgecolor='blue',
            facecolor='none', lw=2)

--- a/docs/getting_started/overview.rst
+++ b/docs/getting_started/overview.rst
@@ -332,7 +332,7 @@ spherical circle falling outside of the planar circle and vice versa.
     # Define transformed-to pixel regions
     pix_circ_distort = sph_circle.to_pixel(wcs=wcs,
                                            include_boundary_distortions=True,
-                                           n_points=1000)
+                                           n_vertices=1000)
     pix_circ_nodistort = circle.to_pixel(wcs=wcs)
 
     # Get contained points

--- a/docs/user_guide/compound.rst
+++ b/docs/user_guide/compound.rst
@@ -246,7 +246,7 @@ and spherical sky regions, with the same circle centers and radii.
                transform=ax.get_transform('galactic'))
 
     boundary_kwargs = {'include_boundary_distortions': True,
-                       'n_points': 1000}
+                       'n_vertices': 1000}
     sph_circle1.to_pixel(wcs=wcs, **boundary_kwargs).plot(
         ax=ax, edgecolor='green', facecolor='none', alpha=0.8, lw=3)
     sph_circle2.to_pixel(wcs=wcs, **boundary_kwargs).plot(

--- a/docs/user_guide/plotting.rst
+++ b/docs/user_guide/plotting.rst
@@ -125,13 +125,13 @@ It is also possible to use the coordinates of a discretized
     sph_sky_region.to_pixel(
         wcs=wcs,
         include_boundary_distortions=True,
-        n_points=1000,
+        n_vertices=1000,
     ).plot(ax=ax, color='tab:red', lw=3)
 
     sph_sky_center2 = SkyCoord(42, 43, unit='deg', frame='galactic')
     sph_sky_radius2 = Angle(25, 'deg')
     sph_sky_region2 = CircleSphericalSkyRegion(sph_sky_center2, sph_sky_radius2)
-    poly_sph_sky2 = sph_sky_region2.discretize_boundary(n_points=1000)
+    poly_sph_sky2 = sph_sky_region2.discretize_boundary(n_vertices=1000)
     ax.plot(
         poly_sph_sky2.vertices.l,
         poly_sph_sky2.vertices.b,

--- a/docs/user_guide/shapes.rst
+++ b/docs/user_guide/shapes.rst
@@ -398,7 +398,7 @@ to the `~regions.SphericalSkyRegion.discretize_boundary()` method.
 
     >>> sky_reg = sph_sky_reg.to_sky(wcs=wcs,
     ...                              include_boundary_distortions=True,
-    ...                              n_points=10)
+    ...                              n_vertices=10)
     >>> print(sky_reg)  # doctest: +FLOAT_CMP
     Region: PolygonSkyRegion
     vertices: <SkyCoord (ICRS): (ra, dec) in deg
@@ -423,7 +423,7 @@ respectively).
 
     >>> pix_reg2 = sph_sky_reg.to_pixel(wcs=wcs,
     ...                                 include_boundary_distortions=True,
-    ...                                 n_points=10)
+    ...                                 n_vertices=10)
     >>> print(pix_reg2)  # doctest: +FLOAT_CMP
     Region: PolygonPixelRegion
     vertices: PixCoord(x=[225.3356 334.317 334.317 225.3356 49.0 ...],

--- a/docs/user_guide/spherical_bounding_regions.rst
+++ b/docs/user_guide/spherical_bounding_regions.rst
@@ -131,13 +131,13 @@ both the original and transformed coordinate frames.
     patch = sph_circ.to_pixel(
         wcs=wcs,
         include_boundary_distortions=True,
-        n_points=1000,
+        n_vertices=1000,
     ).plot(ax=ax, color='tab:blue', lw=3)
 
     sph_range.to_pixel(
         wcs=wcs,
         include_boundary_distortions=True,
-        n_points=250,
+        n_vertices=250,
     ).plot(ax=ax, color='tab:red', lw=3)
 
     bound_color = 'tab:blue'
@@ -166,7 +166,7 @@ both the original and transformed coordinate frames.
     sph_range.bounding_circle.to_pixel(
         wcs=wcs,
         include_boundary_distortions=True,
-        n_points=1000,
+        n_vertices=1000,
     ).plot(ax=ax, color='tab:red', lw=bound_lw, ls='--', zorder=bound_zord)
 
     patch.set_clip_path(ax.coords.frame.patch)
@@ -183,13 +183,13 @@ both the original and transformed coordinate frames.
     patch = sph_circ_transf.to_pixel(
         wcs=wcs_icrs,
         include_boundary_distortions=True,
-        n_points=1000,
+        n_vertices=1000,
     ).plot(ax=ax, color='tab:blue', lw=3)
 
     sph_range_transf.to_pixel(
         wcs=wcs_icrs,
         include_boundary_distortions=True,
-        n_points=250,
+        n_vertices=250,
     ).plot(ax=ax, color='tab:red', lw=3)
 
     bound_color = 'tab:blue'
@@ -236,7 +236,7 @@ both the original and transformed coordinate frames.
     sph_range_transf.bounding_circle.to_pixel(
         wcs=wcs_icrs,
         include_boundary_distortions=True,
-        n_points=1000,
+        n_vertices=1000,
     ).plot(ax=ax, color='tab:red', lw=bound_lw, ls='--', zorder=bound_zord)
 
     patch.set_clip_path(ax.coords.frame.patch)

--- a/docs/user_guide/spherical_frame_transform.rst
+++ b/docs/user_guide/spherical_frame_transform.rst
@@ -132,13 +132,13 @@ projections for the Galactic and ICRS coordinate reference frames
     patch = sph_circ.to_pixel(
         wcs=wcs,
         include_boundary_distortions=True,
-        n_points=1000,
+        n_vertices=1000,
     ).plot(ax=ax, color='tab:blue', lw=3)
 
     sph_range.to_pixel(
         wcs=wcs,
         include_boundary_distortions=True,
-        n_points=250,
+        n_vertices=250,
     ).plot(ax=ax, color='tab:red', lw=3)
 
     patch.set_clip_path(ax.coords.frame.patch)
@@ -158,13 +158,13 @@ projections for the Galactic and ICRS coordinate reference frames
     patch = sph_circ_transf.to_pixel(
         wcs=wcs_icrs,
         include_boundary_distortions=True,
-        n_points=1000,
+        n_vertices=1000,
     ).plot(ax=ax, color='tab:blue', lw=3)
 
     sph_range_transf.to_pixel(
         wcs=wcs_icrs,
         include_boundary_distortions=True,
-        n_points=250,
+        n_vertices=250,
     ).plot(ax=ax, color='tab:red', lw=3)
 
     patch.set_clip_path(ax.coords.frame.patch)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,12 @@ exclude = [
     '^conftest.*$',  # pytest configuration
 ]
 
+[tool.ruff]
+line-length = 79
+
+[tool.ruff.lint.pylint]
+max-statements = 130
+
 [tool.ruff.lint]
 select = [
     'B', 'COM', 'D', 'E', 'F', 'FLY', 'I', 'INT', 'N', 'NPY', 'PERF', 'PL', 'Q',

--- a/regions/_utils/spherical_helpers.py
+++ b/regions/_utils/spherical_helpers.py
@@ -487,7 +487,7 @@ def get_edge_raw_lonlat_bounds_circ_edges(vertices, centroid, gcs):
     return Longitude(lons_arr).to(u.deg), Latitude(lats_arr).to(u.deg)
 
 
-def _discretize_edge_boundary(vertices, circ, n_points,
+def _discretize_edge_boundary(vertices, circ, n_vertices,
                               circ_center=None, circ_radius=None):
 
     if circ is not None:
@@ -512,7 +512,7 @@ def _discretize_edge_boundary(vertices, circ, n_points,
 
     # Sample angle range over pa_span with Npoints, and offset
     # to start at pas_verts[0]
-    theta = np.linspace(0, 1, num=n_points, endpoint=False) * pa_span + pas_verts[0]
+    theta = np.linspace(0, 1, num=n_vertices, endpoint=False) * pa_span + pas_verts[0]
 
     # Calculate directional offsets to get boundary discretization,
     # with vertices as SkyCoords
@@ -521,7 +521,7 @@ def _discretize_edge_boundary(vertices, circ, n_points,
     return bound_verts
 
 
-def discretize_line_boundary(coords, n_points):
+def discretize_line_boundary(coords, n_vertices):
     """
     Discretize all edge boundaries for spherical sky regions.
 
@@ -530,7 +530,7 @@ def discretize_line_boundary(coords, n_points):
     coords : `~astropy.coordinates.SkyCoord`
         The start, end of the line as a SkyCoord.
 
-    n_points : int
+    n_vertices : int
         The number of points for discretization along each edge.
 
     Returns
@@ -544,7 +544,7 @@ def discretize_line_boundary(coords, n_points):
     gc_center = cross_product_skycoord2skycoord(coords[0], coords[1])
     gc_radius = 90 * u.deg
 
-    bound_verts = _discretize_edge_boundary(coords, None, n_points,
+    bound_verts = _discretize_edge_boundary(coords, None, n_vertices,
                                             circ_center=gc_center, circ_radius=gc_radius)
 
     return SkyCoord(
@@ -556,7 +556,7 @@ def discretize_line_boundary(coords, n_points):
     )
 
 
-def discretize_all_edge_boundaries(vertices, circs, n_points):
+def discretize_all_edge_boundaries(vertices, circs, n_vertices):
     """
     Discretize all edge boundaries for spherical sky regions.
 
@@ -568,7 +568,7 @@ def discretize_all_edge_boundaries(vertices, circs, n_points):
     circs : `~regions.CircleSphericalSkyRegion`
         The circle boundaries as CircleSphericalSkyRegion instances.
 
-    n_points : int
+    n_vertices : int
         The number of points for discretization along the boundary.
 
     Returns
@@ -579,19 +579,19 @@ def discretize_all_edge_boundaries(vertices, circs, n_points):
     # Iterate over full set of vertices & boundary circles for
     # a region (polygon or range)
 
-    # Verify n_points >= the number of vertices:
-    if n_points < len(vertices):
+    # Verify n_vertices >= the number of vertices:
+    if n_vertices < len(vertices):
         raise ValueError(
-            f"n_points must be greater than {len(vertices)} "
+            f"n_vertices must be greater than {len(vertices)} "
             'to discretize/polygonize this region!',
         )
 
-    # Return if n_points = len(vertices)
-    if n_points == len(vertices):
+    # Return if n_vertices = len(vertices)
+    if n_vertices == len(vertices):
         return vertices
 
     # Determine the number of vertices per edge:
-    npt_edge, remainder = np.divmod(n_points, len(vertices))
+    npt_edge, remainder = np.divmod(n_vertices, len(vertices))
 
     all_edge_bound_verts = None
     for i, circ in enumerate(circs):

--- a/regions/_utils/spherical_helpers.py
+++ b/regions/_utils/spherical_helpers.py
@@ -72,7 +72,8 @@ def cross_product_skycoord2skycoord(c1, c2):
     `~astropy.coordinates.SkyCoord`
         The cross product as a SkyCoord, with a spherical representation.
     """
-    cross = c1.frame.represent_as('cartesian').cross(c2.frame.represent_as('cartesian'))
+    cross = c1.frame.represent_as('cartesian').cross(
+        c2.frame.represent_as('cartesian'))
     c_cart = cross / cross.norm()
     _, lat, lon = cartesian_to_spherical(c_cart.x, c_cart.y, c_cart.z)
     return SkyCoord(lon, lat, frame=c1.frame)
@@ -117,7 +118,8 @@ def cross_product_sum_skycoord2skycoord(coos):
     return SkyCoord(lon.to(unit), lat.to(unit), frame=coos.frame)
 
 
-def bounding_lonlat_poles_processing(region, lons_arr, lats_arr, inner_region=None):
+def bounding_lonlat_poles_processing(
+        region, lons_arr, lats_arr, inner_region=None):
     """
     Check if region covers either pole & modify latitude bounds
     accordingly.
@@ -171,8 +173,8 @@ def bounding_lonlat_poles_processing(region, lons_arr, lats_arr, inner_region=No
     # Inner region set: annulus logic:
     pole_contains = inner_region.contains(poles)
     if np.any(pole_contains):
-        lats_raw_inner = get_circle_latitude_tangent_limits(inner_region.center,
-                                                            inner_region.radius)
+        lats_raw_inner = get_circle_latitude_tangent_limits(
+            inner_region.center, inner_region.radius)
 
         # S pole:
         if pole_contains[0]:
@@ -227,7 +229,8 @@ def _get_circle_longitude_tangent_points(center, radius):
     lats = [0 * u.deg, 0 * u.deg]
 
     lats_ref = np.array(
-        [(crepr.lat - radius).to_value(u.deg), (crepr.lat + radius).to_value(u.deg)],
+        [(crepr.lat - radius).to_value(u.deg),
+         (crepr.lat + radius).to_value(u.deg)],
     )
     lons = []
 
@@ -236,14 +239,16 @@ def _get_circle_longitude_tangent_points(center, radius):
 
     if np.any(np.abs(lats_ref) == 90):
         return SkyCoord(
-            [crepr.lon - 90 * u.deg, crepr.lon + 90 * u.deg], lats, frame=center.frame,
+            [crepr.lon - 90 * u.deg, crepr.lon + 90 * u.deg],
+            lats, frame=center.frame,
         )
 
     for sgn in [-1, 1]:
         # Do 1 then -1, because of lon increasing to east
         lon_gc = crepr.lon - sgn * (
             np.arccos(
-                np.sin(radius.to_value(u.radian)) / np.cos(crepr.lat.to_value(u.radian)),
+                np.sin(radius.to_value(u.radian))
+                / np.cos(crepr.lat.to_value(u.radian)),
             )
             * u.radian
         ).to(u.deg)
@@ -359,7 +364,8 @@ def _add_tan_pts_if_in_pa_range(
 def _check_edge_lt_pi(pas_verts, wrap_ang):
     pas_verts_wrap = pas_verts.wrap_at(wrap_ang)
 
-    is_valid_arc_length = ((pas_verts_wrap[1] - pas_verts_wrap[0]).to(u.deg) <= 180 * u.deg)
+    is_valid_arc_length = (
+        (pas_verts_wrap[1] - pas_verts_wrap[0]).to(u.deg) <= 180 * u.deg)
 
     return pas_verts_wrap, is_valid_arc_length
 
@@ -377,7 +383,8 @@ def _validate_vertices_ordering(verts, gc, gc_center=None):
     # So difference of pa[1] - pa[0] <= 180 deg
     # If not, swap the order.
 
-    pas_verts_wrap, is_valid_arc_length = _check_edge_lt_pi(pas_verts, wrap_ang)
+    pas_verts_wrap, is_valid_arc_length = _check_edge_lt_pi(
+        pas_verts, wrap_ang)
 
     if not is_valid_arc_length:
         wrap_ang_opp = pas_verts[-1]
@@ -395,7 +402,8 @@ def _validate_vertices_ordering(verts, gc, gc_center=None):
 def _validate_lon_bounds_ordering(lons_arr, centroid):
     # Invert longitude order if centroid is outside of range:
     wrap_ang = lons_arr[0]
-    centroid_lon_wrap = centroid.represent_as('spherical').lon.wrap_at(wrap_ang)
+    centroid_lon_wrap = centroid.represent_as(
+        'spherical').lon.wrap_at(wrap_ang)
     in_range_lon = (centroid_lon_wrap >= lons_arr[0].wrap_at(wrap_ang)) & (
         centroid_lon_wrap <= lons_arr[1].wrap_at(wrap_ang)
     )
@@ -470,7 +478,8 @@ def get_edge_raw_lonlat_bounds_circ_edges(vertices, centroid, gcs):
         # Longitude tangent points from bound circle as len 2 SkyCoord:
         # Only add to the list if the tangent point is located along this edge
 
-        tan_lon_pts = _get_circle_longitude_tangent_points(gc.center, gc.radius)
+        tan_lon_pts = _get_circle_longitude_tangent_points(
+            gc.center, gc.radius)
         if tan_lon_pts is not None:
             lons_list = _add_tan_pts_if_in_pa_range(
                 lons_list, tan_lon_pts, gc, wrap_ang, pas_verts_wrap,
@@ -512,7 +521,8 @@ def _discretize_edge_boundary(vertices, circ, n_vertices,
 
     # Sample angle range over pa_span with Npoints, and offset
     # to start at pas_verts[0]
-    theta = np.linspace(0, 1, num=n_vertices, endpoint=False) * pa_span + pas_verts[0]
+    theta = np.linspace(0, 1, num=n_vertices,
+                        endpoint=False) * pa_span + pas_verts[0]
 
     # Calculate directional offsets to get boundary discretization,
     # with vertices as SkyCoords
@@ -544,8 +554,9 @@ def discretize_line_boundary(coords, n_vertices):
     gc_center = cross_product_skycoord2skycoord(coords[0], coords[1])
     gc_radius = 90 * u.deg
 
-    bound_verts = _discretize_edge_boundary(coords, None, n_vertices,
-                                            circ_center=gc_center, circ_radius=gc_radius)
+    bound_verts = _discretize_edge_boundary(
+        coords, None, n_vertices,
+        circ_center=gc_center, circ_radius=gc_radius)
 
     return SkyCoord(
         SkyCoord(
@@ -606,7 +617,8 @@ def discretize_all_edge_boundaries(vertices, circs, n_vertices):
             all_edge_bound_verts = bound_verts
         else:
             # Specify representation type, as in some cases
-            # concatenate introduces distances/non unit spherical representation
+            # concatenate introduces distances/non unit spherical
+            # representation
             all_edge_bound_verts = SkyCoord(
                 np.concatenate(
                     [all_edge_bound_verts.copy(), bound_verts],

--- a/regions/core/attributes.py
+++ b/regions/core/attributes.py
@@ -173,17 +173,22 @@ class TwoValAngleorNone(RegionAttribute):
         else:
             try:
                 if len(value) == 2:
-                    # Check if list-like with individual entries having angular units:
+                    # Check if list-like with individual entries having angular
+                    # units:
                     for val in value:
                         if isinstance(val, Quantity):
                             if not val.unit.physical_type == 'angle':
-                                raise ValueError(f'{self.name!r} must have angular units')
+                                raise ValueError(
+                                    f'{self.name!r} must have angular units')
                         else:
-                            raise ValueError(f'{self.name!r} must be an angle of length 2')
+                            raise ValueError(
+                                f'{self.name!r} must be an angle of length 2')
                 else:
-                    raise ValueError(f'{self.name!r} must be an angle of length 2')
+                    raise ValueError(
+                        f'{self.name!r} must be an angle of length 2')
             except TypeError:
-                raise ValueError(f'{self.name!r} must be an angle of length 2') from None
+                raise ValueError(
+                    f'{self.name!r} must be an angle of length 2') from None
 
 
 class RegionType(RegionAttribute):

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -10,7 +10,8 @@ from regions.core.attributes import RegionType
 from regions.core.core import PixelRegion, SkyRegion, SphericalSkyRegion
 from regions.core.mask import RegionMask
 
-__all__ = ['CompoundPixelRegion', 'CompoundSkyRegion', 'CompoundSphericalSkyRegion']
+__all__ = ['CompoundPixelRegion', 'CompoundSkyRegion',
+           'CompoundSphericalSkyRegion']
 
 
 class CompoundPixelRegion(PixelRegion):
@@ -377,7 +378,8 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
 
             pa = circ1.center.position_angle(circ2.center)
 
-            e1 = circ1.center.directional_offset_by(180 * u.deg + pa, circ1.radius)
+            e1 = circ1.center.directional_offset_by(
+                180 * u.deg + pa, circ1.radius)
             e2 = circ2.center.directional_offset_by(pa, circ2.radius)
             sep = e1.separation(e2)
 
@@ -458,8 +460,10 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
     def transform_to(self, frame, merge_attributes=True):
         # Transform the consitituent regions then recompose:
         return self.__class__(
-            self.region1.transform_to(frame, merge_attributes=merge_attributes),
-            self.region2.transform_to(frame, merge_attributes=merge_attributes),
+            self.region1.transform_to(
+                frame, merge_attributes=merge_attributes),
+            self.region2.transform_to(
+                frame, merge_attributes=merge_attributes),
             self.operator,
             meta=self.meta,
             visual=self.visual,
@@ -474,10 +478,8 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
             visual=self.visual.copy(),
         )
 
-    def to_sky(
-        self, wcs=None, include_boundary_distortions=False,
-        *, n_vertices=None,
-    ):
+    def to_sky(self, wcs=None, include_boundary_distortions=False, *,
+               n_vertices=None):
         planarreg1 = self.region1.to_sky(
             wcs=wcs,
             include_boundary_distortions=include_boundary_distortions,
@@ -496,9 +498,8 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
             visual=self.visual.copy(),
         )
 
-    def to_pixel(
-        self, wcs, *, include_boundary_distortions=False, n_vertices=None,
-    ):
+    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+                 n_vertices=None):
         pixreg1 = self.region1.to_pixel(
             wcs,
             include_boundary_distortions=include_boundary_distortions,

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -98,16 +98,16 @@ class CompoundPixelRegion(PixelRegion):
                                  visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         sphreg1 = self.region1.to_spherical_sky(
             wcs=wcs,
             include_boundary_distortions=include_boundary_distortions,
-            n_points=n_points,
+            n_vertices=n_vertices,
         )
         sphreg2 = self.region2.to_spherical_sky(
             wcs=wcs,
             include_boundary_distortions=include_boundary_distortions,
-            n_points=n_points,
+            n_vertices=n_vertices,
         )
         return CompoundSphericalSkyRegion(
             region1=sphreg1,
@@ -276,16 +276,16 @@ class CompoundSkyRegion(SkyRegion):
                                    visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         sphreg1 = self.region1.to_spherical_sky(
             wcs=wcs,
             include_boundary_distortions=include_boundary_distortions,
-            n_points=n_points,
+            n_vertices=n_vertices,
         )
         sphreg2 = self.region2.to_spherical_sky(
             wcs=wcs,
             include_boundary_distortions=include_boundary_distortions,
-            n_points=n_points,
+            n_vertices=n_vertices,
         )
         return CompoundSphericalSkyRegion(
             region1=sphreg1,
@@ -465,10 +465,10 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
             visual=self.visual,
         )
 
-    def discretize_boundary(self, n_points=100):
+    def discretize_boundary(self, n_vertices=100):
         return CompoundSphericalSkyRegion(
-            self.region1.discretize_boundary(n_points=n_points),
-            self.region2.discretize_boundary(n_points=n_points),
+            self.region1.discretize_boundary(n_vertices=n_vertices),
+            self.region2.discretize_boundary(n_vertices=n_vertices),
             operator=self.operator,
             meta=self.meta.copy(),
             visual=self.visual.copy(),
@@ -476,17 +476,17 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
 
     def to_sky(
         self, wcs=None, include_boundary_distortions=False,
-        n_points=None,
+        n_vertices=None,
     ):
         planarreg1 = self.region1.to_sky(
             wcs=wcs,
             include_boundary_distortions=include_boundary_distortions,
-            n_points=n_points,
+            n_vertices=n_vertices,
         )
         planarreg2 = self.region2.to_sky(
             wcs=wcs,
             include_boundary_distortions=include_boundary_distortions,
-            n_points=n_points,
+            n_vertices=n_vertices,
         )
         return CompoundSkyRegion(
             region1=planarreg1,
@@ -498,17 +498,17 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
 
     def to_pixel(
         self, wcs, include_boundary_distortions=False,
-        n_points=None,
+        n_vertices=None,
     ):
         pixreg1 = self.region1.to_pixel(
             wcs,
             include_boundary_distortions=include_boundary_distortions,
-            n_points=n_points,
+            n_vertices=n_vertices,
         )
         pixreg2 = self.region2.to_pixel(
             wcs,
             include_boundary_distortions=include_boundary_distortions,
-            n_points=n_points,
+            n_vertices=n_vertices,
         )
         return CompoundPixelRegion(
             region1=pixreg1,

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -97,7 +97,7 @@ class CompoundPixelRegion(PixelRegion):
                                  region2=skyreg2, meta=self.meta.copy(),
                                  visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         sphreg1 = self.region1.to_spherical_sky(
             wcs=wcs,
@@ -275,7 +275,7 @@ class CompoundSkyRegion(SkyRegion):
                                    region2=pixreg2, meta=self.meta.copy(),
                                    visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         sphreg1 = self.region1.to_spherical_sky(
             wcs=wcs,
@@ -465,7 +465,7 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
             visual=self.visual,
         )
 
-    def discretize_boundary(self, n_vertices=100):
+    def discretize_boundary(self, *, n_vertices=100):
         return CompoundSphericalSkyRegion(
             self.region1.discretize_boundary(n_vertices=n_vertices),
             self.region2.discretize_boundary(n_vertices=n_vertices),
@@ -476,7 +476,7 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
 
     def to_sky(
         self, wcs=None, include_boundary_distortions=False,
-        n_vertices=None,
+        *, n_vertices=None,
     ):
         planarreg1 = self.region1.to_sky(
             wcs=wcs,
@@ -497,8 +497,7 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
         )
 
     def to_pixel(
-        self, wcs, include_boundary_distortions=False,
-        n_vertices=None,
+        self, wcs, *, include_boundary_distortions=False, n_vertices=None,
     ):
         pixreg1 = self.region1.to_pixel(
             wcs,

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -531,7 +531,7 @@ class PixelRegion(Region):
 
     @abc.abstractmethod
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         """
         Convert to an equivalent spherical `~regions.SphericalSkyRegion`
         instance.
@@ -549,7 +549,7 @@ class PixelRegion(Region):
             conversions, by discretizing the boundary and converting the boundary polygon.
             Default is False, which converts to an equivalent idealized shape.
 
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices for boundary discretization.
             This keyword will have no effect unless ``include_boundary_distortions=True``.
             Default is 100.
@@ -825,7 +825,7 @@ class SkyRegion(Region):
 
     @abc.abstractmethod
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         """
         Convert to an equivalent spherical `~regions.SphericalSkyRegion`
         instance.
@@ -843,7 +843,7 @@ class SkyRegion(Region):
             conversions, by discretizing the boundary and converting the boundary polygon.
             Default is False, which converts to an equivalent idealized shape.
 
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices for boundary discretization.
             This keyword will have no effect unless ``include_boundary_distortions=True``.
             Default is 100.
@@ -1072,7 +1072,7 @@ class SphericalSkyRegion(Region):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def discretize_boundary(self, n_points=100):
+    def discretize_boundary(self, n_vertices=100):
         """
         Discretize the boundary into a
         `~regions.PolygonSphericalSkyRegion`, as an approximation where
@@ -1080,7 +1080,7 @@ class SphericalSkyRegion(Region):
 
         Parameters
         ----------
-        n_points : int, optional
+        n_vertices : int, optional
             Number of points along the region's boundary. Default is 100.
 
         Returns
@@ -1092,7 +1092,7 @@ class SphericalSkyRegion(Region):
 
     @abc.abstractmethod
     def to_sky(
-        self, wcs=None, include_boundary_distortions=False, n_points=None,
+        self, wcs=None, include_boundary_distortions=False, n_vertices=None,
     ):
         """
         Convert to a planar `~regions.SkyRegion`.
@@ -1110,7 +1110,7 @@ class SphericalSkyRegion(Region):
             conversions, by discretizing the boundary and converting the boundary polygon.
             Default is False, which converts to an equivalent idealized shape.
 
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices for boundary discretization.
             This keyword will have no effect unless ``include_boundary_distortions=True``.
             Default is 100.
@@ -1126,7 +1126,7 @@ class SphericalSkyRegion(Region):
 
     @abc.abstractmethod
     def to_pixel(
-        self, wcs, include_boundary_distortions=False, n_points=None,
+        self, wcs, include_boundary_distortions=False, n_vertices=None,
     ):
         """
         Convert to a planar `~regions.PixelRegion`.
@@ -1142,7 +1142,7 @@ class SphericalSkyRegion(Region):
             conversions, by discretizing the boundary and converting the boundary polygon.
             Default is False, which converts to an equivalent idealized shape.
 
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices for boundary discretization.
             This keyword will have no effect unless ``include_boundary_distortions=True``.
             Default is 100.

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -1067,7 +1067,8 @@ class SphericalSkyRegion(Region):
 
         Parameters
         ----------
-        frame : str, or `~astropy.coordinates.BaseCoordinateFrame` class or instance
+        frame : str, or `~astropy.coordinates.BaseCoordinateFrame` class \
+                or instance
             The frame to transform this coordinate into.
         merge_attributes : bool, optional
             Whether the default attributes in the destination frame are allowed

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -377,8 +377,10 @@ class Region(abc.ABC):
                                          **kwargs)
 
     @staticmethod
-    def _validate_planar_spherical_transform(wcs, include_boundary_distortions):
-        # Validate whether inputs are valid for planar <-> spherical transformations
+    def _validate_planar_spherical_transform(
+            wcs, include_boundary_distortions):
+        # Validate whether inputs are valid for planar <-> spherical
+        # transformations
         if include_boundary_distortions and (wcs is None):
             raise ValueError(
                 "'wcs' must be set if `include_boundary_distortions=True`",
@@ -541,25 +543,29 @@ class PixelRegion(Region):
         wcs : `~astropy.wcs.WCS` instance, optional
             The world coordinate system transformation to use to convert
             between sky and pixel coordinates. Required if transforming
-            with boundary distortions (if ``include_boundary_distortions`` is True).
+            with boundary distortions (if
+            ``include_boundary_distortions`` is True).
             Ignored if boundary distortions not included.
 
         include_boundary_distortions : bool, optional
             If True, accounts for boundary distortions in spherical to planar
-            conversions, by discretizing the boundary and converting the boundary polygon.
+            conversions, by discretizing the boundary and
+            converting the boundary polygon.
             Default is False, which converts to an equivalent idealized shape.
 
         n_vertices : int, optional
             The number of polygon vertices for boundary discretization.
-            This keyword will have no effect unless ``include_boundary_distortions=True``.
+            This keyword will have no effect unless
+            ``include_boundary_distortions=True``.
             Default is 100.
 
         Returns
         -------
         spherical_sky_region : `~regions.SphericalSkyRegion`
             A spherical sky region, with an equivalent shape (if
-            ``include_boundary_distortions`` is False), or a discretized polygon of
-            the boundary (if ``include_boundary_distortions`` is True).
+            ``include_boundary_distortions`` is False), or a
+            discretized polygon of the boundary (if
+            ``include_boundary_distortions`` is True).
         """
         raise NotImplementedError
 
@@ -835,25 +841,29 @@ class SkyRegion(Region):
         wcs : `~astropy.wcs.WCS` instance, optional
             The world coordinate system transformation to use to convert
             between sky and pixel coordinates. Required if transforming
-            with boundary distortions (if ``include_boundary_distortions`` is True).
+            with boundary distortions (if
+            ``include_boundary_distortions`` is True).
             Ignored if boundary distortions not included.
 
         include_boundary_distortions : bool, optional
             If True, accounts for boundary distortions in spherical to planar
-            conversions, by discretizing the boundary and converting the boundary polygon.
+            conversions, by discretizing the boundary and
+            converting the boundary polygon.
             Default is False, which converts to an equivalent idealized shape.
 
         n_vertices : int, optional
             The number of polygon vertices for boundary discretization.
-            This keyword will have no effect unless ``include_boundary_distortions=True``.
+            This keyword will have no effect unless
+            ``include_boundary_distortions=True``.
             Default is 100.
 
         Returns
         -------
         spherical_sky_region : `~regions.SphericalSkyRegion`
             A spherical sky region, with an equivalent shape (if
-            ``include_boundary_distortions`` is False), or a discretized polygon of
-            the boundary (if ``include_boundary_distortions`` is True).
+            ``include_boundary_distortions`` is False), or a
+            discretized polygon of the boundary (if
+            ``include_boundary_distortions`` is True).
         """
         raise NotImplementedError
 
@@ -1091,9 +1101,8 @@ class SphericalSkyRegion(Region):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def to_sky(
-        self, wcs=None, *, include_boundary_distortions=False, n_vertices=None,
-    ):
+    def to_sky(self, wcs=None, *, include_boundary_distortions=False,
+               n_vertices=None):
         """
         Convert to a planar `~regions.SkyRegion`.
 
@@ -1102,32 +1111,35 @@ class SphericalSkyRegion(Region):
         wcs : `~astropy.wcs.WCS`, optional
             The world coordinate system transformation to use to convert
             between sky and pixel coordinates. Required if transforming
-            with boundary distortions (if ``include_boundary_distortions`` is True).
+            with boundary distortions (if
+            ``include_boundary_distortions`` is True).
             Ignored if boundary distortions not included.
 
         include_boundary_distortions : bool, optional
             If True, accounts for boundary distortions in spherical to planar
-            conversions, by discretizing the boundary and converting the boundary polygon.
+            conversions, by discretizing the boundary and
+            converting the boundary polygon.
             Default is False, which converts to an equivalent idealized shape.
 
         n_vertices : int, optional
             The number of polygon vertices for boundary discretization.
-            This keyword will have no effect unless ``include_boundary_distortions=True``.
+            This keyword will have no effect unless
+            ``include_boundary_distortions=True``.
             Default is 100.
 
         Returns
         -------
         sky_region : `~regions.SkyRegion`
             A planar sky region, with an equivalent shape (if
-            ``include_boundary_distortions`` is False), or a discretized polygon of
-            the boundary (if ``include_boundary_distortions`` is True).
+            ``include_boundary_distortions`` is False), or a
+            discretized polygon of the boundary (if
+            ``include_boundary_distortions`` is True).
         """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def to_pixel(
-        self, wcs, *, include_boundary_distortions=False, n_vertices=None,
-    ):
+    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+                 n_vertices=None):
         """
         Convert to a planar `~regions.PixelRegion`.
 
@@ -1139,20 +1151,23 @@ class SphericalSkyRegion(Region):
 
         include_boundary_distortions : bool, optional
             If True, accounts for boundary distortions in spherical to planar
-            conversions, by discretizing the boundary and converting the boundary polygon.
+            conversions, by discretizing the boundary and
+            converting the boundary polygon.
             Default is False, which converts to an equivalent idealized shape.
 
         n_vertices : int, optional
             The number of polygon vertices for boundary discretization.
-            This keyword will have no effect unless ``include_boundary_distortions=True``.
+            This keyword will have no effect unless
+            ``include_boundary_distortions=True``.
             Default is 100.
 
         Returns
         -------
         pixel_region : `~regions.PixelRegion`
             A pixel region, with an equivalent shape (if
-            ``include_boundary_distortions`` is False), or a discretized polygon of
-            the boundary (if ``include_boundary_distortions`` is True).
+            ``include_boundary_distortions`` is False), or a
+            discretized polygon of the boundary (if
+            ``include_boundary_distortions`` is True).
         """
         raise NotImplementedError
 
@@ -1181,8 +1196,10 @@ class ComplexSphericalSkyRegion(SphericalSkyRegion):
     # but breaking out these methods/properties to streamline).
 
     # Instead, a variable set _boundaries is used, containing the
-    # subclass boundary properties. These boundary properties are, in order of preference,
-    # (a) accessed from `_[boundname]`, for transformed instances of subclass shapes that
+    # subclass boundary properties. These boundary properties are,
+    # in order of preference,
+    # (a) accessed from `_[boundname]`, for transformed
+    #     instances of subclass shapes that
     #     don't simply map in parameterization from frame to frame (eg, Range)
     # (b) derived on-the-fly
 
@@ -1193,7 +1210,8 @@ class ComplexSphericalSkyRegion(SphericalSkyRegion):
         cls_info = []
 
         _do_params_info = False
-        if (self._params is not None) and ((len(self._params) > 1) | (self._params[0] != 'frame')):
+        if (self._params is not None) and (
+                (len(self._params) > 1) | (self._params[0] != 'frame')):
             # Only do param-based repr if params other than "frame" are set
             # If only param is "frame", make repr with boundary info
             _do_params_info = True
@@ -1235,7 +1253,8 @@ class ComplexSphericalSkyRegion(SphericalSkyRegion):
         cls_info = [('Region', self.__class__.__name__)]
 
         _do_params_info = False
-        if (self._params is not None) and ((len(self._params) > 1) | (self._params[0] != 'frame')):
+        if (self._params is not None) and (
+                (len(self._params) > 1) | (self._params[0] != 'frame')):
             # Only do param-based str if params other than "frame" are set.
             # If only param is "frame", make str with boundary info
             _do_params_info = True

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -530,7 +530,7 @@ class PixelRegion(Region):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         """
         Convert to an equivalent spherical `~regions.SphericalSkyRegion`
@@ -824,7 +824,7 @@ class SkyRegion(Region):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         """
         Convert to an equivalent spherical `~regions.SphericalSkyRegion`
@@ -1072,7 +1072,7 @@ class SphericalSkyRegion(Region):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def discretize_boundary(self, n_vertices=100):
+    def discretize_boundary(self, *, n_vertices=100):
         """
         Discretize the boundary into a
         `~regions.PolygonSphericalSkyRegion`, as an approximation where
@@ -1092,7 +1092,7 @@ class SphericalSkyRegion(Region):
 
     @abc.abstractmethod
     def to_sky(
-        self, wcs=None, include_boundary_distortions=False, n_vertices=None,
+        self, wcs=None, *, include_boundary_distortions=False, n_vertices=None,
     ):
         """
         Convert to a planar `~regions.SkyRegion`.
@@ -1126,7 +1126,7 @@ class SphericalSkyRegion(Region):
 
     @abc.abstractmethod
     def to_pixel(
-        self, wcs, include_boundary_distortions=False, n_vertices=None,
+        self, wcs, *, include_boundary_distortions=False, n_vertices=None,
     ):
         """
         Convert to a planar `~regions.PixelRegion`.

--- a/regions/core/tests/test_compound.py
+++ b/regions/core/tests/test_compound.py
@@ -251,7 +251,7 @@ def test_compound_spherical_sky(wcs):
     assert isinstance(union.transform_to('icrs'),
                       CompoundSphericalSkyRegion)
 
-    assert isinstance(union.discretize_boundary(n_points=2),
+    assert isinstance(union.discretize_boundary(n_vertices=2),
                       CompoundSphericalSkyRegion)
 
     skycoord4 = SkyCoord(1 * u.deg, 89 * u.deg, frame='galactic')

--- a/regions/io/crtf/tests/test_crtf.py
+++ b/regions/io/crtf/tests/test_crtf.py
@@ -223,4 +223,5 @@ def test_read_sexagesimal_regression407():
     filename = get_pkg_data_filename(filename)
     regs = Regions.read(filename, errors='warn', format='crtf')
 
-    assert_quantity_allclose(regs[0].center.ra, 281.93342096 * u.deg, rtol=1e-9)
+    assert_quantity_allclose(
+        regs[0].center.ra, 281.93342096 * u.deg, rtol=1e-9)

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -251,7 +251,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
         return CircleAnnulusSkyRegion(center, inner_radius, outer_radius,
                                       self.meta.copy(), self.visual.copy())
 
-    def to_polygon(self, n_points=100):
+    def to_polygon(self, n_vertices=100):
         """
         Return a `~regions.CompoundPixelRegion` of two
         `~regions.PolygonPixelRegion` objects that approximates this
@@ -259,7 +259,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
 
         Parameters
         ----------
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices for each circle. Default
             is 100.
 
@@ -269,14 +269,14 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
             A compound region of two polygon regions approximating the
             annulus.
         """
-        inner_polygon = self._inner_region.to_polygon(n_points=n_points)
-        outer_polygon = self._outer_region.to_polygon(n_points=n_points)
+        inner_polygon = self._inner_region.to_polygon(n_vertices=n_vertices)
+        outer_polygon = self._outer_region.to_polygon(n_vertices=n_vertices)
         return CompoundPixelRegion(inner_polygon, outer_polygon,
                                    operator.xor, self.meta.copy(),
                                    self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
@@ -289,7 +289,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
             # # Leverage polygon class to_spherical_sky() functionality without
             # # distortions, as the distortions were already computed in creating
             # # that polygon approximation
-            # return self.discretize_boundary(n_points=n_points).to_spherical_sky(
+            # return self.discretize_boundary(n_vertices=n_vertices).to_spherical_sky(
             #     wcs=wcs, include_boundary_distortions=False
             # )
 
@@ -382,7 +382,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
                                         meta=self.meta.copy(),
                                         visual=self.visual.copy())
 
-    def to_polygon(self, wcs, n_points=100):
+    def to_polygon(self, wcs, n_vertices=100):
         """
         Return a `~regions.CompoundSkyRegion` of two
         `~regions.PolygonSkyRegion` objects that approximates this
@@ -392,7 +392,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
         ----------
         wcs : `~astropy.wcs.WCS`
             The WCS to use for the sky-to-pixel-to-sky conversion.
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices for each circle. Default
             is 100.
 
@@ -402,10 +402,10 @@ class CircleAnnulusSkyRegion(SkyRegion):
             A compound region of two polygon regions approximating the
             annulus.
         """
-        return self.to_pixel(wcs).to_polygon(n_points=n_points).to_sky(wcs)
+        return self.to_pixel(wcs).to_polygon(n_vertices=n_vertices).to_sky(wcs)
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
@@ -418,7 +418,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
             # # Leverage polygon class to_spherical_sky() functionality without
             # # distortions, as the distortions were already computed in creating
             # # that polygon approximation
-            # return self.to_pixel(wcs).discretize_boundary(n_points=npoints).to_spherical_sky(
+            # return self.to_pixel(wcs).discretize_boundary(n_vertices=n_vertices).to_spherical_sky(
             #     wcs=wcs, include_boundary_distortions=False
             # )
 
@@ -493,16 +493,16 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
             self.visual.copy(),
         )
 
-    def discretize_boundary(self, n_points=100):
+    def discretize_boundary(self, n_vertices=100):
         return CompoundSphericalSkyRegion(
-            self._inner_region.discretize_boundary(n_points=n_points),
-            self._outer_region.discretize_boundary(n_points=n_points),
+            self._inner_region.discretize_boundary(n_vertices=n_vertices),
+            self._outer_region.discretize_boundary(n_vertices=n_vertices),
             operator=operator.xor,
             meta=self.meta.copy(),
             visual=self.visual.copy(),
         )
 
-    def to_polygon(self, n_points=100):
+    def to_polygon(self, n_vertices=100):
         """
         Return a `~regions.CompoundSphericalSkyRegion` of two
         `~regions.PolygonSphericalSkyRegion` objects that approximates this
@@ -510,7 +510,7 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
 
         Parameters
         ----------
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices for each circle. Default
             is 100.
 
@@ -520,13 +520,13 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
             A compound region of two polygon regions approximating the
             annulus.
         """
-        return self.discretize_boundary(n_points=n_points)
+        return self.discretize_boundary(n_vertices=n_vertices)
 
     def to_sky(
         self,
         wcs=None,
         include_boundary_distortions=False,
-        n_points=None,
+        n_vertices=None,
     ):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
@@ -536,7 +536,7 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
             return self.to_pixel(
                 include_boundary_distortions=include_boundary_distortions,
                 wcs=wcs,
-                n_points=n_points,
+                n_vertices=n_vertices,
             ).to_sky(wcs)
 
         return CircleAnnulusSkyRegion(
@@ -550,7 +550,7 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
     def to_pixel(
         self, wcs,
         include_boundary_distortions=False,
-        n_points=None,
+        n_vertices=None,
     ):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
@@ -558,7 +558,7 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
             from .polygon import PolygonPixelRegion
 
             # Requires spherical to planar projection (from WCS) and discretization
-            disc_kwargs = {} if n_points is None else {'n_points': n_points}
+            disc_kwargs = {} if n_vertices is None else {'n_vertices': n_vertices}
             polygonized = self.discretize_boundary(**disc_kwargs)
 
             inner_vertices = wcs.world_to_pixel(polygonized.region1.vertices)
@@ -822,7 +822,7 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
         super().__init__(center, inner_width, outer_width, inner_height,
                          outer_height, angle, meta, visual)
 
-    def to_polygon(self, n_points=100):
+    def to_polygon(self, n_vertices=100):
         """
         Return a `~regions.CompoundPixelRegion` of two
         `~regions.PolygonPixelRegion` objects that approximates this
@@ -830,7 +830,7 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
 
         Parameters
         ----------
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices for each ellipse. Default
             is 100.
 
@@ -840,8 +840,8 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
             A compound region of two polygon regions approximating the
             annulus.
         """
-        inner_polygon = self._inner_region.to_polygon(n_points=n_points)
-        outer_polygon = self._outer_region.to_polygon(n_points=n_points)
+        inner_polygon = self._inner_region.to_polygon(n_vertices=n_vertices)
+        outer_polygon = self._outer_region.to_polygon(n_vertices=n_vertices)
         return CompoundPixelRegion(inner_polygon, outer_polygon,
                                    operator.xor, self.meta.copy(),
                                    self.visual.copy())
@@ -852,7 +852,7 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
                                        visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         raise NotImplementedError
 
 
@@ -908,7 +908,7 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
         super().__init__(center, inner_width, outer_width, inner_height,
                          outer_height, angle, meta, visual)
 
-    def to_polygon(self, wcs, n_points=100):
+    def to_polygon(self, wcs, n_vertices=100):
         """
         Return a `~regions.CompoundSkyRegion` of two
         `~regions.PolygonSkyRegion` objects that approximates this
@@ -918,7 +918,7 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
         ----------
         wcs : `~astropy.wcs.WCS`
             The WCS to use for the sky-to-pixel-to-sky conversion.
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices for each ellipse. Default
             is 100.
 
@@ -928,7 +928,7 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
             A compound region of two polygon regions approximating the
             annulus.
         """
-        return self.to_pixel(wcs).to_polygon(n_points=n_points).to_sky(wcs)
+        return self.to_pixel(wcs).to_polygon(n_vertices=n_vertices).to_sky(wcs)
 
     def to_pixel(self, wcs):
         return EllipseAnnulusPixelRegion(*self.to_pixel_args(wcs),
@@ -936,7 +936,7 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
                                          visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         raise NotImplementedError
 
 
@@ -1055,7 +1055,7 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
                                          visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         raise NotImplementedError
 
 
@@ -1154,5 +1154,5 @@ class RectangleAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
                                            visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -251,7 +251,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
         return CircleAnnulusSkyRegion(center, inner_radius, outer_radius,
                                       self.meta.copy(), self.visual.copy())
 
-    def to_polygon(self, n_vertices=100):
+    def to_polygon(self, *, n_vertices=100):
         """
         Return a `~regions.CompoundPixelRegion` of two
         `~regions.PolygonPixelRegion` objects that approximates this
@@ -275,7 +275,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
                                    operator.xor, self.meta.copy(),
                                    self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
@@ -382,7 +382,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
                                         meta=self.meta.copy(),
                                         visual=self.visual.copy())
 
-    def to_polygon(self, wcs, n_vertices=100):
+    def to_polygon(self, wcs, *, n_vertices=100):
         """
         Return a `~regions.CompoundSkyRegion` of two
         `~regions.PolygonSkyRegion` objects that approximates this
@@ -404,7 +404,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
         """
         return self.to_pixel(wcs).to_polygon(n_vertices=n_vertices).to_sky(wcs)
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
@@ -493,7 +493,7 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
             self.visual.copy(),
         )
 
-    def discretize_boundary(self, n_vertices=100):
+    def discretize_boundary(self, *, n_vertices=100):
         return CompoundSphericalSkyRegion(
             self._inner_region.discretize_boundary(n_vertices=n_vertices),
             self._outer_region.discretize_boundary(n_vertices=n_vertices),
@@ -502,7 +502,7 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
             visual=self.visual.copy(),
         )
 
-    def to_polygon(self, n_vertices=100):
+    def to_polygon(self, *, n_vertices=100):
         """
         Return a `~regions.CompoundSphericalSkyRegion` of two
         `~regions.PolygonSphericalSkyRegion` objects that approximates this
@@ -525,7 +525,7 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
     def to_sky(
         self,
         wcs=None,
-        include_boundary_distortions=False,
+        *, include_boundary_distortions=False,
         n_vertices=None,
     ):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
@@ -535,8 +535,7 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
             # Use to_pixel(), then apply "small angle approx" to get planar sky.
             return self.to_pixel(
                 include_boundary_distortions=include_boundary_distortions,
-                wcs=wcs,
-                n_vertices=n_vertices,
+                wcs=wcs, n_vertices=n_vertices,
             ).to_sky(wcs)
 
         return CircleAnnulusSkyRegion(
@@ -548,7 +547,7 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
         )
 
     def to_pixel(
-        self, wcs,
+        self, wcs, *,
         include_boundary_distortions=False,
         n_vertices=None,
     ):
@@ -822,7 +821,7 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
         super().__init__(center, inner_width, outer_width, inner_height,
                          outer_height, angle, meta, visual)
 
-    def to_polygon(self, n_vertices=100):
+    def to_polygon(self, *, n_vertices=100):
         """
         Return a `~regions.CompoundPixelRegion` of two
         `~regions.PolygonPixelRegion` objects that approximates this
@@ -851,7 +850,7 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
                                        meta=self.meta.copy(),
                                        visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -908,7 +907,7 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
         super().__init__(center, inner_width, outer_width, inner_height,
                          outer_height, angle, meta, visual)
 
-    def to_polygon(self, wcs, n_vertices=100):
+    def to_polygon(self, wcs, *, n_vertices=100):
         """
         Return a `~regions.CompoundSkyRegion` of two
         `~regions.PolygonSkyRegion` objects that approximates this
@@ -935,7 +934,7 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
                                          meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -1054,7 +1053,7 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
                                          meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -1153,6 +1152,6 @@ class RectangleAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
                                            meta=self.meta.copy(),
                                            visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -32,7 +32,8 @@ from regions.shapes.rectangle import RectanglePixelRegion, RectangleSkyRegion
 __all__ = ['AnnulusPixelRegion', 'AnnulusSphericalSkyRegion',
            'AsymmetricAnnulusPixelRegion',
            'AsymmetricAnnulusSkyRegion',
-           'CircleAnnulusPixelRegion', 'CircleAnnulusSkyRegion', 'CircleAnnulusSphericalSkyRegion',
+           'CircleAnnulusPixelRegion', 'CircleAnnulusSkyRegion',
+           'CircleAnnulusSphericalSkyRegion',
            'EllipseAnnulusPixelRegion', 'EllipseAnnulusSkyRegion',
            'RectangleAnnulusPixelRegion', 'RectangleAnnulusSkyRegion']
 
@@ -101,8 +102,9 @@ class AnnulusSphericalSkyRegion(SphericalSkyRegion, abc.ABC):
 
     @property
     def _compound_region(self):
-        return CompoundSphericalSkyRegion(self._inner_region, self._outer_region,
-                                          operator.xor, self.meta, self.visual)
+        return CompoundSphericalSkyRegion(
+            self._inner_region, self._outer_region,
+            operator.xor, self.meta, self.visual)
 
     @property
     def frame(self):
@@ -277,19 +279,23 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
 
     def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+        self._validate_planar_spherical_transform(
+            wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
-            # Requires planar to spherical projection (using WCS) and discretization
+            # Requires planar to spherical projection (using WCS)
+            # and discretization
             # Will require implementing discretization in pixel space
             # to get correct handling of distortions.
             raise NotImplementedError
 
             # ### Potential solution:
             # # Leverage polygon class to_spherical_sky() functionality without
-            # # distortions, as the distortions were already computed in creating
+            # # distortions, as the distortions were already
+            # # computed in creating
             # # that polygon approximation
-            # return self.discretize_boundary(n_vertices=n_vertices).to_spherical_sky(
+            # return self.discretize_boundary(
+            #     n_vertices=n_vertices).to_spherical_sky(
             #     wcs=wcs, include_boundary_distortions=False
             # )
 
@@ -406,19 +412,24 @@ class CircleAnnulusSkyRegion(SkyRegion):
 
     def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+        self._validate_planar_spherical_transform(
+            wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
-            # Requires planar to spherical projection (using WCS) and discretization
+            # Requires planar to spherical projection (using WCS)
+            # and discretization
             # Will require implementing discretization in pixel space
             # to get correct handling of distortions.
             raise NotImplementedError
 
             # ### Potential solution:
             # # Leverage polygon class to_spherical_sky() functionality without
-            # # distortions, as the distortions were already computed in creating
+            # # distortions, as the distortions were already
+            # # computed in creating
             # # that polygon approximation
-            # return self.to_pixel(wcs).discretize_boundary(n_vertices=n_vertices).to_spherical_sky(
+            # return self.to_pixel(wcs)
+            #     .discretize_boundary(n_vertices=n_vertices)
+            #     .to_spherical_sky(
             #     wcs=wcs, include_boundary_distortions=False
             # )
 
@@ -483,7 +494,8 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
         frame = self._validate_frame_transformation(frame)
 
         # Only center transforms, radii preserved
-        center_transf = self.center.transform_to(frame, merge_attributes=merge_attributes)
+        center_transf = self.center.transform_to(
+            frame, merge_attributes=merge_attributes)
 
         return CircleAnnulusSphericalSkyRegion(
             center_transf,
@@ -522,17 +534,16 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
         """
         return self.discretize_boundary(n_vertices=n_vertices)
 
-    def to_sky(
-        self,
-        wcs=None,
-        *, include_boundary_distortions=False,
-        n_vertices=None,
-    ):
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+    def to_sky(self, wcs=None, *, include_boundary_distortions=False,
+               n_vertices=None):
+        self._validate_planar_spherical_transform(
+            wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
-            # Requires spherical to planar projection (from WCS) and discretization
-            # Use to_pixel(), then apply "small angle approx" to get planar sky.
+            # Requires spherical to planar projection (from WCS)
+            # and discretization
+            # Use to_pixel(), then apply "small angle approx" to get planar
+            # sky.
             return self.to_pixel(
                 include_boundary_distortions=include_boundary_distortions,
                 wcs=wcs, n_vertices=n_vertices,
@@ -546,18 +557,19 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
             visual=self.visual.copy(),
         )
 
-    def to_pixel(
-        self, wcs, *,
-        include_boundary_distortions=False,
-        n_vertices=None,
-    ):
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+                 n_vertices=None):
+        self._validate_planar_spherical_transform(
+            wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
             from .polygon import PolygonPixelRegion
 
-            # Requires spherical to planar projection (from WCS) and discretization
-            disc_kwargs = {} if n_vertices is None else {'n_vertices': n_vertices}
+            # Requires spherical to planar projection (from WCS) and
+            # discretization
+            disc_kwargs = (
+                {} if n_vertices is None
+                else {'n_vertices': n_vertices})
             polygonized = self.discretize_boundary(**disc_kwargs)
 
             inner_vertices = wcs.world_to_pixel(polygonized.region1.vertices)

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -226,7 +226,8 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
 
         Returns
         -------
-        region : `~regions.CircleAnnulusSkyRegion` or `~regions.EllipseAnnulusSkyRegion`
+        region : `~regions.CircleAnnulusSkyRegion` or \
+                `~regions.EllipseAnnulusSkyRegion`
             The sky region. An ellipse annulus is returned if
             ``as_ellipse`` is `True`.
         """
@@ -362,7 +363,8 @@ class CircleAnnulusSkyRegion(SkyRegion):
 
         Returns
         -------
-        region : `~regions.CircleAnnulusPixelRegion` or `~regions.EllipseAnnulusPixelRegion`
+        region : `~regions.CircleAnnulusPixelRegion` or \
+                `~regions.EllipseAnnulusPixelRegion`
             The pixel region. An ellipse annulus is returned if
             ``as_ellipse`` is `True`.
         """

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -161,7 +161,8 @@ class CirclePixelRegion(PixelRegion):
             # Leverage polygon class to_spherical_sky() functionality
             # without distortions, as the distortions were already
             # computed in creating that polygon approximation
-            # return self.discretize_boundary(n_vertices=n_vertices).to_spherical_sky(
+            # return self.discretize_boundary(
+            #     n_vertices=n_vertices).to_spherical_sky(
             #     wcs=wcs, include_boundary_distortions=False
             # )
 
@@ -374,16 +375,20 @@ class CircleSkyRegion(SkyRegion):
                                                   include_boundary_distortions)
 
         if include_boundary_distortions:
-            # Requires planar to spherical projection (using WCS) and discretization
+            # Requires planar to spherical projection (using WCS)
+            # and discretization
             # Will require implementing discretization in pixel space
             # to get correct handling of distortions.
             raise NotImplementedError
 
             # ### Potential solution:
             # # Leverage polygon class to_spherical_sky() functionality without
-            # # distortions, as the distortions were already computed in creating
+            # # distortions, as the distortions were already
+            # # computed in creating
             # # that polygon approximation
-            # return self.to_pixel(wcs).discretize_boundary(n_vertices=n_vertices).to_spherical_sky(
+            # return self.to_pixel(wcs)
+            #     .discretize_boundary(n_vertices=n_vertices)
+            #     .to_spherical_sky(
             #     wcs=wcs, include_boundary_distortions=False
             # )
 
@@ -465,6 +470,7 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
     def discretize_boundary(self, *, n_vertices=100):
         # Avoid circular imports:
         from .polygon import PolygonSphericalSkyRegion
+
         theta = np.linspace(0, 1, num=n_vertices, endpoint=False) * 360 * u.deg
         # Need to invert order because of CW convention:
         bound_verts = self.center.directional_offset_by(theta[::-1],
@@ -495,8 +501,10 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
                                                   include_boundary_distortions)
 
         if include_boundary_distortions:
-            # Requires spherical to planar projection (from WCS) and discretization
-            # Use to_pixel(), then apply "small angle approx" to get planar sky.
+            # Requires spherical to planar projection (from WCS)
+            # and discretization
+            # Use to_pixel(), then apply "small angle approx" to get planar
+            # sky.
             return self.to_pixel(
                 include_boundary_distortions=include_boundary_distortions,
                 wcs=wcs,

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -145,20 +145,22 @@ class CirclePixelRegion(PixelRegion):
         return CircleSkyRegion(center, radius, meta=self.meta.copy(),
                                visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+        self._validate_planar_spherical_transform(wcs,
+                                                  include_boundary_distortions)
 
         if include_boundary_distortions:
-            # Requires planar to spherical projection (using WCS) and discretization
+            # Requires planar to spherical projection (using WCS) and
+            # discretization.
             # Will require implementing discretization in pixel space
             # to get correct handling of distortions.
             raise NotImplementedError
 
             # ### Potential solution:
-            # # Leverage polygon class to_spherical_sky() functionality without
-            # # distortions, as the distortions were already computed in creating
-            # # that polygon approximation
+            # Leverage polygon class to_spherical_sky() functionality
+            # without distortions, as the distortions were already
+            # computed in creating that polygon approximation
             # return self.discretize_boundary(n_vertices=n_vertices).to_spherical_sky(
             #     wcs=wcs, include_boundary_distortions=False
             # )
@@ -253,7 +255,7 @@ class CirclePixelRegion(PixelRegion):
         center = self.center.rotate(center, angle)
         return self.copy(center=center)
 
-    def to_polygon(self, n_vertices=100):
+    def to_polygon(self, *, n_vertices=100):
         """
         Return a `~regions.PolygonPixelRegion` that approximates this
         circle.
@@ -347,7 +349,7 @@ class CircleSkyRegion(SkyRegion):
                                  meta=self.meta.copy(),
                                  visual=self.visual.copy())
 
-    def to_polygon(self, wcs, n_vertices=100):
+    def to_polygon(self, wcs, *, n_vertices=100):
         """
         Return a `~regions.PolygonSkyRegion` that approximates this
         circle.
@@ -366,9 +368,10 @@ class CircleSkyRegion(SkyRegion):
         """
         return self.to_pixel(wcs).to_polygon(n_vertices=n_vertices).to_sky(wcs)
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+        self._validate_planar_spherical_transform(wcs,
+                                                  include_boundary_distortions)
 
         if include_boundary_distortions:
             # Requires planar to spherical projection (using WCS) and discretization
@@ -437,7 +440,8 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
 
     @property
     def bounding_lonlat(self):
-        lons_arr = get_circle_longitude_tangent_limits(self.center, self.radius)
+        lons_arr = get_circle_longitude_tangent_limits(self.center,
+                                                       self.radius)
         lats_arr = get_circle_latitude_tangent_limits(self.center, self.radius)
 
         lons_arr, lats_arr = self._validate_lonlat_bounds(lons_arr, lats_arr)
@@ -458,16 +462,17 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
             self.visual.copy(),
         )
 
-    def discretize_boundary(self, n_vertices=100):
+    def discretize_boundary(self, *, n_vertices=100):
         # Avoid circular imports:
         from .polygon import PolygonSphericalSkyRegion
         theta = np.linspace(0, 1, num=n_vertices, endpoint=False) * 360 * u.deg
         # Need to invert order because of CW convention:
-        bound_verts = self.center.directional_offset_by(theta[::-1], self.radius)
+        bound_verts = self.center.directional_offset_by(theta[::-1],
+                                                        self.radius)
         return PolygonSphericalSkyRegion(bound_verts, meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
-    def to_polygon(self, n_vertices=100):
+    def to_polygon(self, *, n_vertices=100):
         """
         Return a `~regions.PolygonSphericalSkyRegion` that approximates this
         circle.
@@ -484,10 +489,10 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
         """
         return self.discretize_boundary(n_vertices=n_vertices)
 
-    def to_sky(
-        self, wcs=None, include_boundary_distortions=False, n_vertices=None,
-    ):
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+    def to_sky(self, wcs=None, *, include_boundary_distortions=False,
+               n_vertices=None):
+        self._validate_planar_spherical_transform(wcs,
+                                                  include_boundary_distortions)
 
         if include_boundary_distortions:
             # Requires spherical to planar projection (from WCS) and discretization
@@ -502,24 +507,25 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
             self.center, self.radius, meta=self.meta, visual=self.visual,
         )
 
-    def to_pixel(
-        self, wcs,
-        include_boundary_distortions=False,
-        n_vertices=None,
-    ):
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+                 n_vertices=None):
+        self._validate_planar_spherical_transform(wcs,
+                                                  include_boundary_distortions)
 
         if include_boundary_distortions:
             from .polygon import PolygonPixelRegion
 
-            disc_kwargs = {} if n_vertices is None else {'n_vertices': n_vertices}
+            disc_kwargs = ({} if n_vertices is None
+                           else {'n_vertices': n_vertices})
 
-            # Requires spherical to planar projection (from WCS) and discretization
+            # Requires spherical to planar projection (from WCS) and
+            # discretization
             verts = wcs.world_to_pixel(
                 self.discretize_boundary(**disc_kwargs).vertices,
             )
             return PolygonPixelRegion(
-                PixCoord(*verts), meta=self.meta.copy(), visual=self.visual.copy(),
+                PixCoord(*verts), meta=self.meta.copy(),
+                visual=self.visual.copy(),
             )
 
         return self.to_sky().to_pixel(wcs)

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -146,7 +146,7 @@ class CirclePixelRegion(PixelRegion):
                                visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
@@ -159,7 +159,7 @@ class CirclePixelRegion(PixelRegion):
             # # Leverage polygon class to_spherical_sky() functionality without
             # # distortions, as the distortions were already computed in creating
             # # that polygon approximation
-            # return self.discretize_boundary(n_points=npoints).to_spherical_sky(
+            # return self.discretize_boundary(n_vertices=n_vertices).to_spherical_sky(
             #     wcs=wcs, include_boundary_distortions=False
             # )
 
@@ -253,14 +253,14 @@ class CirclePixelRegion(PixelRegion):
         center = self.center.rotate(center, angle)
         return self.copy(center=center)
 
-    def to_polygon(self, n_points=100):
+    def to_polygon(self, n_vertices=100):
         """
         Return a `~regions.PolygonPixelRegion` that approximates this
         circle.
 
         Parameters
         ----------
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices. Default is 100.
 
         Returns
@@ -268,7 +268,7 @@ class CirclePixelRegion(PixelRegion):
         polygon : `~regions.PolygonPixelRegion`
             A polygon region approximating the circle.
         """
-        theta = np.linspace(0, 2 * np.pi, n_points, endpoint=False)
+        theta = np.linspace(0, 2 * np.pi, n_vertices, endpoint=False)
         x = self.radius * np.cos(theta) + self.center.x
         y = self.radius * np.sin(theta) + self.center.y
         vertices = PixCoord(x=x, y=y)
@@ -347,7 +347,7 @@ class CircleSkyRegion(SkyRegion):
                                  meta=self.meta.copy(),
                                  visual=self.visual.copy())
 
-    def to_polygon(self, wcs, n_points=100):
+    def to_polygon(self, wcs, n_vertices=100):
         """
         Return a `~regions.PolygonSkyRegion` that approximates this
         circle.
@@ -356,7 +356,7 @@ class CircleSkyRegion(SkyRegion):
         ----------
         wcs : `~astropy.wcs.WCS`
             The WCS to use for the sky-to-pixel-to-sky conversion.
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices. Default is 100.
 
         Returns
@@ -364,10 +364,10 @@ class CircleSkyRegion(SkyRegion):
         polygon : `~regions.PolygonSkyRegion`
             A polygon region approximating the circle.
         """
-        return self.to_pixel(wcs).to_polygon(n_points=n_points).to_sky(wcs)
+        return self.to_pixel(wcs).to_polygon(n_vertices=n_vertices).to_sky(wcs)
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
@@ -380,7 +380,7 @@ class CircleSkyRegion(SkyRegion):
             # # Leverage polygon class to_spherical_sky() functionality without
             # # distortions, as the distortions were already computed in creating
             # # that polygon approximation
-            # return self.to_pixel(wcs).discretize_boundary(n_points=n_points).to_spherical_sky(
+            # return self.to_pixel(wcs).discretize_boundary(n_vertices=n_vertices).to_spherical_sky(
             #     wcs=wcs, include_boundary_distortions=False
             # )
 
@@ -458,23 +458,23 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
             self.visual.copy(),
         )
 
-    def discretize_boundary(self, n_points=100):
+    def discretize_boundary(self, n_vertices=100):
         # Avoid circular imports:
         from .polygon import PolygonSphericalSkyRegion
-        theta = np.linspace(0, 1, num=n_points, endpoint=False) * 360 * u.deg
+        theta = np.linspace(0, 1, num=n_vertices, endpoint=False) * 360 * u.deg
         # Need to invert order because of CW convention:
         bound_verts = self.center.directional_offset_by(theta[::-1], self.radius)
         return PolygonSphericalSkyRegion(bound_verts, meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
-    def to_polygon(self, n_points=100):
+    def to_polygon(self, n_vertices=100):
         """
         Return a `~regions.PolygonSphericalSkyRegion` that approximates this
         circle.
 
         Parameters
         ----------
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices. Default is 100.
 
         Returns
@@ -482,10 +482,10 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
         polygon : `~regions.PolygonSphericalSkyRegion`
             A polygon region approximating the circle.
         """
-        return self.discretize_boundary(n_points=n_points)
+        return self.discretize_boundary(n_vertices=n_vertices)
 
     def to_sky(
-        self, wcs=None, include_boundary_distortions=False, n_points=None,
+        self, wcs=None, include_boundary_distortions=False, n_vertices=None,
     ):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
@@ -495,7 +495,7 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
             return self.to_pixel(
                 include_boundary_distortions=include_boundary_distortions,
                 wcs=wcs,
-                n_points=n_points,
+                n_vertices=n_vertices,
             ).to_sky(wcs)
 
         return CircleSkyRegion(
@@ -505,14 +505,14 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
     def to_pixel(
         self, wcs,
         include_boundary_distortions=False,
-        n_points=None,
+        n_vertices=None,
     ):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
             from .polygon import PolygonPixelRegion
 
-            disc_kwargs = {} if n_points is None else {'n_points': n_points}
+            disc_kwargs = {} if n_vertices is None else {'n_vertices': n_vertices}
 
             # Requires spherical to planar projection (from WCS) and discretization
             verts = wcs.world_to_pixel(

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -130,7 +130,7 @@ class EllipsePixelRegion(PixelRegion):
                                 meta=self.meta.copy(),
                                 visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -333,7 +333,7 @@ class EllipsePixelRegion(PixelRegion):
         angle = self.angle + angle
         return self.copy(center=center, angle=angle)
 
-    def to_polygon(self, n_vertices=100):
+    def to_polygon(self, *, n_vertices=100):
         """
         Return a `~regions.PolygonPixelRegion` that approximates this
         ellipse.
@@ -417,7 +417,7 @@ class EllipseSkyRegion(SkyRegion):
                                   meta=self.meta.copy(),
                                   visual=self.visual.copy())
 
-    def to_polygon(self, wcs, n_vertices=100):
+    def to_polygon(self, wcs, *, n_vertices=100):
         """
         Return a `~regions.PolygonSkyRegion` that approximates this
         ellipse.
@@ -436,6 +436,6 @@ class EllipseSkyRegion(SkyRegion):
         """
         return self.to_pixel(wcs).to_polygon(n_vertices=n_vertices).to_sky(wcs)
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -277,10 +277,12 @@ class EllipsePixelRegion(PixelRegion):
         from matplotlib.widgets import EllipseSelector
 
         if hasattr(self, '_mpl_selector'):
-            raise AttributeError('Cannot attach more than one selector to a region.')
+            raise AttributeError(
+                'Cannot attach more than one selector to a region.')
 
         if self.angle.value != 0:
-            raise NotImplementedError('Cannot create matplotlib selector for rotated ellipse.')
+            raise NotImplementedError(
+                'Cannot create matplotlib selector for rotated ellipse.')
 
         if sync:
             sync_callback = self._update_from_mpl_selector

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -131,7 +131,7 @@ class EllipsePixelRegion(PixelRegion):
                                 visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         raise NotImplementedError
 
     @property
@@ -333,14 +333,14 @@ class EllipsePixelRegion(PixelRegion):
         angle = self.angle + angle
         return self.copy(center=center, angle=angle)
 
-    def to_polygon(self, n_points=100):
+    def to_polygon(self, n_vertices=100):
         """
         Return a `~regions.PolygonPixelRegion` that approximates this
         ellipse.
 
         Parameters
         ----------
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices. Default is 100.
 
         Returns
@@ -348,7 +348,7 @@ class EllipsePixelRegion(PixelRegion):
         polygon : `~regions.PolygonPixelRegion`
             A polygon region approximating the ellipse.
         """
-        theta = np.linspace(0, 2 * np.pi, n_points, endpoint=False)
+        theta = np.linspace(0, 2 * np.pi, n_vertices, endpoint=False)
         x = 0.5 * self.width * np.cos(theta)
         y = 0.5 * self.height * np.sin(theta)
         cos_angle = np.cos(self.angle)
@@ -417,7 +417,7 @@ class EllipseSkyRegion(SkyRegion):
                                   meta=self.meta.copy(),
                                   visual=self.visual.copy())
 
-    def to_polygon(self, wcs, n_points=100):
+    def to_polygon(self, wcs, n_vertices=100):
         """
         Return a `~regions.PolygonSkyRegion` that approximates this
         ellipse.
@@ -426,7 +426,7 @@ class EllipseSkyRegion(SkyRegion):
         ----------
         wcs : `~astropy.wcs.WCS`
             The WCS to use for the sky-to-pixel-to-sky conversion.
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices. Default is 100.
 
         Returns
@@ -434,8 +434,8 @@ class EllipseSkyRegion(SkyRegion):
         polygon : `~regions.PolygonSkyRegion`
             A polygon region approximating the ellipse.
         """
-        return self.to_pixel(wcs).to_polygon(n_points=n_points).to_sky(wcs)
+        return self.to_pixel(wcs).to_polygon(n_vertices=n_vertices).to_sky(wcs)
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -85,7 +85,7 @@ class LinePixelRegion(PixelRegion):
         return LineSkyRegion(start, end, meta=self.meta.copy(),
                              visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -201,6 +201,6 @@ class LineSkyRegion(SkyRegion):
         return LinePixelRegion(start, end, meta=self.meta.copy(),
                                visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -86,7 +86,7 @@ class LinePixelRegion(PixelRegion):
                              visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         raise NotImplementedError
 
     @property
@@ -202,5 +202,5 @@ class LineSkyRegion(SkyRegion):
                                visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/lune.py
+++ b/regions/shapes/lune.py
@@ -187,22 +187,22 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
             self.visual.copy(),
         )
 
-    def discretize_boundary(self, n_points=100):
+    def discretize_boundary(self, n_vertices=100):
         bound_verts = discretize_all_edge_boundaries(
-            self.vertices, self._edge_circs, n_points,
+            self.vertices, self._edge_circs, n_vertices,
         )[::-1]  # inverted for lune
         # TODO: properly check for CW order even for a nverts=2 spherical polygon (lune).
         return PolygonSphericalSkyRegion(bound_verts, meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
-    def to_polygon(self, n_points=100):
+    def to_polygon(self, n_vertices=100):
         """
         Return a `~regions.PolygonSphericalSkyRegion` that approximates this
         lune.
 
         Parameters
         ----------
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices. Default is 100.
 
         Returns
@@ -210,13 +210,13 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
         polygon : `~regions.PolygonSphericalSkyRegion`
             A polygon region approximating the lune.
         """
-        return self.discretize_boundary(n_points=n_points)
+        return self.discretize_boundary(n_vertices=n_vertices)
 
     def to_sky(
         self,
         wcs=None,
         include_boundary_distortions=False,
-        n_points=None,
+        n_vertices=None,
     ):
         if not include_boundary_distortions:
             raise ValueError(
@@ -232,13 +232,13 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
         return self.to_pixel(
             include_boundary_distortions=include_boundary_distortions,
             wcs=wcs,
-            n_points=n_points,
+            n_vertices=n_vertices,
         ).to_sky(wcs)
 
     def to_pixel(
         self, wcs,
         include_boundary_distortions=False,
-        n_points=None,
+        n_vertices=None,
     ):
         if not include_boundary_distortions:
             raise ValueError(
@@ -249,7 +249,7 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
 
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
-        disc_kwargs = {} if n_points is None else {'n_points': n_points}
+        disc_kwargs = {} if n_vertices is None else {'n_vertices': n_vertices}
 
         # Requires spherical to planar projection (from WCS) and discretization
         disc_bound = self.discretize_boundary(**disc_kwargs)

--- a/regions/shapes/lune.py
+++ b/regions/shapes/lune.py
@@ -187,15 +187,15 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
             self.visual.copy(),
         )
 
-    def discretize_boundary(self, n_vertices=100):
+    def discretize_boundary(self, *, n_vertices=100):
         bound_verts = discretize_all_edge_boundaries(
-            self.vertices, self._edge_circs, n_vertices,
+            self.vertices, self._edge_circs, n_vertices=n_vertices,
         )[::-1]  # inverted for lune
         # TODO: properly check for CW order even for a nverts=2 spherical polygon (lune).
         return PolygonSphericalSkyRegion(bound_verts, meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
-    def to_polygon(self, n_vertices=100):
+    def to_polygon(self, *, n_vertices=100):
         """
         Return a `~regions.PolygonSphericalSkyRegion` that approximates this
         lune.
@@ -215,6 +215,7 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
     def to_sky(
         self,
         wcs=None,
+        *,
         include_boundary_distortions=False,
         n_vertices=None,
     ):
@@ -231,12 +232,11 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
         # Use to_pixel(), then apply "small angle approx" to get planar sky.
         return self.to_pixel(
             include_boundary_distortions=include_boundary_distortions,
-            wcs=wcs,
-            n_vertices=n_vertices,
+            wcs=wcs, n_vertices=n_vertices,
         ).to_sky(wcs)
 
     def to_pixel(
-        self, wcs,
+        self, wcs, *,
         include_boundary_distortions=False,
         n_vertices=None,
     ):

--- a/regions/shapes/lune.py
+++ b/regions/shapes/lune.py
@@ -46,8 +46,10 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
     """
 
     _params = ('center_gc1', 'center_gc2')
-    center_gc1 = ScalarSkyCoord('The center position of the first great circle as a |SkyCoord|.')
-    center_gc2 = ScalarSkyCoord('The center position of the second great circle as a |SkyCoord|.')
+    center_gc1 = ScalarSkyCoord(
+        'The center position of the first great circle as a |SkyCoord|.')
+    center_gc2 = ScalarSkyCoord(
+        'The center position of the second great circle as a |SkyCoord|.')
 
     meta = RegionMetaDescr('The meta attributes as a |RegionMeta|')
     visual = RegionVisualDescr('The visual attributes as a |RegionVisual|.')
@@ -82,8 +84,9 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
 
     @property
     def _compound_region(self):
-        return CompoundSphericalSkyRegion(self._circle_1, self._circle_2,
-                                          operator.and_, self.meta, self.visual)
+        return CompoundSphericalSkyRegion(
+            self._circle_1, self._circle_2,
+            operator.and_, self.meta, self.visual)
 
     @property
     def frame(self):
@@ -94,9 +97,11 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
         """
         Region centroid.
         """
-        # Cross product to get poles:
-        c_pole = cross_product_skycoord2skycoord(self.center_gc2, self.center_gc1)
-        c_pole_a = cross_product_skycoord2skycoord(self.center_gc1, self.center_gc2)
+        # Cross product to get poles
+        c_pole = cross_product_skycoord2skycoord(
+            self.center_gc2, self.center_gc1)
+        c_pole_a = cross_product_skycoord2skycoord(
+            self.center_gc1, self.center_gc2)
 
         # Use centers + poles to get centroid from cross products of vertices
         # with cartesian representation
@@ -107,21 +112,10 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
         c_p_sph = c_pole.represent_as('spherical')
         c_p_a_sph = c_pole_a.represent_as('spherical')
 
-        verts = SkyCoord(
-            [
-                c_gc2_sph.lon,
-                c_p_a_sph.lon,
-                c_gc1_sph.lon,
-                c_p_sph.lon,
-            ],
-            [
-                c_gc2_sph.lat,
-                c_p_a_sph.lat,
-                c_gc1_sph.lat,
-                c_p_sph.lat,
-            ],
-            frame=self.frame,
-        )
+        verts = SkyCoord([c_gc2_sph.lon, c_p_a_sph.lon, c_gc1_sph.lon,
+                          c_p_sph.lon],
+                         [c_gc2_sph.lat, c_p_a_sph.lat, c_gc1_sph.lat,
+                          c_p_sph.lat], frame=self.frame)
 
         return cross_product_sum_skycoord2skycoord(verts)
 
@@ -133,24 +127,17 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
         For a lune, these are the intersections of the two bounding
         great circles, and are antipodes.
         """
-        # Cross product to get poles:
-        c_pole = cross_product_skycoord2skycoord(self.center_gc2, self.center_gc1)
-        c_pole_a = cross_product_skycoord2skycoord(self.center_gc1, self.center_gc2)
+        # Cross product to get poles
+        c_pole = cross_product_skycoord2skycoord(
+            self.center_gc2, self.center_gc1)
+        c_pole_a = cross_product_skycoord2skycoord(
+            self.center_gc1, self.center_gc2)
 
         c_p_sph = c_pole.represent_as('spherical')
         c_p_a_sph = c_pole_a.represent_as('spherical')
 
-        verts = SkyCoord(
-            [
-                c_p_sph.lon,
-                c_p_a_sph.lon,
-            ],
-            [
-                c_p_sph.lat,
-                c_p_a_sph.lat,
-            ],
-            frame=self.frame,
-        )
+        verts = SkyCoord([c_p_sph.lon, c_p_a_sph.lon],
+                         [c_p_sph.lat, c_p_a_sph.lat], frame=self.frame)
 
         return verts
 
@@ -177,8 +164,10 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
     def transform_to(self, frame, merge_attributes=True):
         frame = self._validate_frame_transformation(frame)
 
-        center_gc1_transf = self.center_gc1.transform_to(frame, merge_attributes=merge_attributes)
-        center_gc2_transf = self.center_gc2.transform_to(frame, merge_attributes=merge_attributes)
+        center_gc1_transf = self.center_gc1.transform_to(
+            frame, merge_attributes=merge_attributes)
+        center_gc2_transf = self.center_gc2.transform_to(
+            frame, merge_attributes=merge_attributes)
 
         return LuneSphericalSkyRegion(
             center_gc1_transf,
@@ -191,7 +180,8 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
         bound_verts = discretize_all_edge_boundaries(
             self.vertices, self._edge_circs, n_vertices=n_vertices,
         )[::-1]  # inverted for lune
-        # TODO: properly check for CW order even for a nverts=2 spherical polygon (lune).
+        # TODO: properly check for CW order even for a nverts=2 spherical
+        # polygon (lune).
         return PolygonSphericalSkyRegion(bound_verts, meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
@@ -212,42 +202,39 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
         """
         return self.discretize_boundary(n_vertices=n_vertices)
 
-    def to_sky(
-        self,
-        wcs=None,
-        *,
-        include_boundary_distortions=False,
-        n_vertices=None,
-    ):
+    def to_sky(self, wcs=None, *, include_boundary_distortions=False,
+               n_vertices=None):
         if not include_boundary_distortions:
             raise ValueError(
                 'Invalid parameter: `include_boundary_distortions=False`!\n'
                 'Transforming lune to planar sky region is only possible by '
-                'including boundary distortions, as there is no analogous sky region.',
+                'including boundary distortions, as there is no '
+                'analogous sky region.',
             )
 
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+        self._validate_planar_spherical_transform(
+            wcs, include_boundary_distortions)
 
-        # Requires spherical to planar projection (from WCS) and discretization
-        # Use to_pixel(), then apply "small angle approx" to get planar sky.
+        # Requires spherical to planar projection (from WCS) and
+        # discretization. Use to_pixel(), then apply "small angle
+        # approx" to get planar sky.
         return self.to_pixel(
             include_boundary_distortions=include_boundary_distortions,
             wcs=wcs, n_vertices=n_vertices,
         ).to_sky(wcs)
 
-    def to_pixel(
-        self, wcs, *,
-        include_boundary_distortions=False,
-        n_vertices=None,
-    ):
+    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+                 n_vertices=None):
         if not include_boundary_distortions:
             raise ValueError(
                 'Invalid parameter: `include_boundary_distortions=False`!\n'
                 'Transforming lune to planar pixel region is only possible by '
-                'including boundary distortions, as there is no analogous pixel region.',
+                'including boundary distortions, as there is no '
+                'analogous pixel region.',
             )
 
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+        self._validate_planar_spherical_transform(
+            wcs, include_boundary_distortions)
 
         disc_kwargs = {} if n_vertices is None else {'n_vertices': n_vertices}
 

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -89,7 +89,7 @@ class PointPixelRegion(PixelRegion):
         return PointSkyRegion(center, meta=self.meta.copy(),
                               visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -196,6 +196,6 @@ class PointSkyRegion(SkyRegion):
         return PointPixelRegion(center, meta=self.meta.copy(),
                                 visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -90,7 +90,7 @@ class PointPixelRegion(PixelRegion):
                               visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         raise NotImplementedError
 
     @property
@@ -197,5 +197,5 @@ class PointSkyRegion(SkyRegion):
                                 visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -128,7 +128,7 @@ class PolygonPixelRegion(PixelRegion):
         return PolygonSkyRegion(vertices=vertices_sky, meta=self.meta.copy(),
                                 visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
@@ -424,7 +424,7 @@ class PolygonSkyRegion(SkyRegion):
         return PolygonPixelRegion(vertices_pix, meta=self.meta.copy(),
                                   visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
@@ -595,9 +595,9 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
             self.visual.copy(),
         )
 
-    def discretize_boundary(self, n_vertices=100):
+    def discretize_boundary(self, *, n_vertices=100):
         bound_verts = discretize_all_edge_boundaries(
-            self.vertices, self._edge_circs, n_vertices,
+            self.vertices, self._edge_circs, n_vertices=n_vertices,
         )
         return PolygonSphericalSkyRegion(bound_verts, meta=self.meta.copy(),
                                          visual=self.visual.copy())
@@ -605,6 +605,7 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
     def to_sky(
         self,
         wcs=None,
+        *,
         include_boundary_distortions=False,
         n_vertices=None,
     ):
@@ -615,8 +616,7 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
             # Use to_pixel(), then apply "small angle approx" to get planar sky.
             return self.to_pixel(
                 include_boundary_distortions=include_boundary_distortions,
-                wcs=wcs,
-                n_vertices=n_vertices,
+                wcs=wcs, n_vertices=n_vertices,
             ).to_sky(wcs)
 
         return PolygonSkyRegion(
@@ -626,7 +626,7 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
         )
 
     def to_pixel(
-        self, wcs,
+        self, wcs, *,
         include_boundary_distortions=False,
         n_vertices=None,
     ):

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -130,19 +130,24 @@ class PolygonPixelRegion(PixelRegion):
 
     def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+        self._validate_planar_spherical_transform(
+            wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
-            # Requires planar to spherical projection (using WCS) and discretization
+            # Requires planar to spherical projection (using WCS)
+            # and discretization
             # Will require implementing discretization in pixel space
             # to get correct handling of distortions.
             raise NotImplementedError
 
             # ### Potential solution:
             # # Leverage polygon class to_spherical_sky() functionality without
-            # # distortions, as the distortions were already computed in creating
+            # # distortions, as the distortions were already
+            # # computed in creating
             # # that polygon approximation
-            # return self.to_pixel(wcs).discretize_boundary(n_vertices=n_vertices).to_spherical_sky(
+            # return self.to_pixel(wcs)
+            #     .discretize_boundary(n_vertices=n_vertices)
+            #     .to_spherical_sky(
             #     wcs=wcs, include_boundary_distortions=False
             # )
 
@@ -426,19 +431,24 @@ class PolygonSkyRegion(SkyRegion):
 
     def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+        self._validate_planar_spherical_transform(
+            wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
-            # Requires planar to spherical projection (using WCS) and discretization
+            # Requires planar to spherical projection (using WCS)
+            # and discretization
             # Will require implementing discretization in pixel space
             # to get correct handling of distortions.
             raise NotImplementedError
 
             # ### Potential solution:
             # # Leverage polygon class to_spherical_sky() functionality without
-            # # distortions, as the distortions were already computed in creating
+            # # distortions, as the distortions were already
+            # # computed in creating
             # # that polygon approximation
-            # return self.to_pixel(wcs).discretize_boundary(n_vertices=n_vertices).to_spherical_sky(
+            # return self.to_pixel(wcs)
+            #     .discretize_boundary(n_vertices=n_vertices)
+            #     .to_spherical_sky(
             #     wcs=wcs, include_boundary_distortions=False
             # )
 
@@ -490,9 +500,11 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
         from .circle import CircleSphericalSkyRegion
         gcs = []
         for i in range(len(self.vertices)):
-            # verts are in CW order: Cross product to get bounding great circle centers
+            # verts are in CW order: Cross product to get bounding
+            # great circle centers
             # Compute GCs and stack into a compound set:
-            c_gc = cross_product_skycoord2skycoord(self.vertices[i - 1], self.vertices[i])
+            c_gc = cross_product_skycoord2skycoord(
+                self.vertices[i - 1], self.vertices[i])
             gcs.append(CircleSphericalSkyRegion(c_gc, 90 * u.deg))
         return gcs
 
@@ -602,18 +614,16 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
         return PolygonSphericalSkyRegion(bound_verts, meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
-    def to_sky(
-        self,
-        wcs=None,
-        *,
-        include_boundary_distortions=False,
-        n_vertices=None,
-    ):
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+    def to_sky(self, wcs=None, *, include_boundary_distortions=False,
+               n_vertices=None):
+        self._validate_planar_spherical_transform(
+            wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
-            # Requires spherical to planar projection (from WCS) and discretization
-            # Use to_pixel(), then apply "small angle approx" to get planar sky.
+            # Requires spherical to planar projection (from WCS)
+            # and discretization
+            # Use to_pixel(), then apply "small angle approx" to get planar
+            # sky.
             return self.to_pixel(
                 include_boundary_distortions=include_boundary_distortions,
                 wcs=wcs, n_vertices=n_vertices,
@@ -625,16 +635,17 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
             visual=self.visual,
         )
 
-    def to_pixel(
-        self, wcs, *,
-        include_boundary_distortions=False,
-        n_vertices=None,
-    ):
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+                 n_vertices=None):
+        self._validate_planar_spherical_transform(
+            wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
-            # Requires spherical to planar projection (from WCS) and discretization
-            disc_kwargs = {} if n_vertices is None else {'n_vertices': n_vertices}
+            # Requires spherical to planar projection (from WCS) and
+            # discretization
+            disc_kwargs = (
+                {} if n_vertices is None
+                else {'n_vertices': n_vertices})
 
             verts = wcs.world_to_pixel(
                 self.discretize_boundary(**disc_kwargs).vertices,

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -129,7 +129,7 @@ class PolygonPixelRegion(PixelRegion):
                                 visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
@@ -142,7 +142,7 @@ class PolygonPixelRegion(PixelRegion):
             # # Leverage polygon class to_spherical_sky() functionality without
             # # distortions, as the distortions were already computed in creating
             # # that polygon approximation
-            # return self.to_pixel(wcs).discretize_boundary(n_points=n_points).to_spherical_sky(
+            # return self.to_pixel(wcs).discretize_boundary(n_vertices=n_vertices).to_spherical_sky(
             #     wcs=wcs, include_boundary_distortions=False
             # )
 
@@ -425,7 +425,7 @@ class PolygonSkyRegion(SkyRegion):
                                   visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
@@ -438,7 +438,7 @@ class PolygonSkyRegion(SkyRegion):
             # # Leverage polygon class to_spherical_sky() functionality without
             # # distortions, as the distortions were already computed in creating
             # # that polygon approximation
-            # return self.to_pixel(wcs).discretize_boundary(n_points=n_points).to_spherical_sky(
+            # return self.to_pixel(wcs).discretize_boundary(n_vertices=n_vertices).to_spherical_sky(
             #     wcs=wcs, include_boundary_distortions=False
             # )
 
@@ -595,9 +595,9 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
             self.visual.copy(),
         )
 
-    def discretize_boundary(self, n_points=100):
+    def discretize_boundary(self, n_vertices=100):
         bound_verts = discretize_all_edge_boundaries(
-            self.vertices, self._edge_circs, n_points,
+            self.vertices, self._edge_circs, n_vertices,
         )
         return PolygonSphericalSkyRegion(bound_verts, meta=self.meta.copy(),
                                          visual=self.visual.copy())
@@ -606,7 +606,7 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
         self,
         wcs=None,
         include_boundary_distortions=False,
-        n_points=None,
+        n_vertices=None,
     ):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
@@ -616,7 +616,7 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
             return self.to_pixel(
                 include_boundary_distortions=include_boundary_distortions,
                 wcs=wcs,
-                n_points=n_points,
+                n_vertices=n_vertices,
             ).to_sky(wcs)
 
         return PolygonSkyRegion(
@@ -628,13 +628,13 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
     def to_pixel(
         self, wcs,
         include_boundary_distortions=False,
-        n_points=None,
+        n_vertices=None,
     ):
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
         if include_boundary_distortions:
             # Requires spherical to planar projection (from WCS) and discretization
-            disc_kwargs = {} if n_points is None else {'n_points': n_points}
+            disc_kwargs = {} if n_vertices is None else {'n_vertices': n_vertices}
 
             verts = wcs.world_to_pixel(
                 self.discretize_boundary(**disc_kwargs).vertices,

--- a/regions/shapes/range.py
+++ b/regions/shapes/range.py
@@ -821,30 +821,30 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
 
         return self.__class__(**transformed)
 
-    def discretize_boundary(self, n_points=100):
+    def discretize_boundary(self, n_vertices=100):
         bound_nverts = self._bound_nverts
 
         if bound_nverts == 0:
-            return self.latitude_bounds.discretize_boundary(n_points=n_points)
+            return self.latitude_bounds.discretize_boundary(n_vertices=n_vertices)
         elif bound_nverts == 2:
-            return self.longitude_bounds.discretize_boundary(n_points=n_points)
+            return self.longitude_bounds.discretize_boundary(n_vertices=n_vertices)
         elif (bound_nverts == 4) | (bound_nverts == 3):
             bound_verts = discretize_all_edge_boundaries(
-                self.vertices, self._edge_circs, n_points,
+                self.vertices, self._edge_circs, n_vertices,
             )
             return PolygonSphericalSkyRegion(bound_verts, meta=self.meta.copy(),
                                              visual=self.visual.copy())
         elif bound_nverts == 6:
             raise NotImplementedError
 
-    def to_polygon(self, n_points=100):
+    def to_polygon(self, n_vertices=100):
         """
         Return a `~regions.PolygonSphericalSkyRegion` that approximates this
         longitude/latitude range.
 
         Parameters
         ----------
-        n_points : int, optional
+        n_vertices : int, optional
             The number of polygon vertices. Default is 100.
 
         Returns
@@ -852,13 +852,13 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         polygon : `~regions.PolygonSphericalSkyRegion`
             A polygon region approximating the range.
         """
-        return self.discretize_boundary(n_points=n_points)
+        return self.discretize_boundary(n_vertices=n_vertices)
 
     def to_sky(
         self,
         wcs=None,
         include_boundary_distortions=False,
-        n_points=None,
+        n_vertices=None,
     ):
         if not include_boundary_distortions:
             raise ValueError(
@@ -874,13 +874,13 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         return self.to_pixel(
             include_boundary_distortions=include_boundary_distortions,
             wcs=wcs,
-            n_points=n_points,
+            n_vertices=n_vertices,
         ).to_sky(wcs)
 
     def to_pixel(
         self, wcs,
         include_boundary_distortions=False,
-        n_points=None,
+        n_vertices=None,
     ):
         if not include_boundary_distortions:
             raise ValueError(
@@ -891,7 +891,7 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
 
         self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
 
-        disc_kwargs = {} if n_points is None else {'n_points': n_points}
+        disc_kwargs = {} if n_vertices is None else {'n_vertices': n_vertices}
 
         # Requires spherical to planar projection (from WCS) and discretization
         disc_bound = self.discretize_boundary(**disc_kwargs)

--- a/regions/shapes/range.py
+++ b/regions/shapes/range.py
@@ -821,7 +821,7 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
 
         return self.__class__(**transformed)
 
-    def discretize_boundary(self, n_vertices=100):
+    def discretize_boundary(self, *, n_vertices=100):
         bound_nverts = self._bound_nverts
 
         if bound_nverts == 0:
@@ -830,14 +830,14 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
             return self.longitude_bounds.discretize_boundary(n_vertices=n_vertices)
         elif (bound_nverts == 4) | (bound_nverts == 3):
             bound_verts = discretize_all_edge_boundaries(
-                self.vertices, self._edge_circs, n_vertices,
+                self.vertices, self._edge_circs, n_vertices=n_vertices,
             )
             return PolygonSphericalSkyRegion(bound_verts, meta=self.meta.copy(),
                                              visual=self.visual.copy())
         elif bound_nverts == 6:
             raise NotImplementedError
 
-    def to_polygon(self, n_vertices=100):
+    def to_polygon(self, *, n_vertices=100):
         """
         Return a `~regions.PolygonSphericalSkyRegion` that approximates this
         longitude/latitude range.
@@ -856,7 +856,7 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
 
     def to_sky(
         self,
-        wcs=None,
+        wcs=None, *,
         include_boundary_distortions=False,
         n_vertices=None,
     ):
@@ -873,12 +873,11 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         # Use to_pixel(), then apply "small angle approx" to get planar sky.
         return self.to_pixel(
             include_boundary_distortions=include_boundary_distortions,
-            wcs=wcs,
-            n_vertices=n_vertices,
+            wcs=wcs, n_vertices=n_vertices,
         ).to_sky(wcs)
 
     def to_pixel(
-        self, wcs,
+        self, wcs, *,
         include_boundary_distortions=False,
         n_vertices=None,
     ):

--- a/regions/shapes/range.py
+++ b/regions/shapes/range.py
@@ -55,7 +55,8 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         Latitude range in region. Spans from first to second entries
         (in increasing latitude value), so inverting the order will select
         the complement latitude range.
-        I.e., if latitude_range[0] > latitude_range[1], will wrap over the poles,
+        I.e., if latitude_range[0] > latitude_range[1], will wrap
+        over the poles,
         and will instead exclude the central latitude range.
         Longitude values must be within [-90, 90] degrees (or equivalent).
 
@@ -74,34 +75,35 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
     _params = ('frame', 'longitude_range', 'latitude_range')
     _boundaries = ('longitude_bounds', 'latitude_bounds')
     longitude_range = TwoValAngleorNone(
-        'The range of longitude values, as a length-2 |Quantity| angle or list or as None',
+        'The range of longitude values, as a length-2 |Quantity|'
+        ' angle or list or as None',
     )
     latitude_range = TwoValAngleorNone(
-        'The range of latitude values, as a length-2 |Quantity| angle or list or as None',
+        'The range of latitude values, as a length-2 |Quantity|'
+        ' angle or list or as None',
     )
 
-    def __init__(
-        self,
-        frame=None,
-        longitude_range=None,
-        latitude_range=None,
-        meta=None,
-        visual=None,
-        **kwargs,
-    ):
-        # Validate inputs:
+    def __init__(self, frame=None, longitude_range=None, latitude_range=None,
+                 meta=None, visual=None, **kwargs):
+        # Validate inputs
         if ((longitude_range is None) & (latitude_range is None)
                 & (kwargs.get('_longitude_bounds', None) is None)
                 & (kwargs.get('_latitude_bounds', None) is None)):
-            # Non-frame transformation instantiation is only intended to be used
-            # by setting longitude_range and latitude_range, so note those in the error message
-            raise ValueError('A range for at least one of longitude and latitude must be set')
+            # Non-frame transformation instantiation is only
+            # intended to be used
+            # by setting longitude_range and latitude_range, so note those in
+            # the error message
+            raise ValueError(
+                'A range for at least one of longitude and'
+                ' latitude must be set')
 
         self.longitude_range = longitude_range
         self.latitude_range = latitude_range
 
-        # Validate lon/lat range inputs, to ensure ranges have expected definitions.
-        # Run this after setting the attribute, which performs initial validation using
+        # Validate lon/lat range inputs, to ensure ranges have
+        # expected definitions.
+        # Run this after setting the attribute, which performs
+        # initial validation using
         # TwoValAngleorNone attribute class
         self._validate_longitude_range(self.longitude_range)
         self._validate_latitude_range(self.latitude_range)
@@ -111,20 +113,19 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         self._vertices = None
         self._is_original_frame = kwargs.pop('_is_original_frame', True)
 
-        # Check if "_frame" is passed as a kwarg, from a copy:
+        # Check if "_frame" is passed as a kwarg, from a copy
         _frame = None
         if kwargs.get('_frame', 'missing') != 'missing':
             _frame = kwargs.pop('_frame', None)
 
         # Passing frame overrides any value passed in "_frame" in the kwargs,
-        # so only if "frame"=None is "_frame" used:
+        # so only if "frame"=None is "_frame" used
         if frame is None:
             frame = _frame
 
-        # Get frame into standard format instance:
+        # Get frame into standard format instance
         frame = self._standardize_frame(frame)
 
-        # --------------------
         if (
                 ((longitude_range is None)
                  & (latitude_range is None))
@@ -132,7 +133,8 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
                    | (kwargs.get('_latitude_bounds', None) is not None))
         ):
             # Create class by directly passing long/lat bounds
-            # -- for cases when creating transformed RangeSphericalSkyRegion instances
+            # -- for cases when creating transformed
+            # RangeSphericalSkyRegion instances
 
             self._longitude_bounds = kwargs.pop('_longitude_bounds', None)
             self._latitude_bounds = kwargs.pop('_latitude_bounds', None)
@@ -141,14 +143,15 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
             # original frame
             self._vertices = kwargs.pop('_vertices', None)
 
-            # Also set _params to to just ("frame") for this transformed instance.
+            # Also set _params to to just ("frame") for this transformed
+            # instance.
             self._params = ('frame',)
 
-            # Validate direct bounds, vertices inputs:
+            # Validate direct bounds, vertices inputs
             self._validate_inputs_lonlat_bounds_vertices()
 
         # Stash frame in private attribute to access when building on-the-fly
-        # derived attributes & bounds:
+        # derived attributes & bounds
         self._frame = frame
 
         self.meta = meta or RegionMeta()
@@ -157,18 +160,18 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
     def __eq__(self, other):
         # Equality operator for RangeSphericalSkyRegion.
 
-        # Modified from default, because the lon/lat ranges can be none
-        # -- requiring comparison of boundaries.
+        # Modified from default, because the lon/lat ranges can be none,
+        # requiring comparison of boundaries.
 
         # All Region properties are compared for strict equality except
         # for Quantity parameters, which allow for different units if they
         # are directly convertible.
-
         if not isinstance(other, self.__class__):
             return False
 
         meta_params = ['meta', 'visual']
-        intern_params = ['_frame', '_vertices', '_is_original_frame', '_params']
+        intern_params = ['_frame', '_vertices',
+                         '_is_original_frame', '_params']
         params_list = (
             list(self._params) + [f"_{bn}" for bn in list(self._boundaries)]
             + intern_params + meta_params
@@ -187,7 +190,8 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         return True
 
     def _validate_longitude_range(self, longitude_range):
-        # Specifying longitude_range as an TwoValAngleorNone attribute already validates
+        # Specifying longitude_range as an TwoValAngleorNone
+        # attribute already validates
         # for input as either length-2 list-like with angular units, or None
 
         # Here, only check that if not None,
@@ -196,11 +200,13 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
             for i in range(2):
                 if not ((longitude_range[i].to_value(u.deg) >= 0)
                         & (longitude_range[i].to_value(u.deg) <= 360)):
-                    raise ValueError('Longitude values must be within [0, 360] degrees or '
-                                     'equivalent!')
+                    raise ValueError(
+                        'Longitude values must be within'
+                        ' [0, 360] degrees or equivalent!')
 
     def _validate_latitude_range(self, latitude_range):
-        # Specifying latitude_range as an TwoValAngleorNone attribute already validates
+        # Specifying latitude_range as an TwoValAngleorNone
+        # attribute already validates
         # for input as either length-2 list-like with angular units, or None
 
         # Here, only check that if not None,
@@ -209,11 +215,12 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
             for i in range(2):
                 if not ((latitude_range[i].to_value(u.deg) >= -90)
                         & (latitude_range[i].to_value(u.deg) <= 90)):
-                    raise ValueError('Latitude values must be within [-90, 90] degrees or '
-                                     'equivalent!')
+                    raise ValueError(
+                        'Latitude values must be within'
+                        ' [-90, 90] degrees or equivalent!')
 
     def _validate_inputs_lonlat_bounds_vertices(self):
-        # Validate direct bounds, vertices inputs:
+        # Validate direct bounds, vertices inputs
 
         # Lon bounds can be lune or None
         if not (isinstance(self._longitude_bounds, LuneSphericalSkyRegion)
@@ -221,33 +228,40 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
             raise ValueError('Invalid direct longitude bounds input! Must be '
                              'LuneSphericalSkyRegion or None.')
 
-        # Lat bounds can be circle, annulus, compound xor of whole sky and annulus, or None
-        if not (isinstance(self._latitude_bounds, (CircleAnnulusSphericalSkyRegion,
-                                                   CircleSphericalSkyRegion))
-                | (isinstance(self._latitude_bounds, CompoundSphericalSkyRegion)
-                & isinstance(getattr(self._latitude_bounds, 'region1', None),
-                             WholeSphericalSkyRegion)
-                & isinstance(getattr(self._latitude_bounds, 'region2', None),
-                             CircleAnnulusSphericalSkyRegion)
-                & (getattr(self._latitude_bounds, 'operator', None) == operator.xor))
-                | (self._latitude_bounds is None)):
-            raise ValueError('Invalid direct latitude bounds input! Must be one of: '
-                             'CircleSphericalSkyRegion, CircleAnnulusSphericalSkyRegion, '
-                             'CompoundSphericalSkyRegion (as WholeSphericalSkyRegion '
-                             '^ CircleAnnulusSphericalSkyRegion), or None.')
+        # Lat bounds can be circle, annulus, compound xor of whole sky and
+        # annulus, or None
+        lat_bounds = self._latitude_bounds
+        valid_lat = (
+            isinstance(lat_bounds, (CircleAnnulusSphericalSkyRegion,
+                                    CircleSphericalSkyRegion))
+            | (isinstance(lat_bounds, CompoundSphericalSkyRegion)
+               & isinstance(getattr(lat_bounds, 'region1', None),
+                            WholeSphericalSkyRegion)
+               & isinstance(getattr(lat_bounds, 'region2', None),
+                            CircleAnnulusSphericalSkyRegion)
+               & (getattr(lat_bounds, 'operator', None) == operator.xor))
+            | (lat_bounds is None))
+        if not valid_lat:
+            raise ValueError('Invalid direct latitude bounds input!'
+                             ' Must be one of: CircleSphericalSkyRegion,'
+                             ' CircleAnnulusSphericalSkyRegion,'
+                             ' CompoundSphericalSkyRegion (as'
+                             ' WholeSphericalSkyRegion'
+                             ' ^ CircleAnnulusSphericalSkyRegion), or None.')
 
-        # Vertices can be Skycoord of specified length or None, depending on bounds:
+        # Vertices can be Skycoord of specified length or None, depending on
+        # bounds
         if self._bound_nverts > 0:
             if (isinstance(self._vertices, SkyCoord)
                     & (len(self._vertices) != self._bound_nverts)):
-                raise ValueError('Invalid vertices direct input! Inconsistent with bounds.')
+                raise ValueError(
+                    'Invalid vertices direct input! Inconsistent with bounds.')
         elif (self._vertices is not None) & (self._bound_nverts == 0):
-            raise ValueError('Invalid vertices direct input! Inconsistent with bounds.')
+            raise ValueError(
+                'Invalid vertices direct input! Inconsistent with bounds.')
 
-    # -------------------------------------------------------------------------------
-    # ALWAYS derive boundaries on the fly, IF all _params are not None
-    # --- only a concern for RangeSphericalSkyRegion....
-
+    # ALWAYS derive boundaries on the fly, IF all _params are not None.
+    # Only a concern for RangeSphericalSkyRegion.
     def _derive_longitude_bounds(self):
         # Internal, on-the-fly boundaries determination.
         # A concern if range values change after original _longitude_bounds
@@ -266,17 +280,18 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         else:
             c_pole = cross_product_skycoord2skycoord(c1, c2)
 
-        # GC centers from cross products:
+        # GC centers from cross products
         center_gc1 = cross_product_skycoord2skycoord(c_pole, c1)
         center_gc2 = cross_product_skycoord2skycoord(c2, c_pole)
 
         c_gc1_sph = center_gc1.represent_as('spherical')
         c_gc2_sph = center_gc2.represent_as('spherical')
 
-        # Squash small machine-rounding problems in cross product:
+        # Squash small machine-rounding problems in cross product
         # latitude should be 0 for these longitude-describing GCs,
         # as they pass through the poles.
-        # Only possible in the original frame, when defining from longitude_range
+        # Only possible in the original frame, when defining from
+        # longitude_range
 
         center_gc1 = SkyCoord(c_gc1_sph.lon, 0 * u.deg, frame=self.frame)
         center_gc2 = SkyCoord(c_gc2_sph.lon, 0 * u.deg, frame=self.frame)
@@ -294,13 +309,13 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
 
         # Define north pole: 0 lon, 90 lat
         c_pole = SkyCoord(0 * u.deg, 90 * u.deg, frame=self.frame)
-        # Define south pole:
+        # Define south pole
         c_pole_s = SkyCoord(0 * u.deg, -90 * u.deg, frame=self.frame)
 
         lat_arr = self.latitude_range.copy()
 
         # Logic if this is a "across-polar" region is handled by swapping
-        # the logic of the latitude boundary itself:
+        # the logic of the latitude boundary itself
         _wraps_poles = False
         if lat_arr[0] > lat_arr[1]:
             _wraps_poles = True
@@ -309,25 +324,25 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         inner_rad = 90.0 * u.deg - lat_arr[1]
         outer_rad = 90.0 * u.deg - lat_arr[0]
 
-        # Special handling: check if either edge of the range is -90 or 90:
+        # Special handling: check if either edge of the range is -90 or 90
         if (
             (lat_arr[1] == Angle(90 * u.deg))
             & (lat_arr[0] == Angle(-90 * u.deg))
         ):
-            # Whole sky: no constraint:
+            # Whole sky: no constraint
             return None
 
         elif lat_arr[1] == Angle(90 * u.deg):
             if _wraps_poles:
-                # Check if it wrapped pole, with input [90*u.deg, X*u.deg]:
+                # Check if it wrapped pole, with input [90*u.deg, X*u.deg]
                 # equivalent to [-90*u.deg, X*u.deg], and is a
-                # simple circle centered at S pole:
+                # simple circle centered at S pole.
                 lat_bounds = CircleSphericalSkyRegion(
                     c_pole_s, lat_arr[0] + 90.0 * u.deg,
                     self.meta, self.visual,
                 )
             else:
-                # Simple circle case:
+                # Simple circle case
                 lat_bounds = CircleSphericalSkyRegion(
                     c_pole, outer_rad, self.meta, self.visual,
                 )
@@ -336,19 +351,20 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
             if _wraps_poles:
                 # Check if it wrapped pole, with input [X*u.deg, -90*u.deg],
                 # equivalent to [X*u.deg, 90*u.deg], and is a simple circle
-                # Radius from input X*u.deg constraint is in inner_rad after swap
+                # Radius from input X*u.deg constraint is in inner_rad after
+                # swap
                 lat_bounds = CircleSphericalSkyRegion(
                     c_pole, inner_rad, self.meta, self.visual,
                 )
             else:
-                # Simple circle centered at S pole:
+                # Simple circle centered at S pole
                 lat_bounds = CircleSphericalSkyRegion(
                     c_pole_s, lat_arr[1] + 90.0 * u.deg,
                     self.meta, self.visual,
                 )
             return lat_bounds
 
-        # True annular range:
+        # True annular range
         if _wraps_poles:
             # Negate by passing as xor with whole sky
             return CompoundSphericalSkyRegion(
@@ -360,19 +376,19 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
                 operator.xor, self.meta, self.visual,
             )
 
-        # Not wrapping poles:
+        # Not wrapping poles
         return CircleAnnulusSphericalSkyRegion(
             c_pole, inner_rad, outer_rad, self.meta, self.visual,
         )
 
     @property
     def _bound_nverts(self):
-        # Number of vertices for boundary:
+        # Number of vertices for boundary
         # lat-only: 0 (annulus)
         # lon-only: 2 (lune)
         # both: 4 (range), unless one touches the pole: 3
 
-        # Only compute params once:
+        # Only compute params once
         lon_bounds = self.longitude_bounds
         lat_bounds = self.latitude_bounds
 
@@ -381,12 +397,12 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
                 nverts = 6
                 # pole-wrapping gives 2 disjoint triangles
             elif isinstance(lat_bounds, CircleAnnulusSphericalSkyRegion):
-                # 4 vertices:
+                # 4 vertices
                 nverts = 4
             elif isinstance(lat_bounds, CircleSphericalSkyRegion):
                 nverts = 3
         elif (lon_bounds is not None) & (lat_bounds is None):
-            # 2 vertices:
+            # 2 vertices
             nverts = 2
         else:
             # Only lat_bounds: 0 vertices
@@ -439,16 +455,16 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
 
         Defined as a spherical lune, or None if no longitude bound set.
         """
-        # If set, get bounds from internal attribute:
+        # If set, get bounds from internal attribute
         if getattr(self, '_longitude_bounds', None) is not None:
             return self._longitude_bounds
 
         # Otherwise, check whether range is set.
-        # If set, derive bounds on-the-fly:
+        # If set, derive bounds on-the-fly
         elif self.longitude_range is not None:
             return self._derive_longitude_bounds()
 
-        # If both are set to None, then the bounds are intended to be not set:
+        # If both are set to None, then the bounds are intended to be not set
         else:
             return None
 
@@ -460,16 +476,16 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         Defined as a spherical circular annulus, a circle (if ending at
         a pole), or None if no latitude bound set.
         """
-        # If set, get bounds from internal attribute:
+        # If set, get bounds from internal attribute
         if getattr(self, '_latitude_bounds', None) is not None:
             return self._latitude_bounds
 
         # Otherwise, check whether range is set.
-        # If set, derive bounds on-the-fly:
+        # If set, derive bounds on-the-fly
         elif self.latitude_range is not None:
             return self._derive_latitude_bounds()
 
-        # If both are set to None, then the bounds are intended to be not set:
+        # If both are set to None, then the bounds are intended to be not set
         else:
             return None
 
@@ -478,18 +494,17 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         """
         Region centroid.
 
-        If both longitude and latitude bounds are set:
+        Defined as the point equidistant from all vertices, if both
+        longitude and latitude bounds are set.
 
-        Defined as the point equidistant from all vertices.
+        However, if this point falls outside of the region (as in
+        cases very "long and narrow" ranges), the centroid is instead
+        approximated as the average of the longitude and latitudes of
+        all vertices.
 
-        However, if this point falls outside of the region
-        (as in cases very "long and narrow" ranges),
-        the centroid is instead approximated as the average
-        of the longitude and latitudes of all vertices.
-
-        If only longitude or only latitude bounds are set,
-        the centroid is taken as the centroid of that
-        boundary shape (i.e., the lune centroid or annulus center).
+        If only longitude or only latitude bounds are set, the centroid
+        is taken as the centroid of that boundary shape (i.e., the lune
+        centroid or annulus center).
         """
         return self.centroid_mindist
 
@@ -522,16 +537,16 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
                     not self.longitude_bounds.contains(centroid)
                 )
             ):
-                # If centroid not contained in range, or in subset longitude bounds:
-                # modify longitude by adding 180 deg:
+                # If centroid not contained in range, or in subset
+                # longitude bounds, modify longitude by adding 180 deg
                 centroid = SkyCoord(lon + 180 * u.deg, lat, frame=self.frame)
 
             return centroid
         elif bound_nverts == 2:
-            # Only lon bounds: just get centroid of lune:
+            # Only lon bounds; just get centroid of lune
             return self.longitude_bounds.centroid
         elif bound_nverts == 0:
-            # Only lat_bounds: just get center of annulus:
+            # Only lat_bounds: just get center of annulus
             return self.latitude_bounds.center
 
     @property
@@ -547,26 +562,28 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
             raise NotImplementedError
 
         if (bound_nverts == 4) | (bound_nverts == 3):
-            # If both lon/lat bounds:
-            # Calculate from sum of cross products of vertices with cartesian representation
-            # verts are in CW order:
-            centroid_mindist = cross_product_sum_skycoord2skycoord(self.vertices)
+            # If both lon/lat bounds, calculate from sum of cross
+            # products of vertices with cartesian representation; verts
+            # are in CW order
+            centroid_mindist = cross_product_sum_skycoord2skycoord(
+                self.vertices)
 
             if ((not self.contains(centroid_mindist))
                and (not self.latitude_bounds.contains(centroid_mindist))):
                 # If it's not contained, check if it's because it's
-                # outside the latitude range: if so, instead just use avg centroid:
+                # outside the latitude range; if so, instead just use avg
+                # centroid.
 
                 # Problem of very elongated bounds at high latitude --
-                # end up outside range. If so, fall back to average
+                # end up outside range. If so, fall back to average.
                 return self.centroid_avg
 
             return centroid_mindist
         elif bound_nverts == 2:
-            # Only lon bounds: just get centroid of lune:
+            # Only lon bounds; just get centroid of lune
             return self.longitude_bounds.centroid
         elif bound_nverts == 0:
-            # Only lat_bounds: just get center of annulus:
+            # Only lat_bounds; just get center of annulus
             return self.latitude_bounds.center
 
     @property
@@ -574,7 +591,7 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         """
         Region vertices.
 
-        The result depends on which ranges are set:
+        The result depends on which ranges are set.
 
         If both longitude and latitude ranges are set, returns 4 vertices
         (the "corners" of the composite range) as a SkyCoord.
@@ -594,8 +611,10 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
                 raise NotImplementedError
 
             if bound_nverts == 4:
-                # Both lon/lat bounds:on the fly construct from the lon/lat range attrib
-                # Longitude min is on the right, so derive CW from lower right corner.
+                # Both lon/lat bounds: on the fly construct from
+                # the lon/lat range attrib
+                # Longitude min is on the right, so derive CW from lower right
+                # corner.
 
                 # Note this is never called for transformed instances,
                 # which have vertices info stashed in _vertices.
@@ -614,8 +633,10 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
                 return SkyCoord(verts_lon, verts_lat, frame=self.frame)
 
             elif bound_nverts == 3:
-                # Both lon/lat bounds:on the fly construct from the lon/lat range attrib
-                # Longitude min is on the right, so derive CW from lower right corner.
+                # Both lon/lat bounds: on the fly construct from
+                # the lon/lat range attrib
+                # Longitude min is on the right, so derive CW
+                # from lower right corner.
                 # However, ONE of the vertices is on a pole.
 
                 # Note this is never called for transformed instances,
@@ -657,14 +678,14 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
     def bounding_circle(self):
         bound_nverts = self._bound_nverts
         if bound_nverts == 0:
-            # No vertices: only an annulus:
-            # Use the annulus bounding circle:
+            # No vertices: only an annulus
+            # Use the annulus bounding circle.
             return self.latitude_bounds.bounding_circle
         elif bound_nverts == 2:
             # Lune: get lune bounding circle
             return self.longitude_bounds.bounding_circle
         elif bound_nverts == 4:
-            # Quadrilateral: use max of seps to vertices:
+            # Quadrilateral: use max of seps to vertices
             cent = self.centroid_mindist
             seps = cent.separation(self.vertices)
             return CircleSphericalSkyRegion(center=cent, radius=np.max(seps))
@@ -675,7 +696,7 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
     def bounding_lonlat(self):
         bound_nverts = self._bound_nverts
         if bound_nverts == 0:
-            # Only an annulus: Use the annulus bounding lonlat:
+            # Only an annulus: Use the annulus bounding lonlat.
             return self.latitude_bounds.bounding_lonlat
 
         if bound_nverts == 2:
@@ -693,7 +714,8 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
             # Only validate and change if not the original frame
             # (eg, when the region could cap the pole)
             if not self._is_original_frame:
-                lons_arr, lats_arr = self._validate_lonlat_bounds(lons_arr, lats_arr)
+                lons_arr, lats_arr = self._validate_lonlat_bounds(
+                    lons_arr, lats_arr)
 
             return lons_arr, lats_arr
 
@@ -717,8 +739,10 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
                 wrap_ang = self.longitude_range[0]
                 coord_lons = c_repr.lon.wrap_at(wrap_ang)
                 in_range_lon = (
-                    (coord_lons >= Angle(self.longitude_range[0]).wrap_at(wrap_ang))
-                    & (coord_lons <= Angle(self.longitude_range[1]).wrap_at(wrap_ang))
+                    (coord_lons >= Angle(
+                        self.longitude_range[0]).wrap_at(wrap_ang))
+                    & (coord_lons <= Angle(
+                        self.longitude_range[1]).wrap_at(wrap_ang))
                 )
             # No constraints
             elif coord.isscalar:
@@ -736,7 +760,7 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
                     (self.latitude_range[1] == Angle(90 * u.deg))
                     & (self.latitude_range[0] == Angle(-90 * u.deg))
                 ):
-                    # Whole sky:
+                    # Whole sky
                     if coord.isscalar:
                         in_range_lat = True
                     else:
@@ -765,7 +789,7 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
 
             return in_range_lon & in_range_lat
 
-        # If transformed: must use boundary compound region logic:
+        # If transformed: must use boundary compound region logic
         if covers:
             return self._compound_region.covers(coord)
 
@@ -802,7 +826,7 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
             else:
                 transformed[f"_{bound}"] = bound_orig
 
-        # Also transform vertices:
+        # Also transform vertices
         for field in ['_vertices']:
             verts = copy.deepcopy(getattr(self, field))
             if (verts is None) and self._is_original_frame:
@@ -816,7 +840,7 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
             else:
                 transformed[field] = None
 
-        # Add transformed frame to transformed dict:
+        # Add transformed frame to transformed dict
         transformed['frame'] = frame
 
         return self.__class__(**transformed)
@@ -825,15 +849,18 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         bound_nverts = self._bound_nverts
 
         if bound_nverts == 0:
-            return self.latitude_bounds.discretize_boundary(n_vertices=n_vertices)
+            return self.latitude_bounds.discretize_boundary(
+                n_vertices=n_vertices)
         elif bound_nverts == 2:
-            return self.longitude_bounds.discretize_boundary(n_vertices=n_vertices)
+            return self.longitude_bounds.discretize_boundary(
+                n_vertices=n_vertices)
         elif (bound_nverts == 4) | (bound_nverts == 3):
             bound_verts = discretize_all_edge_boundaries(
                 self.vertices, self._edge_circs, n_vertices=n_vertices,
             )
-            return PolygonSphericalSkyRegion(bound_verts, meta=self.meta.copy(),
-                                             visual=self.visual.copy())
+            return PolygonSphericalSkyRegion(
+                bound_verts, meta=self.meta.copy(),
+                visual=self.visual.copy())
         elif bound_nverts == 6:
             raise NotImplementedError
 
@@ -867,7 +894,8 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
                 'including boundary distortions.',
             )
 
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+        self._validate_planar_spherical_transform(
+            wcs, include_boundary_distortions)
 
         # Requires spherical to planar projection (from WCS) and discretization
         # Use to_pixel(), then apply "small angle approx" to get planar sky.
@@ -884,17 +912,19 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         if not include_boundary_distortions:
             raise ValueError(
                 'Invalid parameter: `include_boundary_distortions=False`!\n'
-                'Transforming range to planar pixel region is only possible by '
+                'Transforming range to planar pixel region is'
+                ' only possible by '
                 'including boundary distortions.',
             )
 
-        self._validate_planar_spherical_transform(wcs, include_boundary_distortions)
+        self._validate_planar_spherical_transform(
+            wcs, include_boundary_distortions)
 
         disc_kwargs = {} if n_vertices is None else {'n_vertices': n_vertices}
 
         # Requires spherical to planar projection (from WCS) and discretization
         disc_bound = self.discretize_boundary(**disc_kwargs)
-        # Anticipating complex, wrapped over the poles case:
+        # Anticipating complex, wrapped over the poles case
         if isinstance(disc_bound, CompoundSphericalSkyRegion):
             return disc_bound.to_pixel(wcs)
 

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -130,7 +130,7 @@ class RectanglePixelRegion(PixelRegion):
                                   meta=self.meta.copy(),
                                   visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -451,6 +451,6 @@ class RectangleSkyRegion(SkyRegion):
         """
         return self.to_pixel(wcs).to_polygon().to_sky(wcs)
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -131,7 +131,7 @@ class RectanglePixelRegion(PixelRegion):
                                   visual=self.visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         raise NotImplementedError
 
     @property
@@ -452,5 +452,5 @@ class RectangleSkyRegion(SkyRegion):
         return self.to_pixel(wcs).to_polygon().to_sky(wcs)
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -274,7 +274,8 @@ class RectanglePixelRegion(PixelRegion):
         from matplotlib.widgets import RectangleSelector
 
         if hasattr(self, '_mpl_selector'):
-            raise AttributeError('Cannot attach more than one selector to a region.')
+            raise AttributeError(
+                'Cannot attach more than one selector to a region.')
 
         if self.angle.value != 0:
             raise NotImplementedError('Cannot create matplotlib selector for '

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -85,8 +85,8 @@ class TestCircleAnnulusPixelRegion(BaseTestPixelRegion):
         assert isinstance(skyannulus, CircleAnnulusSkyRegion)
 
     def test_to_spherical_sky(self, wcs):
-        sphskyann = self.reg.to_spherical_sky(wcs,
-                                              include_boundary_distortions=False)
+        sphskyann = self.reg.to_spherical_sky(
+            wcs, include_boundary_distortions=False)
         assert isinstance(sphskyann, CircleAnnulusSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
@@ -165,8 +165,8 @@ class TestCircleAnnulusSkyRegion(BaseTestSkyRegion):
         assert isinstance(pixannulus, CircleAnnulusPixelRegion)
 
     def test_to_spherical_sky(self, wcs):
-        sphskyann = self.reg.to_spherical_sky(wcs,
-                                              include_boundary_distortions=False)
+        sphskyann = self.reg.to_spherical_sky(
+            wcs, include_boundary_distortions=False)
         assert isinstance(sphskyann, CircleAnnulusSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
@@ -192,16 +192,18 @@ class TestCircleAnnulusSphericalSkyRegion(BaseTestSphericalSkyRegion):
     meta = RegionMeta({'text': 'test'})
     visual = RegionVisual({'color': 'blue'})
     reg = CircleAnnulusSphericalSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg),
-                                          20 * u.arcsec, 30 * u.arcsec, meta=meta,
-                                          visual=visual)
+                                          20 * u.arcsec, 30 * u.arcsec,
+                                          meta=meta, visual=visual)
     skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='icrs')
     wcs = make_simple_wcs(skycoord, 5 * u.arcsec, 20)
 
-    expected_repr = ('<CircleAnnulusSphericalSkyRegion(center=<SkyCoord (ICRS): '
-                     '(ra, dec) in deg\n    (3., 4.)>, inner_radius=20.0 '
+    expected_repr = ('<CircleAnnulusSphericalSkyRegion(center='
+                     '<SkyCoord (ICRS): (ra, dec) in deg\n'
+                     '    (3., 4.)>, inner_radius=20.0 '
                      'arcsec, outer_radius=30.0 arcsec)>')
-    expected_str = ('Region: CircleAnnulusSphericalSkyRegion\ncenter: <SkyCoord '
-                    '(ICRS): (ra, dec) in deg\n    (3., 4.)>\ninner_radius: '
+    expected_str = ('Region: CircleAnnulusSphericalSkyRegion\n'
+                    'center: <SkyCoord (ICRS): (ra, dec) in deg\n'
+                    '    (3., 4.)>\ninner_radius: '
                     '20.0 arcsec\nouter_radius: 30.0 arcsec')
 
     def test_init(self):
@@ -239,7 +241,8 @@ class TestCircleAnnulusSphericalSkyRegion(BaseTestSphericalSkyRegion):
         polysky = self.reg.to_sky(self.wcs, include_boundary_distortions=True)
         assert isinstance(polysky, CompoundSkyRegion)
 
-        polypix = self.reg.to_pixel(self.wcs, include_boundary_distortions=True)
+        polypix = self.reg.to_pixel(
+            self.wcs, include_boundary_distortions=True)
         assert isinstance(polypix, CompoundPixelRegion)
 
     def test_transformation_no_wcs(self):

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -111,11 +111,13 @@ def test_pix_to_sky(region):
 
 
 @pytest.mark.parametrize('region', PIXEL_REGIONS, ids=ids_func)
-@pytest.mark.parametrize('include_dist', INCLUDE_BOUNDARY_DISTORTIONS, ids=ids_func)
+@pytest.mark.parametrize('include_dist',
+                         INCLUDE_BOUNDARY_DISTORTIONS, ids=ids_func)
 def test_pix_to_spherical_sky(region, include_dist):
     # TODO: remove expected failures when implemented
     # Expected failure:
-    #    No spherical Ellipse, EllipseAnnulus, Point, Rectangle, RectangleAnnulus
+    #    No spherical Ellipse, EllipseAnnulus, Point, Rectangle,
+    #    RectangleAnnulus
     # Also expected failure:
     #    Boundary distortions not yet implemented for
     #    CirclePixelRegion, CircleAnnulusPixelRegion, PolygonPixelRegion
@@ -173,11 +175,13 @@ def test_sky_to_pix(region):
 
 
 @pytest.mark.parametrize('region', SKY_REGIONS, ids=ids_func)
-@pytest.mark.parametrize('include_dist', INCLUDE_BOUNDARY_DISTORTIONS, ids=ids_func)
+@pytest.mark.parametrize('include_dist',
+                         INCLUDE_BOUNDARY_DISTORTIONS, ids=ids_func)
 def test_sky_to_spherical_sky(region, include_dist):
     # TODO: remove expected failures when implemented
     # Expected failure:
-    #    No spherical Ellipse, EllipseAnnulus, Point, Rectangle, RectangleAnnulus
+    #    No spherical Ellipse, EllipseAnnulus, Point, Rectangle,
+    #    RectangleAnnulus
     # Also expected failure:
     #    Boundary distortions not yet implemented for
     #    CircleSkyRegion, CircleAnnulusSkyRegion, PolygonSkyRegion
@@ -208,7 +212,8 @@ def test_sky_to_spherical_sky(region, include_dist):
 
 
 @pytest.mark.parametrize('region', SPHERICAL_SKY_REGIONS, ids=ids_func)
-@pytest.mark.parametrize('include_dist', INCLUDE_BOUNDARY_DISTORTIONS, ids=ids_func)
+@pytest.mark.parametrize('include_dist',
+                         INCLUDE_BOUNDARY_DISTORTIONS, ids=ids_func)
 def test_spherical_sky_to_sky(region, include_dist):
     if isinstance(region, WholeSphericalSkyRegion):
         with pytest.raises(ValueError):
@@ -238,7 +243,8 @@ def test_spherical_sky_to_sky(region, include_dist):
 
 
 @pytest.mark.parametrize('region', SPHERICAL_SKY_REGIONS, ids=ids_func)
-@pytest.mark.parametrize('include_dist', INCLUDE_BOUNDARY_DISTORTIONS, ids=ids_func)
+@pytest.mark.parametrize('include_dist',
+                         INCLUDE_BOUNDARY_DISTORTIONS, ids=ids_func)
 def test_spherical_sky_to_pix(region, include_dist):
     if isinstance(region, WholeSphericalSkyRegion):
         with pytest.raises(ValueError):
@@ -350,7 +356,8 @@ def test_attribute_validation_spherical_sky_regions(region):
                                     3 * u.km, (10, 10),
                                     (10 * u.deg, 10 * u.deg)],
                           longitude_range=[1, [1], [1, 2], [1 * u.deg],
-                                           [3 * u.km, 5 * u.km], u.Quantity([1 * u.deg]),
+                                           [3 * u.km, 5 * u.km],
+                                           u.Quantity([1 * u.deg]),
                                            u.Quantity([3 * u.km, 5 * u.km]),
                                            Angle([1 * u.deg])])
 

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -64,8 +64,8 @@ class TestCirclePixelRegion(BaseTestPixelRegion):
         assert reg_new.visual['color'] != self.reg.visual['color']
 
     def test_to_spherical_sky(self, wcs):
-        sphskycircle = self.reg.to_spherical_sky(wcs,
-                                                 include_boundary_distortions=False)
+        sphskycircle = self.reg.to_spherical_sky(
+            wcs, include_boundary_distortions=False)
         assert isinstance(sphskycircle, CircleSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
@@ -166,8 +166,8 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
                                  skycircle2.center.data.lat)
         assert_quantity_allclose(skycircle2.radius, skycircle.radius)
 
-        sphskycircle = self.reg.to_spherical_sky(wcs,
-                                                 include_boundary_distortions=False)
+        sphskycircle = self.reg.to_spherical_sky(
+            wcs, include_boundary_distortions=False)
         assert isinstance(sphskycircle, CircleSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
@@ -210,14 +210,16 @@ class TestCircleSphericalSkyRegion(BaseTestSphericalSkyRegion):
     outside = [(3 * u.deg, 0 * u.deg)]
     meta = RegionMeta({'text': 'test'})
     visual = RegionVisual({'color': 'blue'})
-    reg = CircleSphericalSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg), 2 * u.arcsec,
-                                   meta=meta, visual=visual)
+    reg = CircleSphericalSkyRegion(
+        SkyCoord(3 * u.deg, 4 * u.deg), 2 * u.arcsec,
+        meta=meta, visual=visual)
 
-    expected_repr = ('<CircleSphericalSkyRegion(center=<SkyCoord (ICRS): (ra, dec) in '
-                     'deg\n    (3., 4.)>, radius=2.0 arcsec)>')
-    expected_str = ('Region: CircleSphericalSkyRegion\ncenter: <SkyCoord (ICRS): '
-                    '(ra, dec) in deg\n    (3., 4.)>\nradius: 2.0 '
-                    'arcsec')
+    expected_repr = ('<CircleSphericalSkyRegion(center='
+                     '<SkyCoord (ICRS): (ra, dec) in deg\n'
+                     '    (3., 4.)>, radius=2.0 arcsec)>')
+    expected_str = ('Region: CircleSphericalSkyRegion\n'
+                    'center: <SkyCoord (ICRS): (ra, dec) in deg\n'
+                    '    (3., 4.)>\nradius: 2.0 arcsec')
 
     def test_copy(self):
         reg = self.reg.copy()

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -121,19 +121,21 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         ax.imshow(data)
 
         def update_mask(reg):
-            mask[:] = reg.to_mask(mode='subpixels', subpixels=10).to_image(data.shape)
+            mask[:] = reg.to_mask(
+                mode='subpixels', subpixels=10).to_image(data.shape)
 
         # For now this will only work with unrotated ellipses. Once this
         # works with rotated ellipses, the following exception check can
         # be removed as well as the ``angle=0 * u.deg`` in the call to
         # copy() below.
         with pytest.raises(NotImplementedError,
-                           match=('Cannot create matplotlib selector for rotated ellipse.')):
+                           match=('Cannot create matplotlib selector'
+                                  ' for rotated ellipse.')):
             self.reg.as_mpl_selector(ax)
 
         region = self.reg.copy(angle=0 * u.deg)
 
-        selector = region.as_mpl_selector(ax, callback=update_mask, sync=sync)  # noqa: F841
+        selector = region.as_mpl_selector(ax, callback=update_mask, sync=sync)  # noqa: E501, F841
 
         from matplotlib.backend_bases import MouseEvent
         canvas = ax.figure.canvas
@@ -157,7 +159,8 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
             assert_allclose(region.height, 1)
             assert_quantity_allclose(region.angle, 0 * u.deg)
 
-            assert_equal(mask, region.to_mask(mode='subpixels', subpixels=10).to_image(data.shape))
+            assert_equal(mask, region.to_mask(
+                mode='subpixels', subpixels=10).to_image(data.shape))
 
         else:
 
@@ -169,7 +172,8 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
 
             assert_equal(mask, 0)
 
-        with pytest.raises(AttributeError, match=('Cannot attach more than one selector to a reg')):
+        match = 'Cannot attach more than one selector to a reg'
+        with pytest.raises(AttributeError, match=match):
             region.as_mpl_selector(ax)
 
         plt.close()
@@ -190,7 +194,8 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         ax.imshow(data)
 
         def update_mask(reg):
-            mask[:] = reg.to_mask(mode='subpixels', subpixels=10).to_image(data.shape)
+            mask[:] = reg.to_mask(
+                mode='subpixels', subpixels=10).to_image(data.shape)
 
         region = self.reg.copy(angle=0 * u.deg)
 
@@ -231,7 +236,8 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         canvas.callbacks.process(evt.name, evt)
         ax.figure.canvas.draw()
 
-        # For drag_from_anywhere=False this will have created a new 1x1 rectangle.
+        # For drag_from_anywhere=False this will have created a new 1x1
+        # rectangle.
         if anywhere:
             assert_allclose(region.center.x, 4.5)
             assert_allclose(region.center.y, 5.5)
@@ -241,7 +247,8 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
             assert_allclose(region.center.x, 4.5)
             assert_allclose(region.center.y, 5.5)
 
-        assert_equal(mask, region.to_mask(mode='subpixels', subpixels=10).to_image(data.shape))
+        assert_equal(mask, region.to_mask(
+            mode='subpixels', subpixels=10).to_image(data.shape))
 
         plt.close()
 
@@ -265,23 +272,30 @@ class TestEllipsePixelRegion(BaseTestPixelRegion):
         ax.imshow(data)
 
         def update_mask(reg):
-            mask[:] = reg.to_mask(mode='subpixels', subpixels=10).to_image(data.shape)
+            mask[:] = reg.to_mask(
+                mode='subpixels', subpixels=10).to_image(data.shape)
 
         region = self.reg.copy(angle=0 * u.deg)
         region.visual = {'color': 'red'}
 
         if 'twit' in userargs:
-            with pytest.raises(TypeError, match=(r'__init__.. got an unexpected keyword argument')):
-                selector = region.as_mpl_selector(ax, callback=update_mask, **userargs)
+            match = r'__init__.. got an unexpected keyword argument'
+            with pytest.raises(TypeError, match=match):
+                selector = region.as_mpl_selector(
+                    ax, callback=update_mask, **userargs)
         else:
-            selector = region.as_mpl_selector(ax, callback=update_mask, **userargs)
-            assert region._mpl_selector.artists[0].get_edgecolor() == (1, 0, 0, 1)
+            selector = region.as_mpl_selector(
+                ax, callback=update_mask, **userargs)
+            assert region._mpl_selector.artists[0].get_edgecolor() == (
+                1, 0, 0, 1)
 
             if 'props' in userargs:
-                assert region._mpl_selector.artists[0].get_facecolor() == (0, 0, 1, 1)
+                assert region._mpl_selector.artists[0].get_facecolor() == (
+                    0, 0, 1, 1)
                 assert region._mpl_selector.artists[0].get_linewidth() == 2
             else:
-                assert region._mpl_selector.artists[0].get_facecolor() == (0, 0, 0, 0)
+                assert region._mpl_selector.artists[0].get_facecolor() == (
+                    0, 0, 0, 0)
                 assert region._mpl_selector.artists[0].get_linewidth() == 1
 
                 for key, val in userargs.items():
@@ -444,6 +458,7 @@ class TestEllipseShapelyComparison:
 
         shp_func = {'contains': contains, 'covers': covers}[method]
         x, y = point
-        reg_result = bool(getattr(self.setup_ellipse(), method)(PixCoord(x, y)))
+        reg_result = bool(
+            getattr(self.setup_ellipse(), method)(PixCoord(x, y)))
         shp_result = bool(shp_func(self.shapely_ellipse(), Point(x, y)))
         assert reg_result == shp_result

--- a/regions/shapes/tests/test_lune.py
+++ b/regions/shapes/tests/test_lune.py
@@ -38,11 +38,14 @@ class TestLuneSphericalSkyRegion(BaseTestSphericalSkyRegion):
                                      SkyCoord(3 * u.deg, 0 * u.deg),
                                      meta=meta, visual=visual)
 
-    expected_repr = ('<LuneSphericalSkyRegion(center_gc1=<SkyCoord (ICRS): (ra, dec) in '
-                     'deg\n    (3., 0.)>, center_gc2=<SkyCoord (ICRS): (ra, dec) in deg\n'
-                     '    (178., 0.)>)>')
-    expected_str = ('Region: LuneSphericalSkyRegion\ncenter_gc1: <SkyCoord (ICRS): '
-                    '(ra, dec) in deg\n    (3., 0.)>\ncenter_gc2: <SkyCoord (ICRS): '
+    expected_repr = ('<LuneSphericalSkyRegion(center_gc1='
+                     '<SkyCoord (ICRS): (ra, dec) in deg\n'
+                     '    (3., 0.)>, center_gc2=<SkyCoord (ICRS): '
+                     '(ra, dec) in deg\n    (178., 0.)>)>')
+    expected_str = ('Region: LuneSphericalSkyRegion\n'
+                    'center_gc1: <SkyCoord (ICRS): '
+                    '(ra, dec) in deg\n    (3., 0.)>\n'
+                    'center_gc2: <SkyCoord (ICRS): '
                     '(ra, dec) in deg\n    (178., 0.)>')
 
     def test_copy(self):

--- a/regions/shapes/tests/test_lune.py
+++ b/regions/shapes/tests/test_lune.py
@@ -67,7 +67,7 @@ class TestLuneSphericalSkyRegion(BaseTestSphericalSkyRegion):
         # Test for transformations with `include_boundary_distortions=True`
         polypix = self.reg.to_pixel(wcs,
                                     include_boundary_distortions=True,
-                                    n_points=4)
+                                    n_vertices=4)
         assert isinstance(polypix, PolygonPixelRegion)
         assert len(polypix.vertices) == 4
         assert_allclose(polypix.vertices.x,
@@ -77,7 +77,7 @@ class TestLuneSphericalSkyRegion(BaseTestSphericalSkyRegion):
 
         polysky = self.reg.to_sky(wcs,
                                   include_boundary_distortions=True,
-                                  n_points=4)
+                                  n_vertices=4)
         assert isinstance(polysky, PolygonSkyRegion)
         assert len(polysky.vertices) == 4
         assert_allclose(polysky.vertices.l.deg,
@@ -145,15 +145,15 @@ class TestLuneSphericalSkyRegion(BaseTestSphericalSkyRegion):
         assert bounding_lonlat3[0] is None
 
     def test_discretize_boundary(self):
-        polylune = self.reg.discretize_boundary(n_points=100)
+        polylune = self.reg.discretize_boundary(n_vertices=100)
         assert isinstance(polylune, PolygonSphericalSkyRegion)
         assert len(polylune.vertices) == 100
 
         assert polylune.contains(self.reg.centroid)
-        polylune_inv = self.reg_inv.discretize_boundary(n_points=100)
+        polylune_inv = self.reg_inv.discretize_boundary(n_vertices=100)
         assert polylune_inv.contains(self.reg.centroid)
 
         with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.discretize_boundary(n_points=1)
-        estr = 'n_points must be greater than'
+            _ = self.reg.discretize_boundary(n_vertices=1)
+        estr = 'must be greater than'
         assert estr in str(excinfo.value)

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -74,8 +74,8 @@ class TestPolygonPixelRegion(BaseTestPixelRegion):
         assert reg_new.visual['color'] != self.reg.visual['color']
 
     def test_to_spherical_sky(self, wcs):
-        polysphsky = self.reg.to_spherical_sky(wcs,
-                                               include_boundary_distortions=False)
+        polysphsky = self.reg.to_spherical_sky(
+            wcs, include_boundary_distortions=False)
         assert isinstance(polysphsky, PolygonSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
@@ -230,8 +230,8 @@ class TestPolygonSkyRegion(BaseTestSkyRegion):
         assert_quantity_allclose(poly.vertices.data.lat,
                                  self.reg.vertices.data.lat, atol=1e-3 * u.deg)
 
-        polysphsky = self.reg.to_spherical_sky(wcs,
-                                               include_boundary_distortions=False)
+        polysphsky = self.reg.to_spherical_sky(
+            wcs, include_boundary_distortions=False)
         assert isinstance(polysphsky, PolygonSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
@@ -363,10 +363,12 @@ class TestPolygonSphericalSkyRegion(BaseTestSphericalSkyRegion):
                                              [3, 4, 4] * u.deg),
                                     meta=meta, visual=visual)
 
-    expected_repr = ('<PolygonSphericalSkyRegion(vertices=<SkyCoord (ICRS): (ra, '
-                     'dec) in deg\n    [(3., 3.), (4., 4.), (3., 4.)]>)>')
-    expected_str = ('Region: PolygonSphericalSkyRegion\nvertices: <SkyCoord (ICRS):'
-                    ' (ra, dec) in deg\n    [(3., 3.), (4., 4.), (3., 4.)]>')
+    expected_repr = ('<PolygonSphericalSkyRegion(vertices='
+                     '<SkyCoord (ICRS): (ra, dec) in deg\n'
+                     '    [(3., 3.), (4., 4.), (3., 4.)]>)>')
+    expected_str = ('Region: PolygonSphericalSkyRegion\n'
+                    'vertices: <SkyCoord (ICRS): (ra, dec) in deg\n'
+                    '    [(3., 3.), (4., 4.), (3., 4.)]>')
 
     def test_copy(self):
         reg = self.reg.copy()
@@ -415,8 +417,9 @@ class TestPolygonSphericalSkyRegion(BaseTestSphericalSkyRegion):
 
     def test_frame_transformation(self):
         reg = self.reg.transform_to('galactic')
-        assert_skycoord_allclose(reg.centroid_mindist,
-                                 self.reg.centroid_mindist.transform_to('galactic'))
+        assert_skycoord_allclose(
+            reg.centroid_mindist,
+            self.reg.centroid_mindist.transform_to('galactic'))
         assert_skycoord_allclose(reg.vertices,
                                  self.reg.vertices.transform_to('galactic'))
         assert isinstance(reg, PolygonSphericalSkyRegion)
@@ -519,7 +522,8 @@ class TestPolygonShapelyComparison:
 
         shp_func = {'contains': contains, 'covers': covers}[method]
         x, y = point
-        reg_result = bool(getattr(self.setup_polygon(), method)(PixCoord(x, y)))
+        reg_result = bool(
+            getattr(self.setup_polygon(), method)(PixCoord(x, y)))
         shp_result = bool(shp_func(self.shapely_polygon(), Point(x, y)))
         assert reg_result == shp_result
 

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -397,13 +397,13 @@ class TestPolygonSphericalSkyRegion(BaseTestSphericalSkyRegion):
 
         polysky3 = self.reg.to_sky(wcs,
                                    include_boundary_distortions=True,
-                                   n_points=10)
+                                   n_vertices=10)
         assert isinstance(polysky3, PolygonSkyRegion)
         assert len(polysky3.vertices) == 10
 
         polypix2 = self.reg.to_pixel(wcs,
                                      include_boundary_distortions=True,
-                                     n_points=10)
+                                     n_vertices=10)
         assert isinstance(polypix2, PolygonPixelRegion)
         assert len(polypix2.vertices) == 10
 
@@ -453,13 +453,13 @@ class TestPolygonSphericalSkyRegion(BaseTestSphericalSkyRegion):
                                            4.00015182 * u.deg]))
 
     def test_discretize_boundary(self):
-        poly = self.reg.discretize_boundary(n_points=100)
+        poly = self.reg.discretize_boundary(n_vertices=100)
         assert isinstance(poly, PolygonSphericalSkyRegion)
         assert len(poly.vertices) == 100
 
         with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.discretize_boundary(n_points=2)
-        estr = 'n_points must be greater than'
+            _ = self.reg.discretize_boundary(n_vertices=2)
+        estr = 'must be greater than'
         assert estr in str(excinfo.value)
 
     def test_centroid(self):

--- a/regions/shapes/tests/test_range.py
+++ b/regions/shapes/tests/test_range.py
@@ -282,7 +282,7 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
         # Test boundary distortion transformations:
         polypix2 = self.reg.to_pixel(wcs,
                                      include_boundary_distortions=True,
-                                     n_points=8)
+                                     n_vertices=8)
         assert isinstance(polypix2, PolygonPixelRegion)
         assert len(polypix2.vertices) == 8
 
@@ -299,7 +299,7 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
 
         polysky2 = self.reg.to_sky(wcs,
                                    include_boundary_distortions=True,
-                                   n_points=8)
+                                   n_vertices=8)
         assert isinstance(polysky2, PolygonSkyRegion)
         assert len(polysky2.vertices) == 8
 
@@ -324,7 +324,7 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
         with pytest.raises(NotImplementedError):
             _ = reg.to_pixel(wcs,
                              include_boundary_distortions=True,
-                             n_points=10)
+                             n_vertices=10)
 
     def test_transformation_no_wcs(self):
         with pytest.raises(ValueError) as excinfo:
@@ -486,28 +486,28 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
             _ = reg.bounding_lonlat
 
     def test_discretize_boundary(self):
-        polyrange = self.reg.discretize_boundary(n_points=100)
+        polyrange = self.reg.discretize_boundary(n_vertices=100)
         assert isinstance(polyrange, PolygonSphericalSkyRegion)
         assert len(polyrange.vertices) == 100
 
         # Longitude only
         reg2 = RangeSphericalSkyRegion(longitude_range=[0, 10] * u.deg,
                                        frame='icrs')
-        polyrange2 = reg2.discretize_boundary(n_points=100)
-        assert polyrange2 == reg2.longitude_bounds.discretize_boundary(n_points=100)
+        polyrange2 = reg2.discretize_boundary(n_vertices=100)
+        assert polyrange2 == reg2.longitude_bounds.discretize_boundary(n_vertices=100)
         assert len(polyrange2.vertices) == 100
 
         # Latitude only
         reg3 = RangeSphericalSkyRegion(latitude_range=[-4, 4] * u.deg,
                                        frame='icrs')
-        polyrange3 = reg3.discretize_boundary(n_points=100)
-        assert polyrange3 == reg3.latitude_bounds.discretize_boundary(n_points=100)
+        polyrange3 = reg3.discretize_boundary(n_vertices=100)
+        assert polyrange3 == reg3.latitude_bounds.discretize_boundary(n_vertices=100)
         assert len(polyrange3.region1.vertices) == 100
         assert len(polyrange3.region2.vertices) == 100
 
         with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.discretize_boundary(n_points=3)
-        estr = 'n_points must be greater than'
+            _ = self.reg.discretize_boundary(n_vertices=3)
+        estr = 'must be greater than'
         assert estr in str(excinfo.value)
 
     def test_discretize_over_poles(self):

--- a/regions/shapes/tests/test_range.py
+++ b/regions/shapes/tests/test_range.py
@@ -54,61 +54,73 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
 
     def test_invalid_lon_range(self):
         # Test input types:
-        for lon_range in [u.Quantity([0, 10], u.m / u.s), [0 * u.m / u.s, 30 * u.m / u.s]]:
+        for lon_range in [u.Quantity([0, 10], u.m / u.s),
+                          [0 * u.m / u.s, 30 * u.m / u.s]]:
             with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(longitude_range=lon_range, frame='icrs')
+                _ = RangeSphericalSkyRegion(
+                    longitude_range=lon_range, frame='icrs')
             estr = 'must have angular units'
             assert estr in str(excinfo.value)
 
         for lon_range in [u.Quantity([0], u.deg), Angle([2 * u.radian])]:
             with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(longitude_range=lon_range, frame='icrs')
+                _ = RangeSphericalSkyRegion(
+                    longitude_range=lon_range, frame='icrs')
             estr = 'must be length 2'
             assert estr in str(excinfo.value)
 
         for lon_range in [[0 * u.deg], [0, 10], 'string']:
             with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(longitude_range=lon_range, frame='icrs')
+                _ = RangeSphericalSkyRegion(
+                    longitude_range=lon_range, frame='icrs')
             estr = 'must be an angle of length 2'
             assert estr in str(excinfo.value)
 
         # Test valid boundary values:
         for lon_range in [[-30, 30] * u.deg, [20, 560] * u.deg]:
             with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(longitude_range=lon_range, frame='icrs')
-            estr = 'Longitude values must be within [0, 360] degrees or equivalent!'
+                _ = RangeSphericalSkyRegion(
+                    longitude_range=lon_range, frame='icrs')
+            estr = ('Longitude values must be within [0, 360] degrees'
+                    ' or equivalent!')
             assert estr in str(excinfo.value)
 
     def test_invalid_lat_range(self):
         # Test input types:
-        for lat_range in [u.Quantity([0, 10], u.m / u.s), [0 * u.m / u.s, 30 * u.m / u.s]]:
+        for lat_range in [u.Quantity([0, 10], u.m / u.s),
+                          [0 * u.m / u.s, 30 * u.m / u.s]]:
             with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(latitude_range=lat_range, frame='icrs')
+                _ = RangeSphericalSkyRegion(
+                    latitude_range=lat_range, frame='icrs')
             estr = 'must have angular units'
             assert estr in str(excinfo.value)
 
         for lat_range in [u.Quantity([0], u.deg), Angle([2 * u.radian])]:
             with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(latitude_range=lat_range, frame='icrs')
+                _ = RangeSphericalSkyRegion(
+                    latitude_range=lat_range, frame='icrs')
             estr = 'must be length 2'
             assert estr in str(excinfo.value)
 
         for lat_range in [[0 * u.deg], [0, 10], 'string']:
             with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(latitude_range=lat_range, frame='icrs')
+                _ = RangeSphericalSkyRegion(
+                    latitude_range=lat_range, frame='icrs')
             estr = 'must be an angle of length 2'
             assert estr in str(excinfo.value)
 
         # Test valid boundary values:
         for lat_range in [[-120, -30] * u.deg, [20, 100] * u.deg]:
             with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(latitude_range=lat_range, frame='icrs')
-            estr = 'Latitude values must be within [-90, 90] degrees or equivalent!'
+                _ = RangeSphericalSkyRegion(
+                    latitude_range=lat_range, frame='icrs')
+            estr = ('Latitude values must be within [-90, 90] degrees'
+                    ' or equivalent!')
             assert estr in str(excinfo.value)
 
     def test_invalid_lon_bounds_input(self):
-        invalid_bounds = CircleSphericalSkyRegion(SkyCoord(5 * u.deg, 0 * u.deg),
-                                                  0.2 * u.deg)
+        invalid_bounds = CircleSphericalSkyRegion(
+            SkyCoord(5 * u.deg, 0 * u.deg), 0.2 * u.deg)
         with pytest.raises(ValueError) as excinfo:
             _ = RangeSphericalSkyRegion(_longitude_bounds=invalid_bounds,
                                         frame='icrs')
@@ -116,8 +128,9 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
         assert estr in str(excinfo.value)
 
     def test_invalid_lat_bounds_input(self):
-        invalid_bounds = LuneSphericalSkyRegion(SkyCoord(3 * u.deg, 0 * u.deg),
-                                                SkyCoord(178 * u.deg, 0 * u.deg))
+        invalid_bounds = LuneSphericalSkyRegion(
+            SkyCoord(3 * u.deg, 0 * u.deg),
+            SkyCoord(178 * u.deg, 0 * u.deg))
         with pytest.raises(ValueError) as excinfo:
             _ = RangeSphericalSkyRegion(_latitude_bounds=invalid_bounds,
                                         frame='icrs')
@@ -363,29 +376,31 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
         assert reg2 == reg3
 
     def test_repr_str_frame_transformation(self):
-        expected_repr_transf = ('<RangeSphericalSkyRegion(\n'
-                                'frame=galactic,\n'
-                                'longitude_bounds=<LuneSphericalSkyRegion('
-                                'center_gc1=<SkyCoord (Galactic): (l, b) in deg\n'
-                                '    (206.98913108, -11.42449097)>, '
-                                'center_gc2=<SkyCoord (Galactic): (l, b) in deg\n'
-                                '    (31.62719158, 2.54468138)>)>,\n'
-                                'latitude_bounds=<CircleAnnulusSphericalSkyRegion('
-                                'center=<SkyCoord (Galactic): (l, b) in deg\n'
-                                '    (122.93192526, 27.12825241)>, '
-                                'inner_radius=86.0 deg, outer_radius=94.0 deg)>\n'
-                                ')>')
-        expected_str_transf = ('Region: RangeSphericalSkyRegion\n'
-                               'frame: galactic\n'
-                               'longitude_bounds: <LuneSphericalSkyRegion('
-                               'center_gc1=<SkyCoord (Galactic): (l, b) in deg\n'
-                               '    (206.98913108, -11.42449097)>, '
-                               'center_gc2=<SkyCoord (Galactic): (l, b) in deg\n'
-                               '    (31.62719158, 2.54468138)>)>\n'
-                               'latitude_bounds: <CircleAnnulusSphericalSkyRegion('
-                               'center=<SkyCoord (Galactic): (l, b) in deg\n'
-                               '    (122.93192526, 27.12825241)>, '
-                               'inner_radius=86.0 deg, outer_radius=94.0 deg)>')
+        expected_repr_transf = (
+            '<RangeSphericalSkyRegion(\n'
+            'frame=galactic,\n'
+            'longitude_bounds=<LuneSphericalSkyRegion('
+            'center_gc1=<SkyCoord (Galactic): (l, b) in deg\n'
+            '    (206.98913108, -11.42449097)>, '
+            'center_gc2=<SkyCoord (Galactic): (l, b) in deg\n'
+            '    (31.62719158, 2.54468138)>)>,\n'
+            'latitude_bounds=<CircleAnnulusSphericalSkyRegion('
+            'center=<SkyCoord (Galactic): (l, b) in deg\n'
+            '    (122.93192526, 27.12825241)>, '
+            'inner_radius=86.0 deg, outer_radius=94.0 deg)>\n'
+            ')>')
+        expected_str_transf = (
+            'Region: RangeSphericalSkyRegion\n'
+            'frame: galactic\n'
+            'longitude_bounds: <LuneSphericalSkyRegion('
+            'center_gc1=<SkyCoord (Galactic): (l, b) in deg\n'
+            '    (206.98913108, -11.42449097)>, '
+            'center_gc2=<SkyCoord (Galactic): (l, b) in deg\n'
+            '    (31.62719158, 2.54468138)>)>\n'
+            'latitude_bounds: <CircleAnnulusSphericalSkyRegion('
+            'center=<SkyCoord (Galactic): (l, b) in deg\n'
+            '    (122.93192526, 27.12825241)>, '
+            'inner_radius=86.0 deg, outer_radius=94.0 deg)>')
 
         reg2 = self.reg.transform_to('galactic')
 
@@ -445,8 +460,9 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
         bll_transf = reg_tr.bounding_lonlat
         assert_quantity_allclose(bll_transf[0],
                                  Longitude([92.7264313, 117.42725845] * u.deg))
-        assert_quantity_allclose(bll_transf[1],
-                                 Latitude([-66.71102705, -56.48535559] * u.deg))
+        assert_quantity_allclose(
+            bll_transf[1],
+            Latitude([-66.71102705, -56.48535559] * u.deg))
 
         # Touching poles: should return longitude bounds
         reg2 = RangeSphericalSkyRegion(longitude_range=[0, 10] * u.deg,
@@ -494,14 +510,16 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
         reg2 = RangeSphericalSkyRegion(longitude_range=[0, 10] * u.deg,
                                        frame='icrs')
         polyrange2 = reg2.discretize_boundary(n_vertices=100)
-        assert polyrange2 == reg2.longitude_bounds.discretize_boundary(n_vertices=100)
+        assert polyrange2 == reg2.longitude_bounds.discretize_boundary(
+            n_vertices=100)
         assert len(polyrange2.vertices) == 100
 
         # Latitude only
         reg3 = RangeSphericalSkyRegion(latitude_range=[-4, 4] * u.deg,
                                        frame='icrs')
         polyrange3 = reg3.discretize_boundary(n_vertices=100)
-        assert polyrange3 == reg3.latitude_bounds.discretize_boundary(n_vertices=100)
+        assert polyrange3 == reg3.latitude_bounds.discretize_boundary(
+            n_vertices=100)
         assert len(polyrange3.region1.vertices) == 100
         assert len(polyrange3.region2.vertices) == 100
 

--- a/regions/shapes/tests/test_rectangle.py
+++ b/regions/shapes/tests/test_rectangle.py
@@ -145,19 +145,20 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
         ax.imshow(data)
 
         def update_mask(reg):
-            mask[:] = reg.to_mask(mode='subpixels', subpixels=10).to_image(data.shape)
+            mask[:] = reg.to_mask(
+                mode='subpixels', subpixels=10).to_image(data.shape)
 
         # For now this will only work with unrotated rectangles. Once
         # this works with rotated rectangles, the following exception
         # check can be removed as well as the ``angle=0 * u.deg`` in the
         # call to copy() below.
-        with pytest.raises(NotImplementedError,
-                           match=('Cannot create matplotlib selector for rotated rectangle.')):
+        match = 'Cannot create matplotlib selector for rotated rectangle'
+        with pytest.raises(NotImplementedError, match=match):
             self.reg.as_mpl_selector(ax)
 
         region = self.reg.copy(angle=0 * u.deg)
 
-        selector = region.as_mpl_selector(ax, callback=update_mask, sync=sync)  # noqa: F841
+        selector = region.as_mpl_selector(ax, callback=update_mask, sync=sync)  # noqa: E501, F841
 
         from matplotlib.backend_bases import MouseEvent
         canvas = ax.figure.canvas
@@ -180,7 +181,8 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
             assert_allclose(region.height, 1)
             assert_quantity_allclose(region.angle, 0 * u.deg)
 
-            assert_equal(mask, region.to_mask(mode='subpixels', subpixels=10).to_image(data.shape))
+            assert_equal(mask, region.to_mask(
+                mode='subpixels', subpixels=10).to_image(data.shape))
 
         else:
             assert_allclose(region.center.x, 3)
@@ -191,7 +193,8 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
 
             assert_equal(mask, 0)
 
-        with pytest.raises(AttributeError, match=('Cannot attach more than one selector to a reg')):
+        match = 'Cannot attach more than one selector to a reg'
+        with pytest.raises(AttributeError, match=match):
             region.as_mpl_selector(ax)
 
         plt.close()
@@ -212,7 +215,8 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
         ax.imshow(data)
 
         def update_mask(reg):
-            mask[:] = reg.to_mask(mode='subpixels', subpixels=10).to_image(data.shape)
+            mask[:] = reg.to_mask(
+                mode='subpixels', subpixels=10).to_image(data.shape)
 
         region = self.reg.copy(angle=0 * u.deg)
 
@@ -253,7 +257,8 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
         canvas.callbacks.process(evt.name, evt)
         ax.figure.canvas.draw()
 
-        # For drag_from_anywhere=False this will have created a new 1x1 rectangle.
+        # For drag_from_anywhere=False this will have created a new 1x1
+        # rectangle.
         if anywhere:
             assert_allclose(region.center.x, 4.5)
             assert_allclose(region.center.y, 5.5)
@@ -263,7 +268,8 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
             assert_allclose(region.center.x, 4.5)
             assert_allclose(region.center.y, 5.5)
 
-        assert_equal(mask, region.to_mask(mode='subpixels', subpixels=10).to_image(data.shape))
+        assert_equal(mask, region.to_mask(
+            mode='subpixels', subpixels=10).to_image(data.shape))
 
         plt.close()
 
@@ -287,22 +293,29 @@ class TestRectanglePixelRegion(BaseTestPixelRegion):
         ax.imshow(data)
 
         def update_mask(reg):
-            mask[:] = reg.to_mask(mode='subpixels', subpixels=10).to_image(data.shape)
+            mask[:] = reg.to_mask(
+                mode='subpixels', subpixels=10).to_image(data.shape)
 
         region = self.reg.copy(angle=0 * u.deg)
 
         if 'twit' in userargs:
-            with pytest.raises(TypeError, match=(r'__init__.. got an unexpected keyword argument')):
-                selector = region.as_mpl_selector(ax, callback=update_mask, **userargs)
+            match = r'__init__.. got an unexpected keyword argument'
+            with pytest.raises(TypeError, match=match):
+                selector = region.as_mpl_selector(
+                    ax, callback=update_mask, **userargs)
         else:
-            selector = region.as_mpl_selector(ax, callback=update_mask, **userargs)
-            assert region._mpl_selector.artists[0].get_edgecolor() == (0, 0, 1, 1)
+            selector = region.as_mpl_selector(
+                ax, callback=update_mask, **userargs)
+            assert region._mpl_selector.artists[0].get_edgecolor() == (
+                0, 0, 1, 1)
 
             if 'props' in userargs:
-                assert region._mpl_selector.artists[0].get_facecolor() == (0, 0, 1, 1)
+                assert region._mpl_selector.artists[0].get_facecolor() == (
+                    0, 0, 1, 1)
                 assert region._mpl_selector.artists[0].get_linewidth() == 2
             else:
-                assert region._mpl_selector.artists[0].get_facecolor() == (0, 0, 0, 0)
+                assert region._mpl_selector.artists[0].get_facecolor() == (
+                    0, 0, 0, 0)
                 assert region._mpl_selector.artists[0].get_linewidth() == 1
 
                 for key, val in userargs.items():

--- a/regions/shapes/tests/test_to_polygon.py
+++ b/regions/shapes/tests/test_to_polygon.py
@@ -40,8 +40,8 @@ class TestCirclePixelRegionToPolygon:
         poly = self.reg.to_polygon()
         assert len(poly.vertices.x) == 100
 
-    def test_to_polygon_n_points(self):
-        poly = self.reg.to_polygon(n_points=50)
+    def test_to_polygon_n_vertices(self):
+        poly = self.reg.to_polygon(n_vertices=50)
         assert len(poly.vertices.x) == 50
 
     def test_to_polygon_meta(self):
@@ -55,13 +55,13 @@ class TestCirclePixelRegionToPolygon:
         assert poly.visual['color'] != self.visual['color']
 
     def test_to_polygon_vertices(self):
-        poly = self.reg.to_polygon(n_points=4)
+        poly = self.reg.to_polygon(n_vertices=4)
         # theta = [0, pi/2, pi, 3*pi/2]
         assert_allclose(poly.vertices.x, [5, 3, 1, 3], atol=1e-10)
         assert_allclose(poly.vertices.y, [4, 6, 4, 2], atol=1e-10)
 
     def test_to_polygon_area(self):
-        poly = self.reg.to_polygon(n_points=1000)
+        poly = self.reg.to_polygon(n_vertices=1000)
         assert_allclose(poly.area, self.reg.area, rtol=1e-4)
 
     def test_to_polygon_contains(self):
@@ -85,8 +85,8 @@ class TestCircleSkyRegionToPolygon:
         poly = self.reg.to_polygon(self.wcs)
         assert len(poly.vertices.ra) == 100
 
-    def test_to_polygon_n_points(self):
-        poly = self.reg.to_polygon(self.wcs, n_points=50)
+    def test_to_polygon_n_vertices(self):
+        poly = self.reg.to_polygon(self.wcs, n_vertices=50)
         assert len(poly.vertices.ra) == 50
 
 
@@ -105,8 +105,8 @@ class TestCircleSphericalSkyRegionToPolygon:
         poly = self.reg.to_polygon()
         assert len(poly.vertices.ra) == 100
 
-    def test_to_polygon_n_points(self):
-        poly = self.reg.to_polygon(n_points=50)
+    def test_to_polygon_n_vertices(self):
+        poly = self.reg.to_polygon(n_vertices=50)
         assert len(poly.vertices.ra) == 50
 
     def test_to_polygon_meta(self):
@@ -136,8 +136,8 @@ class TestEllipsePixelRegionToPolygon:
         poly = self.reg.to_polygon()
         assert len(poly.vertices.x) == 100
 
-    def test_to_polygon_n_points(self):
-        poly = self.reg.to_polygon(n_points=50)
+    def test_to_polygon_n_vertices(self):
+        poly = self.reg.to_polygon(n_vertices=50)
         assert len(poly.vertices.x) == 50
 
     def test_to_polygon_meta(self):
@@ -150,7 +150,7 @@ class TestEllipsePixelRegionToPolygon:
         assert poly.visual['color'] != self.visual['color']
 
     def test_to_polygon_vertices_no_rotation(self):
-        poly = self.reg.to_polygon(n_points=4)
+        poly = self.reg.to_polygon(n_vertices=4)
         # Ellipse: width=6, height=4, center=(3,4), angle=0
         # theta = [0, pi/2, pi, 3*pi/2]
         # x = 0.5*6*cos(theta) + 3 = [6, 3, 0, 3]
@@ -161,13 +161,13 @@ class TestEllipsePixelRegionToPolygon:
     def test_to_polygon_vertices_rotated(self):
         reg = EllipsePixelRegion(PixCoord(0, 0), width=4, height=2,
                                  angle=90 * u.deg)
-        poly = reg.to_polygon(n_points=4)
+        poly = reg.to_polygon(n_vertices=4)
         # After 90 deg rotation, width along y and height along x
         assert_allclose(poly.vertices.x, [0, -1, 0, 1], atol=1e-10)
         assert_allclose(poly.vertices.y, [2, 0, -2, 0], atol=1e-10)
 
     def test_to_polygon_area(self):
-        poly = self.reg.to_polygon(n_points=1000)
+        poly = self.reg.to_polygon(n_vertices=1000)
         assert_allclose(poly.area, self.reg.area, rtol=1e-4)
 
     def test_to_polygon_contains(self):
@@ -192,8 +192,8 @@ class TestEllipseSkyRegionToPolygon:
         poly = self.reg.to_polygon(self.wcs)
         assert len(poly.vertices.ra) == 100
 
-    def test_to_polygon_n_points(self):
-        poly = self.reg.to_polygon(self.wcs, n_points=50)
+    def test_to_polygon_n_vertices(self):
+        poly = self.reg.to_polygon(self.wcs, n_vertices=50)
         assert len(poly.vertices.ra) == 50
 
 
@@ -218,8 +218,8 @@ class TestLuneSphericalSkyRegionToPolygon:
         poly = self.reg.to_polygon()
         assert len(poly.vertices.ra) == 100
 
-    def test_to_polygon_n_points(self):
-        poly = self.reg.to_polygon(n_points=50)
+    def test_to_polygon_n_vertices(self):
+        poly = self.reg.to_polygon(n_vertices=50)
         assert len(poly.vertices.ra) == 50
 
     def test_to_polygon_meta(self):
@@ -234,7 +234,7 @@ class TestLuneSphericalSkyRegionToPolygon:
         # Point far away should be outside
         assert not poly.contains(SkyCoord(75 * u.deg, 0 * u.deg))
 
-        polylune_inv = self.reg_inv.discretize_boundary(n_points=100)
+        polylune_inv = self.reg_inv.discretize_boundary(n_vertices=100)
         # Inside point
         assert polylune_inv.contains(SkyCoord(90 * u.deg, 0 * u.deg))
         # Point far away should be outside
@@ -341,8 +341,8 @@ class TestRangeSphericalSkyRegionToPolygon:
         poly = self.reg.to_polygon()
         assert len(poly.vertices.ra) == 100
 
-    def test_to_polygon_n_points(self):
-        poly = self.reg.to_polygon(n_points=50)
+    def test_to_polygon_n_vertices(self):
+        poly = self.reg.to_polygon(n_vertices=50)
         assert len(poly.vertices.ra) == 50
 
     def test_to_polygon_meta(self):
@@ -375,8 +375,8 @@ class TestCircleAnnulusPixelRegionToPolygon:
         assert len(poly.region1.vertices.x) == 100
         assert len(poly.region2.vertices.x) == 100
 
-    def test_to_polygon_n_points(self):
-        poly = self.reg.to_polygon(n_points=50)
+    def test_to_polygon_n_vertices(self):
+        poly = self.reg.to_polygon(n_vertices=50)
         assert len(poly.region1.vertices.x) == 50
         assert len(poly.region2.vertices.x) == 50
 
@@ -407,8 +407,8 @@ class TestCircleAnnulusSkyRegionToPolygon:
         poly = self.reg.to_polygon(self.wcs)
         assert isinstance(poly, CompoundSkyRegion)
 
-    def test_to_polygon_n_points(self):
-        poly = self.reg.to_polygon(self.wcs, n_points=50)
+    def test_to_polygon_n_vertices(self):
+        poly = self.reg.to_polygon(self.wcs, n_vertices=50)
         assert isinstance(poly, CompoundSkyRegion)
 
 
@@ -430,8 +430,8 @@ class TestCircleAnnulusSphericalSkyRegionToPolygon:
         assert len(poly.region1.vertices.ra) == 100
         assert len(poly.region2.vertices.ra) == 100
 
-    def test_to_polygon_n_points(self):
-        poly = self.reg.to_polygon(n_points=50)
+    def test_to_polygon_n_vertices(self):
+        poly = self.reg.to_polygon(n_vertices=50)
         assert len(poly.region1.vertices.ra) == 50
         assert len(poly.region2.vertices.ra) == 50
 
@@ -468,8 +468,8 @@ class TestEllipseAnnulusPixelRegionToPolygon:
         assert len(poly.region1.vertices.x) == 100
         assert len(poly.region2.vertices.x) == 100
 
-    def test_to_polygon_n_points(self):
-        poly = self.reg.to_polygon(n_points=50)
+    def test_to_polygon_n_vertices(self):
+        poly = self.reg.to_polygon(n_vertices=50)
         assert len(poly.region1.vertices.x) == 50
         assert len(poly.region2.vertices.x) == 50
 
@@ -499,8 +499,8 @@ class TestEllipseAnnulusSkyRegionToPolygon:
         poly = self.reg.to_polygon(self.wcs)
         assert isinstance(poly, CompoundSkyRegion)
 
-    def test_to_polygon_n_points(self):
-        poly = self.reg.to_polygon(self.wcs, n_points=50)
+    def test_to_polygon_n_vertices(self):
+        poly = self.reg.to_polygon(self.wcs, n_vertices=50)
         assert isinstance(poly, CompoundSkyRegion)
 
 

--- a/regions/shapes/tests/test_to_polygon.py
+++ b/regions/shapes/tests/test_to_polygon.py
@@ -94,8 +94,9 @@ class TestCircleSphericalSkyRegionToPolygon:
     meta = RegionMeta({'text': 'test'})
     visual = RegionVisual({'color': 'blue'})
 
-    reg = CircleSphericalSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg), 2 * u.arcsec,
-                                   meta=meta, visual=visual)
+    reg = CircleSphericalSkyRegion(
+        SkyCoord(3 * u.deg, 4 * u.deg), 2 * u.arcsec,
+        meta=meta, visual=visual)
 
     def test_to_polygon_type(self):
         poly = self.reg.to_polygon()
@@ -416,8 +417,8 @@ class TestCircleAnnulusSphericalSkyRegionToPolygon:
     meta = RegionMeta({'text': 'test'})
     visual = RegionVisual({'color': 'blue'})
     reg = CircleAnnulusSphericalSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg),
-                                          20 * u.arcsec, 30 * u.arcsec, meta=meta,
-                                          visual=visual)
+                                          20 * u.arcsec, 30 * u.arcsec,
+                                          meta=meta, visual=visual)
 
     def test_to_polygon_type(self):
         poly = self.reg.to_polygon()

--- a/regions/shapes/tests/test_whole_sky.py
+++ b/regions/shapes/tests/test_whole_sky.py
@@ -55,7 +55,7 @@ class TestWholeSphericalSkyRegion(BaseTestSphericalSkyRegion):
 
     def test_discretize_boundary(self):
         with pytest.raises(ValueError):
-            _ = self.reg.discretize_boundary(n_points=100)
+            _ = self.reg.discretize_boundary(n_vertices=100)
 
     def test_eq(self):
         reg = self.reg.copy()

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -87,7 +87,7 @@ class TextPixelRegion(PointPixelRegion):
         return TextSkyRegion(center, self.text, meta=self.meta.copy(),
                              visual=visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -168,6 +168,6 @@ class TextSkyRegion(PointSkyRegion):
                                meta=self.meta.copy(),
                                visual=visual.copy())
 
-    def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -88,7 +88,7 @@ class TextPixelRegion(PointPixelRegion):
                              visual=visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         raise NotImplementedError
 
     def as_artist(self, origin=(0, 0), **kwargs):
@@ -169,5 +169,5 @@ class TextSkyRegion(PointSkyRegion):
                                visual=visual.copy())
 
     def to_spherical_sky(self, wcs=None, include_boundary_distortions=False,
-                         n_points=None):
+                         n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/whole_sky.py
+++ b/regions/shapes/whole_sky.py
@@ -55,13 +55,13 @@ class WholeSphericalSkyRegion(SphericalSkyRegion):
     def transform_to(self, frame, merge_attributes=True):
         return self.__class__()
 
-    def discretize_boundary(self, n_vertices=100):
+    def discretize_boundary(self, *, n_vertices=100):
         # Not defined
         raise ValueError('Not defined.')
 
     def to_sky(
         self,
-        wcs=None,
+        wcs=None, *,
         include_boundary_distortions=False,
         n_vertices=None,
     ):
@@ -69,7 +69,7 @@ class WholeSphericalSkyRegion(SphericalSkyRegion):
         raise ValueError('Not defined.')
 
     def to_pixel(
-        self, wcs,
+        self, wcs, *,
         include_boundary_distortions=False,
         n_vertices=None,
     ):

--- a/regions/shapes/whole_sky.py
+++ b/regions/shapes/whole_sky.py
@@ -55,7 +55,7 @@ class WholeSphericalSkyRegion(SphericalSkyRegion):
     def transform_to(self, frame, merge_attributes=True):
         return self.__class__()
 
-    def discretize_boundary(self, n_points=100):
+    def discretize_boundary(self, n_vertices=100):
         # Not defined
         raise ValueError('Not defined.')
 
@@ -63,7 +63,7 @@ class WholeSphericalSkyRegion(SphericalSkyRegion):
         self,
         wcs=None,
         include_boundary_distortions=False,
-        n_points=None,
+        n_vertices=None,
     ):
         # Not defined
         raise ValueError('Not defined.')
@@ -71,7 +71,7 @@ class WholeSphericalSkyRegion(SphericalSkyRegion):
     def to_pixel(
         self, wcs,
         include_boundary_distortions=False,
-        n_points=None,
+        n_vertices=None,
     ):
         # Not defined
         raise ValueError('Not defined.')

--- a/regions/shapes/whole_sky.py
+++ b/regions/shapes/whole_sky.py
@@ -56,22 +56,12 @@ class WholeSphericalSkyRegion(SphericalSkyRegion):
         return self.__class__()
 
     def discretize_boundary(self, *, n_vertices=100):
-        # Not defined
         raise ValueError('Not defined.')
 
-    def to_sky(
-        self,
-        wcs=None, *,
-        include_boundary_distortions=False,
-        n_vertices=None,
-    ):
-        # Not defined
+    def to_sky(self, wcs=None, *, include_boundary_distortions=False,
+               n_vertices=None):
         raise ValueError('Not defined.')
 
-    def to_pixel(
-        self, wcs, *,
-        include_boundary_distortions=False,
-        n_vertices=None,
-    ):
-        # Not defined
+    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+                 n_vertices=None):
         raise ValueError('Not defined.')

--- a/tox.ini
+++ b/tox.ini
@@ -112,7 +112,7 @@ skip_install = true
 changedir = .
 description = check code style with flake8
 deps = flake8
-commands = flake8 regions --count --max-line-length=100
+commands = flake8 regions --count --max-line-length=79
 
 [testenv:pep517]
 skip_install = true


### PR DESCRIPTION
This PR:

* Renames `to_polygon` `n_points` to `n_vertices` (for consistency with `photutils` and polygons)
* Makes `n_vertices`, and `include_boundary_distortions` keyword-only arguments
* Adds 79 character line length/lint fixes