### PR TITLE
Fix required WCS keyword

### DIFF
--- a/docs/getting_started/overview.rst
+++ b/docs/getting_started/overview.rst
@@ -327,7 +327,7 @@ spherical circle falling outside of the planar circle and vice versa.
         center=SkyCoord(50, 45, unit='deg', frame='galactic'),
         radius=Angle('30 deg'))
     # Note: circle is equivalent to transforming from sph_circle
-    # with sph_circle.to_sky(wcs, include_boundary_distortions=False)
+    # with sph_circle.to_sky(wcs=wcs, include_boundary_distortions=False)
 
     # Define transformed-to pixel regions
     pix_circ_distort = sph_circle.to_pixel(wcs=wcs,

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -98,7 +98,7 @@ class CompoundPixelRegion(PixelRegion):
                                  region2=skyreg2, meta=self.meta.copy(),
                                  visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
                          n_vertices=None):
         sphreg1 = self.region1.to_spherical_sky(
             wcs=wcs,
@@ -276,7 +276,7 @@ class CompoundSkyRegion(SkyRegion):
                                    region2=pixreg2, meta=self.meta.copy(),
                                    visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
                          n_vertices=None):
         sphreg1 = self.region1.to_spherical_sky(
             wcs=wcs,
@@ -478,7 +478,7 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
             visual=self.visual.copy(),
         )
 
-    def to_sky(self, wcs=None, include_boundary_distortions=False, *,
+    def to_sky(self, *, wcs=None, include_boundary_distortions=False,
                n_vertices=None):
         planarreg1 = self.region1.to_sky(
             wcs=wcs,

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -532,7 +532,7 @@ class PixelRegion(Region):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
                          n_vertices=None):
         """
         Convert to an equivalent spherical `~regions.SphericalSkyRegion`
@@ -540,12 +540,9 @@ class PixelRegion(Region):
 
         Parameters
         ----------
-        wcs : `~astropy.wcs.WCS` instance, optional
+        wcs : `~astropy.wcs.WCS` instance
             The world coordinate system transformation to use to convert
-            between sky and pixel coordinates. Required if transforming
-            with boundary distortions (if
-            ``include_boundary_distortions`` is True).
-            Ignored if boundary distortions not included.
+            between pixel and sky coordinates.
 
         include_boundary_distortions : bool, optional
             If True, accounts for boundary distortions in spherical to planar
@@ -830,7 +827,7 @@ class SkyRegion(Region):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
                          n_vertices=None):
         """
         Convert to an equivalent spherical `~regions.SphericalSkyRegion`
@@ -1102,7 +1099,7 @@ class SphericalSkyRegion(Region):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def to_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_sky(self, *, wcs=None, include_boundary_distortions=False,
                n_vertices=None):
         """
         Convert to a planar `~regions.SkyRegion`.

--- a/regions/core/tests/test_compound.py
+++ b/regions/core/tests/test_compound.py
@@ -186,7 +186,7 @@ def test_compound_sky():
     compound = CompoundSkyRegion(c1, c2, operator.and_, meta=meta)
     assert compound.meta['test_meta']
 
-    union_to_sphsky = union.to_spherical_sky(wcs)
+    union_to_sphsky = union.to_spherical_sky(wcs=wcs)
     assert isinstance(union_to_sphsky, CompoundSphericalSkyRegion)
 
     union_to_pixel = union.to_pixel(wcs)
@@ -236,7 +236,7 @@ def test_compound_spherical_sky(wcs):
     assert (diff.contains(coords) == [True, True, False, True]).all()
     assert 'Compound' in str(union)
 
-    union_to_sky = union.to_sky(wcs)
+    union_to_sky = union.to_sky(wcs=wcs)
     assert isinstance(union_to_sky, CompoundSkyRegion)
 
     union_to_pixel = union.to_pixel(wcs)

--- a/regions/io/crtf/tests/test_crtf.py
+++ b/regions/io/crtf/tests/test_crtf.py
@@ -3,6 +3,8 @@
 Tests for the crtf subpackage.
 """
 
+import re
+
 import astropy.units as u
 import pytest
 from astropy.coordinates import Angle, SkyCoord
@@ -37,10 +39,9 @@ def test_valid_crtf_line():
     """
     line_str = 'coord=B1950_VLA, frame=BARY, corr=[I, Q], color=blue'
 
-    with pytest.raises(CRTFRegionParserError) as excinfo:
+    match = 'Not a valid CRTF line:'
+    with pytest.raises(CRTFRegionParserError, match=match):
         Regions.parse(line_str, format='crtf')
-
-    assert 'Not a valid CRTF line:' in str(excinfo.value)
 
 
 def test_valid_region_type():
@@ -49,10 +50,9 @@ def test_valid_region_type():
     """
     reg_str = 'hyperbola[[18h12m24s, -23d11m00s], 2.3arcsec]'
 
-    with pytest.raises(CRTFRegionParserError) as excinfo:
+    match = 'Not a valid CRTF Region type: "hyperbola"'
+    with pytest.raises(CRTFRegionParserError, match=match):
         Regions.parse(reg_str, format='crtf')
-
-    assert 'Not a valid CRTF Region type: "hyperbola"' in str(excinfo.value)
 
 
 def test_valid_global_meta_key():
@@ -61,9 +61,9 @@ def test_valid_global_meta_key():
     """
     global_test_str = ('global label=B1950_VLA, frame=BARY, corr=[I, Q], '
                        'color=blue')
-    with pytest.raises(CRTFRegionParserError) as excinfo:
+    match = '"label" is not a valid global meta key'
+    with pytest.raises(CRTFRegionParserError, match=match):
         Regions.parse(global_test_str, format='crtf')
-    assert '"label" is not a valid global meta key' in str(excinfo.value)
 
 
 def test_valid_meta_key():
@@ -72,9 +72,9 @@ def test_valid_meta_key():
     """
     meta_test_str = ('annulus[[17h51m03.2s, -45d17m50s], [0.10deg, 4.12deg]], '
                      'hello="My label here"')
-    with pytest.raises(CRTFRegionParserError) as excinfo:
+    match = '"hello" is not a valid meta key'
+    with pytest.raises(CRTFRegionParserError, match=match):
         Regions.parse(meta_test_str, format='crtf')
-    assert '"hello" is not a valid meta key' in str(excinfo.value)
 
 
 def test_valid_region_syntax():
@@ -82,36 +82,32 @@ def test_valid_region_syntax():
     Checks whether the region has valid parameters.
     """
     reg_str1 = 'circle[[18h12m24s, -23d11m00s], [2.3arcsec,4.5arcsec]'
-    with pytest.raises(CRTFRegionParserError) as excinfo:
+    match = re.escape("Not in proper format: ('2.3arcsec', '4.5arcsec') "
+                      'should be a single length')
+    with pytest.raises(CRTFRegionParserError, match=match):
         Regions.parse(reg_str1, format='crtf')
-
-    estr = ("Not in proper format: ('2.3arcsec', '4.5arcsec') should be "
-            'a single length')
-    assert estr in str(excinfo.value)
 
     reg_str2 = ('symbol[[32.1423deg, 12.1412deg], 12deg], linewidth=2, '
                 'coord=J2000, symsize=2')
-    with pytest.raises(CRTFRegionParserError) as excinfo:
+    match = 'Not in proper format: "12deg" should be a symbol'
+    with pytest.raises(CRTFRegionParserError, match=match):
         Regions.parse(reg_str2, format='crtf')
-    estr = 'Not in proper format: "12deg" should be a symbol'
-    assert estr in str(excinfo.value)
 
     reg_str3 = 'circle[[18h12m24s, -23d11m00s]'
-    with pytest.raises(CRTFRegionParserError) as excinfo:
+    match = ('Does not contain expected number of parameters for the region '
+             '"circle"')
+    with pytest.raises(CRTFRegionParserError, match=match):
         Regions.parse(reg_str3, format='crtf')
-    estr = ('Does not contain expected number of parameters for the region '
-            '"circle"')
-    assert estr in str(excinfo.value)
 
     reg_str4 = 'poly[[1, 2], [4, 5]]'
-    with pytest.raises(CRTFRegionParserError) as excinfo:
+    match = 'polygon should have >= 3 coordinates'
+    with pytest.raises(CRTFRegionParserError, match=match):
         Regions.parse(reg_str4, format='crtf')
-    assert 'polygon should have >= 3 coordinates' in str(excinfo.value)
 
     reg_str6 = 'rotbox[[12h01m34.1s, 12d23m33s], [3arcmin,], 12deg]'
-    with pytest.raises(CRTFRegionParserError) as excinfo:
+    match = re.escape("('3arcmin', '') should be a pair of lengths")
+    with pytest.raises(CRTFRegionParserError, match=match):
         Regions.parse(reg_str6, format='crtf')
-    assert "('3arcmin', '') should be a pair of lengths" in str(excinfo.value)
 
 
 def test_issue_312_regression():

--- a/regions/io/crtf/tests/test_io_core.py
+++ b/regions/io/crtf/tests/test_io_core.py
@@ -39,17 +39,14 @@ def test_valid_shape():
 
     shape = _CRTFParser(reg_str).shapes[0]
 
-    with pytest.raises(ValueError) as excinfo:
+    match = '"box" is not a valid region type'
+    with pytest.raises(ValueError, match=match):
         shape.region_type = 'box'
 
-    assert '"box" is not a valid region type' in str(excinfo.value)
-
     shape = _CRTFParser(reg_str).shapes[0]
-    with pytest.raises(ValueError) as excinfo:
+    match = '"hello" is not a valid coordinate reference frame'
+    with pytest.raises(ValueError, match=match):
         shape.coordsys = 'hello'
-
-    estr = '"hello" is not a valid coordinate reference frame'
-    assert estr in str(excinfo.value)
 
 
 def test_valid_ellipse_crtf():

--- a/regions/io/ds9/tests/test_ds9.py
+++ b/regions/io/ds9/tests/test_ds9.py
@@ -139,10 +139,9 @@ def test_invalid_region_warns():
     ds9_str = ('# Region file format: DS9 astropy/regions\nfk5\n'
                'circle(42.0000,43.0000,3.0000)\ninvalidregion(blah)')
 
-    with pytest.warns(AstropyUserWarning) as warn_results:
-        regions = Regions.parse(ds9_str, format='ds9')
-    assert len(regions) == 1
-    assert len(warn_results) == 1
+    match = 'frame or shape is not a valid frame or region shape'
+    with pytest.warns(AstropyUserWarning, match=match):
+        Regions.parse(ds9_str, format='ds9')
 
 
 def test_global_parser():
@@ -563,7 +562,8 @@ def test_invalid_metadata():
               'image; circle(202.4,47.2,10.9) # color=blue point=junk 10\n'
               'image; circle(302.4,147.2,10.9) # color=cyan point=invalid\n')
 
-    with pytest.warns(AstropyUserWarning) as record:
+    match = 'is invalid and will be ignored'
+    with pytest.warns(AstropyUserWarning, match=match) as record:
         regs = Regions.parse(regstr, format='ds9')
         assert len(record) == 12
         assert 'source=1.1' in record[0].message.args[0]
@@ -579,10 +579,9 @@ def test_invalid_metadata():
 def test_unsupported_metadata():
     regstr = ('image; point(335.5,415.6) # point=diamond 11 color=yellow '
               'width=2 text={example} dash=1 tag={Tag 1} tag={Tag 2}')
-    with pytest.warns(UserWarning) as record:
+    match = 'dashed lines are unsupported'
+    with pytest.warns(AstropyUserWarning, match=match):
         Regions.parse(regstr, format='ds9')
-        assert len(record) == 1
-        assert 'dashed lines are unsupported' in record[0].message.args[0]
 
 
 def test_text_metadata():
@@ -621,12 +620,13 @@ def test_unsupported_marker():
     marker, but unsupported by DS9.
     """
     region = PointPixelRegion(PixCoord(2, 2), visual=RegionVisual(marker='Z'))
-    with pytest.warns(AstropyUserWarning):
+    match = 'Unable to serialize marker'
+    with pytest.warns(AstropyUserWarning, match=match):
         region.serialize(format='ds9')
 
     region = PointPixelRegion(PixCoord(2, 2),
                               visual=RegionVisual(marker='$f_{init}$'))
-    with pytest.warns(AstropyUserWarning):
+    with pytest.warns(AstropyUserWarning, match=match):
         region.serialize(format='ds9')
 
 

--- a/regions/io/fits/tests/test_fits.py
+++ b/regions/io/fits/tests/test_fits.py
@@ -59,10 +59,9 @@ def test_only_pixel_regions():
 
 def test_valid_columns():
     t = QTable([[1, 2, 3]], names=('a'))
-    with pytest.raises(FITSParserError) as excinfo:
+    match = "'a' is not a valid column name"
+    with pytest.raises(FITSParserError, match=match):
         Regions.parse(t, format='fits')
-        estr = "'a' is not a valid column name"
-        assert estr in str(excinfo.value)
 
 
 def test_invalid_regions():
@@ -91,10 +90,9 @@ def test_valid_row():
     # test invalid shape
     shapes = ['INVALID']
     tbl2 = QTable([x, y, shapes], names=('X', 'Y', 'SHAPE'))
-    with pytest.raises(FITSParserError) as excinfo:
+    match = "'invalid' is not a valid FITS region shape"
+    with pytest.raises(FITSParserError, match=match):
         Regions.parse(tbl2, format='fits')
-        estr = "'invalid' is not a valid FITS region shape"
-        assert estr in str(excinfo.value)
 
     shapes = ['PIE']
     rotang = [[20, 30]] * u.deg

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -278,7 +278,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
                                    operator.xor, self.meta.copy(),
                                    self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(
             wcs, include_boundary_distortions)
@@ -412,7 +412,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
         """
         return self.to_pixel(wcs).to_polygon(n_vertices=n_vertices).to_sky(wcs)
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(
             wcs, include_boundary_distortions)
@@ -536,7 +536,7 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
         """
         return self.discretize_boundary(n_vertices=n_vertices)
 
-    def to_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_sky(self, *, wcs=None, include_boundary_distortions=False,
                n_vertices=None):
         self._validate_planar_spherical_transform(
             wcs, include_boundary_distortions)
@@ -864,7 +864,7 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
                                        meta=self.meta.copy(),
                                        visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -948,7 +948,7 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
                                          meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -1067,7 +1067,7 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
                                          meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -1166,6 +1166,6 @@ class RectangleAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
                                            meta=self.meta.copy(),
                                            visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -145,7 +145,7 @@ class CirclePixelRegion(PixelRegion):
         return CircleSkyRegion(center, radius, meta=self.meta.copy(),
                                visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(wcs,
                                                   include_boundary_distortions)
@@ -369,7 +369,7 @@ class CircleSkyRegion(SkyRegion):
         """
         return self.to_pixel(wcs).to_polygon(n_vertices=n_vertices).to_sky(wcs)
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(wcs,
                                                   include_boundary_distortions)
@@ -495,7 +495,7 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
         """
         return self.discretize_boundary(n_vertices=n_vertices)
 
-    def to_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_sky(self, *, wcs=None, include_boundary_distortions=False,
                n_vertices=None):
         self._validate_planar_spherical_transform(wcs,
                                                   include_boundary_distortions)

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -130,7 +130,7 @@ class EllipsePixelRegion(PixelRegion):
                                 meta=self.meta.copy(),
                                 visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -438,6 +438,6 @@ class EllipseSkyRegion(SkyRegion):
         """
         return self.to_pixel(wcs).to_polygon(n_vertices=n_vertices).to_sky(wcs)
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -85,7 +85,7 @@ class LinePixelRegion(PixelRegion):
         return LineSkyRegion(start, end, meta=self.meta.copy(),
                              visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -201,6 +201,6 @@ class LineSkyRegion(SkyRegion):
         return LinePixelRegion(start, end, meta=self.meta.copy(),
                                visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/lune.py
+++ b/regions/shapes/lune.py
@@ -202,7 +202,7 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
         """
         return self.discretize_boundary(n_vertices=n_vertices)
 
-    def to_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_sky(self, wcs, *, include_boundary_distortions=False,
                n_vertices=None):
         if not include_boundary_distortions:
             raise ValueError(

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -89,7 +89,7 @@ class PointPixelRegion(PixelRegion):
         return PointSkyRegion(center, meta=self.meta.copy(),
                               visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -196,6 +196,6 @@ class PointSkyRegion(SkyRegion):
         return PointPixelRegion(center, meta=self.meta.copy(),
                                 visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -128,7 +128,7 @@ class PolygonPixelRegion(PixelRegion):
         return PolygonSkyRegion(vertices=vertices_sky, meta=self.meta.copy(),
                                 visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(
             wcs, include_boundary_distortions)
@@ -429,7 +429,7 @@ class PolygonSkyRegion(SkyRegion):
         return PolygonPixelRegion(vertices_pix, meta=self.meta.copy(),
                                   visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(
             wcs, include_boundary_distortions)
@@ -614,7 +614,7 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
         return PolygonSphericalSkyRegion(bound_verts, meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
-    def to_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_sky(self, *, wcs=None, include_boundary_distortions=False,
                n_vertices=None):
         self._validate_planar_spherical_transform(
             wcs, include_boundary_distortions)

--- a/regions/shapes/range.py
+++ b/regions/shapes/range.py
@@ -881,12 +881,8 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         """
         return self.discretize_boundary(n_vertices=n_vertices)
 
-    def to_sky(
-        self,
-        wcs=None, *,
-        include_boundary_distortions=False,
-        n_vertices=None,
-    ):
+    def to_sky(self, wcs, *, include_boundary_distortions=False,
+               n_vertices=None):
         if not include_boundary_distortions:
             raise ValueError(
                 'Invalid parameter: `include_boundary_distortions=False`!\n'
@@ -904,11 +900,8 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
             wcs=wcs, n_vertices=n_vertices,
         ).to_sky(wcs)
 
-    def to_pixel(
-        self, wcs, *,
-        include_boundary_distortions=False,
-        n_vertices=None,
-    ):
+    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+                 n_vertices=None):
         if not include_boundary_distortions:
             raise ValueError(
                 'Invalid parameter: `include_boundary_distortions=False`!\n'

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -130,7 +130,7 @@ class RectanglePixelRegion(PixelRegion):
                                   meta=self.meta.copy(),
                                   visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -452,6 +452,6 @@ class RectangleSkyRegion(SkyRegion):
         """
         return self.to_pixel(wcs).to_polygon().to_sky(wcs)
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -94,10 +94,9 @@ class TestCircleAnnulusPixelRegion(BaseTestPixelRegion):
                                           include_boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
-        with pytest.raises(TypeError) as excinfo:
-            _ = self.reg.to_spherical_sky()
-        estr = 'missing 1 required positional argument'
-        assert estr in str(excinfo.value)
+        match = 'missing 1 required positional argument'
+        with pytest.raises(TypeError, match=match):
+            self.reg.to_spherical_sky()
 
     def test_rotate(self):
         reg = self.reg.rotate(PixCoord(2, 3), 90 * u.deg)
@@ -174,10 +173,9 @@ class TestCircleAnnulusSkyRegion(BaseTestSkyRegion):
                                           include_boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.to_spherical_sky(include_boundary_distortions=True)
-        estr = "'wcs' must be set if `include_boundary_distortions=True`"
-        assert estr in str(excinfo.value)
+        match = "'wcs' must be set if `include_boundary_distortions=True`"
+        with pytest.raises(ValueError, match=match):
+            self.reg.to_spherical_sky(include_boundary_distortions=True)
 
     def test_eq(self):
         reg = self.reg.copy()
@@ -212,11 +210,10 @@ class TestCircleAnnulusSphericalSkyRegion(BaseTestSphericalSkyRegion):
         assert_quantity_allclose(self.reg.outer_radius, 30 * u.arcsec)
 
     def test_valid_radii(self):
-        with pytest.raises(ValueError) as excinfo:
-            _ = CircleAnnulusSphericalSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg),
-                                                30 * u.arcsec, 20 * u.arcsec)
-        estr = 'outer_radius must be greater than inner_radius'
-        assert estr in str(excinfo.value)
+        match = 'outer_radius must be greater than inner_radius'
+        with pytest.raises(ValueError, match=match):
+            CircleAnnulusSphericalSkyRegion(SkyCoord(3 * u.deg, 4 * u.deg),
+                                            30 * u.arcsec, 20 * u.arcsec)
 
     def test_copy(self):
         reg = self.reg.copy()
@@ -247,10 +244,9 @@ class TestCircleAnnulusSphericalSkyRegion(BaseTestSphericalSkyRegion):
         assert isinstance(polypix, CompoundPixelRegion)
 
     def test_transformation_no_wcs(self):
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.to_sky(include_boundary_distortions=True)
-        estr = "'wcs' must be set if `include_boundary_distortions=True`"
-        assert estr in str(excinfo.value)
+        match = "'wcs' must be set if `include_boundary_distortions=True`"
+        with pytest.raises(ValueError, match=match):
+            self.reg.to_sky(include_boundary_distortions=True)
 
     def test_frame_transformation(self):
         reg2 = self.reg.transform_to('galactic')

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -94,9 +94,9 @@ class TestCircleAnnulusPixelRegion(BaseTestPixelRegion):
                                           include_boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.to_spherical_sky(include_boundary_distortions=True)
-        estr = "'wcs' must be set if `include_boundary_distortions=True`"
+        with pytest.raises(TypeError) as excinfo:
+            _ = self.reg.to_spherical_sky()
+        estr = 'missing 1 required positional argument'
         assert estr in str(excinfo.value)
 
     def test_rotate(self):
@@ -166,11 +166,11 @@ class TestCircleAnnulusSkyRegion(BaseTestSkyRegion):
 
     def test_to_spherical_sky(self, wcs):
         sphskyann = self.reg.to_spherical_sky(
-            wcs, include_boundary_distortions=False)
+            wcs=wcs, include_boundary_distortions=False)
         assert isinstance(sphskyann, CircleAnnulusSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
-            _ = self.reg.to_spherical_sky(wcs,
+            _ = self.reg.to_spherical_sky(wcs=wcs,
                                           include_boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
@@ -238,7 +238,8 @@ class TestCircleAnnulusSphericalSkyRegion(BaseTestSphericalSkyRegion):
         skyannulus = self.reg.to_sky(wcs=self.wcs)
         assert isinstance(skyannulus, CircleAnnulusSkyRegion)
 
-        polysky = self.reg.to_sky(self.wcs, include_boundary_distortions=True)
+        polysky = self.reg.to_sky(
+            wcs=self.wcs, include_boundary_distortions=True)
         assert isinstance(polysky, CompoundSkyRegion)
 
         polypix = self.reg.to_pixel(

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -199,13 +199,13 @@ def test_sky_to_spherical_sky(region, include_dist):
     ):
         with pytest.raises(NotImplementedError):
             sph_sky_region = region.to_spherical_sky(
-                COMMON_WCS,
+                wcs=COMMON_WCS,
                 include_boundary_distortions=include_dist,
             )
             assert isinstance(sph_sky_region, SphericalSkyRegion)
     else:
         sph_sky_region = region.to_spherical_sky(
-            COMMON_WCS,
+            wcs=COMMON_WCS,
             include_boundary_distortions=include_dist,
         )
         assert isinstance(sph_sky_region, SphericalSkyRegion)
@@ -218,7 +218,7 @@ def test_spherical_sky_to_sky(region, include_dist):
     if isinstance(region, WholeSphericalSkyRegion):
         with pytest.raises(ValueError):
             _ = region.to_sky(
-                COMMON_WCS,
+                wcs=COMMON_WCS,
                 include_boundary_distortions=include_dist,
             )
 
@@ -236,7 +236,7 @@ def test_spherical_sky_to_sky(region, include_dist):
 
     else:
         sky_region = region.to_sky(
-            COMMON_WCS,
+            wcs=COMMON_WCS,
             include_boundary_distortions=include_dist,
         )
         assert isinstance(sky_region, SkyRegion)

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -225,14 +225,12 @@ def test_spherical_sky_to_sky(region, include_dist):
     elif (isinstance(region, (LuneSphericalSkyRegion, RangeSphericalSkyRegion))
           & (not include_dist)):
         # No distortions: not defined:
-        with pytest.raises(ValueError) as excinfo:
-            _ = region.to_sky(
+        match = 'Invalid parameter: `include_boundary_distortions=False`!'
+        with pytest.raises(ValueError, match=match):
+            region.to_sky(
                 COMMON_WCS,
                 include_boundary_distortions=include_dist,
             )
-
-        estr = 'Invalid parameter: `include_boundary_distortions=False`!'
-        assert estr in str(excinfo.value)
 
     else:
         sky_region = region.to_sky(
@@ -256,13 +254,12 @@ def test_spherical_sky_to_pix(region, include_dist):
     elif (isinstance(region, (LuneSphericalSkyRegion, RangeSphericalSkyRegion))
           & (not include_dist)):
         # No distortions: not defined:
-        with pytest.raises(ValueError) as excinfo:
-            _ = region.to_pixel(
+        match = 'Invalid parameter: `include_boundary_distortions=False`!'
+        with pytest.raises(ValueError, match=match):
+            region.to_pixel(
                 COMMON_WCS,
                 include_boundary_distortions=include_dist,
             )
-        estr = 'Invalid parameter: `include_boundary_distortions=False`!'
-        assert estr in str(excinfo.value)
 
     else:
         pixel_region = region.to_pixel(
@@ -298,9 +295,9 @@ def test_attribute_validation_pixel_regions(region):
     for attr in invalid_values:
         if hasattr(region, attr):
             for val in invalid_values.get(attr, None):
-                with pytest.raises(ValueError) as excinfo:
+                match = f'{attr!r} must'
+                with pytest.raises(ValueError, match=match):
                     setattr(region, attr, val)
-                assert f'{attr!r} must' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('region', SKY_REGIONS, ids=ids_func)
@@ -334,9 +331,9 @@ def test_attribute_validation_sky_regions(region):
     for attr in invalid_values:
         if hasattr(region, attr):
             for val in invalid_values.get(attr, None):
-                with pytest.raises(ValueError) as excinfo:
+                match = f'{attr!r} must'
+                with pytest.raises(ValueError, match=match):
                     setattr(region, attr, val)
-                assert f'{attr!r} must' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('region', SPHERICAL_SKY_REGIONS, ids=ids_func)
@@ -378,9 +375,9 @@ def test_attribute_validation_spherical_sky_regions(region):
     for attr in invalid_values:
         if hasattr(region, attr) & (attr in region_attrs):
             for val in invalid_values.get(attr, None):
-                with pytest.raises(ValueError) as excinfo:
+                match = f'{attr!r} must'
+                with pytest.raises(ValueError, match=match):
                     setattr(region, attr, val)
-                assert f'{attr!r} must' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('region', PIXEL_REGIONS + SKY_REGIONS, ids=ids_func)

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -73,10 +73,9 @@ class TestCirclePixelRegion(BaseTestPixelRegion):
                                           include_boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
-        with pytest.raises(TypeError) as excinfo:
-            _ = self.reg.to_spherical_sky()
-        estr = 'missing 1 required positional argument'
-        assert estr in str(excinfo.value)
+        match = 'missing 1 required positional argument'
+        with pytest.raises(TypeError, match=match):
+            self.reg.to_spherical_sky()
 
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
     def test_as_artist(self):
@@ -175,18 +174,16 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
                                           include_boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.to_spherical_sky(include_boundary_distortions=True)
-        estr = "'wcs' must be set if `include_boundary_distortions=True`"
-        assert estr in str(excinfo.value)
+        match = "'wcs' must be set if `include_boundary_distortions=True`"
+        with pytest.raises(ValueError, match=match):
+            self.reg.to_spherical_sky(include_boundary_distortions=True)
 
     def test_dimension_center(self):
         center = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
         radius = 2 * u.arcsec
-        with pytest.raises(ValueError) as excinfo:
+        match = "'center' must be a scalar SkyCoord"
+        with pytest.raises(ValueError, match=match):
             CircleSkyRegion(center, radius)
-        estr = "'center' must be a scalar SkyCoord"
-        assert estr in str(excinfo.value)
 
     def test_contains(self, wcs):
         position = SkyCoord([1, 3] * u.deg, [2, 4] * u.deg)
@@ -257,10 +254,9 @@ class TestCircleSphericalSkyRegion(BaseTestSphericalSkyRegion):
         assert isinstance(polypix, PolygonPixelRegion)
 
     def test_transformation_no_wcs(self):
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.to_sky(include_boundary_distortions=True)
-        estr = "'wcs' must be set if `include_boundary_distortions=True`"
-        assert estr in str(excinfo.value)
+        match = "'wcs' must be set if `include_boundary_distortions=True`"
+        with pytest.raises(ValueError, match=match):
+            self.reg.to_sky(include_boundary_distortions=True)
 
     def test_frame_transformation(self):
         skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='galactic')
@@ -275,10 +271,9 @@ class TestCircleSphericalSkyRegion(BaseTestSphericalSkyRegion):
     def test_dimension_center(self):
         center = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
         radius = 2 * u.arcsec
-        with pytest.raises(ValueError) as excinfo:
+        match = "'center' must be a scalar SkyCoord"
+        with pytest.raises(ValueError, match=match):
             CircleSphericalSkyRegion(center, radius)
-        estr = "'center' must be a scalar SkyCoord"
-        assert estr in str(excinfo.value)
 
     def test_eq(self):
         reg = self.reg.copy()

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -73,9 +73,9 @@ class TestCirclePixelRegion(BaseTestPixelRegion):
                                           include_boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.to_spherical_sky(include_boundary_distortions=True)
-        estr = "'wcs' must be set if `include_boundary_distortions=True`"
+        with pytest.raises(TypeError) as excinfo:
+            _ = self.reg.to_spherical_sky()
+        estr = 'missing 1 required positional argument'
         assert estr in str(excinfo.value)
 
     @pytest.mark.skipif(not HAS_MATPLOTLIB, reason='matplotlib is required')
@@ -167,11 +167,11 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
         assert_quantity_allclose(skycircle2.radius, skycircle.radius)
 
         sphskycircle = self.reg.to_spherical_sky(
-            wcs, include_boundary_distortions=False)
+            wcs=wcs, include_boundary_distortions=False)
         assert isinstance(sphskycircle, CircleSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
-            _ = self.reg.to_spherical_sky(wcs,
+            _ = self.reg.to_spherical_sky(wcs=wcs,
                                           include_boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
@@ -238,7 +238,7 @@ class TestCircleSphericalSkyRegion(BaseTestSphericalSkyRegion):
         assert_allclose(pixcircle.center.y, 299.5)
         assert_allclose(pixcircle.radius, 0.0278117, rtol=1e-6)
 
-        skycircle = sphskycircle.to_sky(wcs)
+        skycircle = sphskycircle.to_sky(wcs=wcs)
         assert isinstance(skycircle, CircleSkyRegion)
 
         sphskycircle2 = pixcircle.to_spherical_sky(wcs)
@@ -249,7 +249,8 @@ class TestCircleSphericalSkyRegion(BaseTestSphericalSkyRegion):
                                  sphskycircle2.center.data.lat)
         assert_quantity_allclose(sphskycircle2.radius, sphskycircle.radius)
 
-        polysky = sphskycircle.to_sky(wcs, include_boundary_distortions=True)
+        polysky = sphskycircle.to_sky(
+            wcs=wcs, include_boundary_distortions=True)
         assert isinstance(polysky, PolygonSkyRegion)
 
         polypix = sphskycircle.to_pixel(wcs, include_boundary_distortions=True)

--- a/regions/shapes/tests/test_common.py
+++ b/regions/shapes/tests/test_common.py
@@ -61,9 +61,9 @@ class BaseTestPixelRegion(BaseTestRegion):
         assert_equal(actual[:len(self.inside)], True)
         assert_equal(actual[len(self.inside):], False)
 
-        with pytest.raises(ValueError) as excinfo:
+        match = 'coord must be scalar'
+        with pytest.raises(ValueError, match=match):
             assert pixcoord in self.reg
-        assert 'coord must be scalar' in str(excinfo.value)
 
     def test_contains_array_2d(self):
         x, y = zip(*(self.inside + self.outside), strict=True)

--- a/regions/shapes/tests/test_ellipse.py
+++ b/regions/shapes/tests/test_ellipse.py
@@ -332,10 +332,9 @@ class TestEllipseSkyRegion(BaseTestSkyRegion):
         center = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
         width = 2 * u.arcsec
         height = 3 * u.arcsec
-        with pytest.raises(ValueError) as excinfo:
+        match = "'center' must be a scalar SkyCoord"
+        with pytest.raises(ValueError, match=match):
             EllipseSkyRegion(center, width, height)
-        estr = "'center' must be a scalar SkyCoord"
-        assert estr in str(excinfo.value)
 
     def test_contains(self, wcs):
         position = SkyCoord([1, 3] * u.deg, [2, 4] * u.deg)

--- a/regions/shapes/tests/test_lune.py
+++ b/regions/shapes/tests/test_lune.py
@@ -57,15 +57,13 @@ class TestLuneSphericalSkyRegion(BaseTestSphericalSkyRegion):
 
     def test_transformation(self, wcs):
         # Test error for no boundary distortions:
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.to_pixel(wcs)
-        estr = 'Invalid parameter: `include_boundary_distortions=False`!'
-        assert estr in str(excinfo.value)
+        match = 'Invalid parameter: `include_boundary_distortions=False`!'
+        with pytest.raises(ValueError, match=match):
+            self.reg.to_pixel(wcs)
 
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.to_sky(wcs)
-        estr = 'Invalid parameter: `include_boundary_distortions=False`!'
-        assert estr in str(excinfo.value)
+        match = 'Invalid parameter: `include_boundary_distortions=False`!'
+        with pytest.raises(ValueError, match=match):
+            self.reg.to_sky(wcs)
 
         # Test for transformations with `include_boundary_distortions=True`
         polypix = self.reg.to_pixel(wcs,
@@ -156,7 +154,6 @@ class TestLuneSphericalSkyRegion(BaseTestSphericalSkyRegion):
         polylune_inv = self.reg_inv.discretize_boundary(n_vertices=100)
         assert polylune_inv.contains(self.reg.centroid)
 
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.discretize_boundary(n_vertices=1)
-        estr = 'must be greater than'
-        assert estr in str(excinfo.value)
+        match = 'must be greater than'
+        with pytest.raises(ValueError, match=match):
+            self.reg.discretize_boundary(n_vertices=1)

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -83,9 +83,9 @@ class TestPolygonPixelRegion(BaseTestPixelRegion):
                                           include_boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.to_spherical_sky(include_boundary_distortions=True)
-        estr = "'wcs' must be set if `include_boundary_distortions=True`"
+        with pytest.raises(TypeError) as excinfo:
+            _ = self.reg.to_spherical_sky()
+        estr = 'missing 1 required positional argument'
         assert estr in str(excinfo.value)
 
     def test_bounding_box(self):
@@ -231,11 +231,11 @@ class TestPolygonSkyRegion(BaseTestSkyRegion):
                                  self.reg.vertices.data.lat, atol=1e-3 * u.deg)
 
         polysphsky = self.reg.to_spherical_sky(
-            wcs, include_boundary_distortions=False)
+            wcs=wcs, include_boundary_distortions=False)
         assert isinstance(polysphsky, PolygonSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
-            _ = self.reg.to_spherical_sky(wcs,
+            _ = self.reg.to_spherical_sky(wcs=wcs,
                                           include_boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
@@ -385,19 +385,19 @@ class TestPolygonSphericalSkyRegion(BaseTestSphericalSkyRegion):
         assert_allclose(polypix.vertices.y,
                         [1.99948607, 2.0390009, 2.07707564])
 
-        polysky = self.reg.to_sky(wcs)
+        polysky = self.reg.to_sky(wcs=wcs)
         assert isinstance(polysky, PolygonSkyRegion)
         assert_allclose(polysky.vertices.ra.deg, [3, 4, 3])
         assert_allclose(polysky.vertices.dec.deg, [3, 4, 4])
 
-        polysky2 = polysky.to_spherical_sky(wcs)
+        polysky2 = polysky.to_spherical_sky(wcs=wcs)
 
         assert_quantity_allclose(self.reg.vertices.ra.deg,
                                  polysky2.vertices.ra.deg)
         assert_quantity_allclose(self.reg.vertices.dec.deg,
                                  polysky2.vertices.dec.deg)
 
-        polysky3 = self.reg.to_sky(wcs,
+        polysky3 = self.reg.to_sky(wcs=wcs,
                                    include_boundary_distortions=True,
                                    n_vertices=10)
         assert isinstance(polysky3, PolygonSkyRegion)

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -83,10 +83,9 @@ class TestPolygonPixelRegion(BaseTestPixelRegion):
                                           include_boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
-        with pytest.raises(TypeError) as excinfo:
-            _ = self.reg.to_spherical_sky()
-        estr = 'missing 1 required positional argument'
-        assert estr in str(excinfo.value)
+        match = 'missing 1 required positional argument'
+        with pytest.raises(TypeError, match=match):
+            self.reg.to_spherical_sky()
 
     def test_bounding_box(self):
         bbox = self.reg.bounding_box
@@ -239,10 +238,9 @@ class TestPolygonSkyRegion(BaseTestSkyRegion):
                                           include_boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.to_spherical_sky(include_boundary_distortions=True)
-        estr = "'wcs' must be set if `include_boundary_distortions=True`"
-        assert estr in str(excinfo.value)
+        match = "'wcs' must be set if `include_boundary_distortions=True`"
+        with pytest.raises(ValueError, match=match):
+            self.reg.to_spherical_sky(include_boundary_distortions=True)
 
     def test_contains(self, wcs):
         position = SkyCoord([1, 3.25] * u.deg, [2, 3.75] * u.deg)
@@ -410,10 +408,9 @@ class TestPolygonSphericalSkyRegion(BaseTestSphericalSkyRegion):
         assert len(polypix2.vertices) == 10
 
     def test_transformation_no_wcs(self):
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.to_sky(include_boundary_distortions=True)
-        estr = "'wcs' must be set if `include_boundary_distortions=True`"
-        assert estr in str(excinfo.value)
+        match = "'wcs' must be set if `include_boundary_distortions=True`"
+        with pytest.raises(ValueError, match=match):
+            self.reg.to_sky(include_boundary_distortions=True)
 
     def test_frame_transformation(self):
         reg = self.reg.transform_to('galactic')
@@ -460,10 +457,9 @@ class TestPolygonSphericalSkyRegion(BaseTestSphericalSkyRegion):
         assert isinstance(poly, PolygonSphericalSkyRegion)
         assert len(poly.vertices) == 100
 
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.discretize_boundary(n_vertices=2)
-        estr = 'must be greater than'
-        assert estr in str(excinfo.value)
+        match = 'must be greater than'
+        with pytest.raises(ValueError, match=match):
+            self.reg.discretize_boundary(n_vertices=2)
 
     def test_centroid(self):
         # Test default polygon has mindist centroid outside region,

--- a/regions/shapes/tests/test_range.py
+++ b/regions/shapes/tests/test_range.py
@@ -340,9 +340,9 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
                              n_vertices=10)
 
     def test_transformation_no_wcs(self):
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.to_sky(include_boundary_distortions=True)
-        estr = "'wcs' must be set if `include_boundary_distortions=True`"
+        with pytest.raises(TypeError) as excinfo:
+            _ = self.reg.to_sky()
+        estr = 'missing 1 required positional argument'
         assert estr in str(excinfo.value)
 
     def test_frame_transformation(self):

--- a/regions/shapes/tests/test_range.py
+++ b/regions/shapes/tests/test_range.py
@@ -47,95 +47,85 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
                     'latitude_range: [-4.  4.] deg')
 
     def test_no_range_set(self):
-        with pytest.raises(ValueError) as excinfo:
-            _ = RangeSphericalSkyRegion(frame='icrs')
-        estr = 'A range for at least one of longitude and latitude must be set'
-        assert estr in str(excinfo.value)
+        match = ('A range for at least one of longitude and latitude must '
+                 'be set')
+        with pytest.raises(ValueError, match=match):
+            RangeSphericalSkyRegion(frame='icrs')
 
     def test_invalid_lon_range(self):
         # Test input types:
         for lon_range in [u.Quantity([0, 10], u.m / u.s),
                           [0 * u.m / u.s, 30 * u.m / u.s]]:
-            with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(
+            match = 'must have angular units'
+            with pytest.raises(ValueError, match=match):
+                RangeSphericalSkyRegion(
                     longitude_range=lon_range, frame='icrs')
-            estr = 'must have angular units'
-            assert estr in str(excinfo.value)
 
         for lon_range in [u.Quantity([0], u.deg), Angle([2 * u.radian])]:
-            with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(
+            match = 'must be length 2'
+            with pytest.raises(ValueError, match=match):
+                RangeSphericalSkyRegion(
                     longitude_range=lon_range, frame='icrs')
-            estr = 'must be length 2'
-            assert estr in str(excinfo.value)
 
         for lon_range in [[0 * u.deg], [0, 10], 'string']:
-            with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(
+            match = 'must be an angle of length 2'
+            with pytest.raises(ValueError, match=match):
+                RangeSphericalSkyRegion(
                     longitude_range=lon_range, frame='icrs')
-            estr = 'must be an angle of length 2'
-            assert estr in str(excinfo.value)
 
         # Test valid boundary values:
         for lon_range in [[-30, 30] * u.deg, [20, 560] * u.deg]:
-            with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(
+            match = (r'Longitude values must be within \[0, 360\] degrees'
+                     r' or equivalent!')
+            with pytest.raises(ValueError, match=match):
+                RangeSphericalSkyRegion(
                     longitude_range=lon_range, frame='icrs')
-            estr = ('Longitude values must be within [0, 360] degrees'
-                    ' or equivalent!')
-            assert estr in str(excinfo.value)
 
     def test_invalid_lat_range(self):
         # Test input types:
         for lat_range in [u.Quantity([0, 10], u.m / u.s),
                           [0 * u.m / u.s, 30 * u.m / u.s]]:
-            with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(
+            match = 'must have angular units'
+            with pytest.raises(ValueError, match=match):
+                RangeSphericalSkyRegion(
                     latitude_range=lat_range, frame='icrs')
-            estr = 'must have angular units'
-            assert estr in str(excinfo.value)
 
         for lat_range in [u.Quantity([0], u.deg), Angle([2 * u.radian])]:
-            with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(
+            match = 'must be length 2'
+            with pytest.raises(ValueError, match=match):
+                RangeSphericalSkyRegion(
                     latitude_range=lat_range, frame='icrs')
-            estr = 'must be length 2'
-            assert estr in str(excinfo.value)
 
         for lat_range in [[0 * u.deg], [0, 10], 'string']:
-            with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(
+            match = 'must be an angle of length 2'
+            with pytest.raises(ValueError, match=match):
+                RangeSphericalSkyRegion(
                     latitude_range=lat_range, frame='icrs')
-            estr = 'must be an angle of length 2'
-            assert estr in str(excinfo.value)
 
         # Test valid boundary values:
         for lat_range in [[-120, -30] * u.deg, [20, 100] * u.deg]:
-            with pytest.raises(ValueError) as excinfo:
-                _ = RangeSphericalSkyRegion(
+            match = (r'Latitude values must be within \[-90, 90\] degrees'
+                     r' or equivalent!')
+            with pytest.raises(ValueError, match=match):
+                RangeSphericalSkyRegion(
                     latitude_range=lat_range, frame='icrs')
-            estr = ('Latitude values must be within [-90, 90] degrees'
-                    ' or equivalent!')
-            assert estr in str(excinfo.value)
 
     def test_invalid_lon_bounds_input(self):
         invalid_bounds = CircleSphericalSkyRegion(
             SkyCoord(5 * u.deg, 0 * u.deg), 0.2 * u.deg)
-        with pytest.raises(ValueError) as excinfo:
-            _ = RangeSphericalSkyRegion(_longitude_bounds=invalid_bounds,
-                                        frame='icrs')
-        estr = 'Invalid direct longitude bounds input!'
-        assert estr in str(excinfo.value)
+        match = 'Invalid direct longitude bounds input!'
+        with pytest.raises(ValueError, match=match):
+            RangeSphericalSkyRegion(_longitude_bounds=invalid_bounds,
+                                    frame='icrs')
 
     def test_invalid_lat_bounds_input(self):
         invalid_bounds = LuneSphericalSkyRegion(
             SkyCoord(3 * u.deg, 0 * u.deg),
             SkyCoord(178 * u.deg, 0 * u.deg))
-        with pytest.raises(ValueError) as excinfo:
-            _ = RangeSphericalSkyRegion(_latitude_bounds=invalid_bounds,
-                                        frame='icrs')
-        estr = 'Invalid direct latitude bounds input!'
-        assert estr in str(excinfo.value)
+        match = 'Invalid direct latitude bounds input!'
+        with pytest.raises(ValueError, match=match):
+            RangeSphericalSkyRegion(_latitude_bounds=invalid_bounds,
+                                    frame='icrs')
 
     def test_lon_only(self):
         reg = RangeSphericalSkyRegion(longitude_range=[0, 10] * u.deg,
@@ -282,15 +272,13 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
     def test_transformation(self, wcs):
 
         # Test error for no boundary distortions:
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.to_pixel(wcs)
-        estr = 'Invalid parameter: `include_boundary_distortions=False`!'
-        assert estr in str(excinfo.value)
+        match = 'Invalid parameter: `include_boundary_distortions=False`!'
+        with pytest.raises(ValueError, match=match):
+            self.reg.to_pixel(wcs)
 
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.to_sky(wcs)
-        estr = 'Invalid parameter: `include_boundary_distortions=False`!'
-        assert estr in str(excinfo.value)
+        match = 'Invalid parameter: `include_boundary_distortions=False`!'
+        with pytest.raises(ValueError, match=match):
+            self.reg.to_sky(wcs)
 
         # Test boundary distortion transformations:
         polypix2 = self.reg.to_pixel(wcs,
@@ -340,10 +328,9 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
                              n_vertices=10)
 
     def test_transformation_no_wcs(self):
-        with pytest.raises(TypeError) as excinfo:
-            _ = self.reg.to_sky()
-        estr = 'missing 1 required positional argument'
-        assert estr in str(excinfo.value)
+        match = 'missing 1 required positional argument'
+        with pytest.raises(TypeError, match=match):
+            self.reg.to_sky()
 
     def test_frame_transformation(self):
         reg2 = self.reg.transform_to('galactic')
@@ -523,10 +510,9 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
         assert len(polyrange3.region1.vertices) == 100
         assert len(polyrange3.region2.vertices) == 100
 
-        with pytest.raises(ValueError) as excinfo:
-            _ = self.reg.discretize_boundary(n_vertices=3)
-        estr = 'must be greater than'
-        assert estr in str(excinfo.value)
+        match = 'must be greater than'
+        with pytest.raises(ValueError, match=match):
+            self.reg.discretize_boundary(n_vertices=3)
 
     def test_discretize_over_poles(self):
         # Wrap over poles:

--- a/regions/shapes/tests/test_whole_sky.py
+++ b/regions/shapes/tests/test_whole_sky.py
@@ -44,7 +44,7 @@ class TestWholeSphericalSkyRegion(BaseTestSphericalSkyRegion):
 
     def test_transformation(self, wcs):
         with pytest.raises(ValueError):
-            _ = self.reg.to_sky(wcs)
+            _ = self.reg.to_sky(wcs=wcs)
 
         with pytest.raises(ValueError):
             _ = self.reg.to_pixel(wcs)

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -87,7 +87,7 @@ class TextPixelRegion(PointPixelRegion):
         return TextSkyRegion(center, self.text, meta=self.meta.copy(),
                              visual=visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -168,6 +168,6 @@ class TextSkyRegion(PointSkyRegion):
                                meta=self.meta.copy(),
                                visual=visual.copy())
 
-    def to_spherical_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/whole_sky.py
+++ b/regions/shapes/whole_sky.py
@@ -58,7 +58,7 @@ class WholeSphericalSkyRegion(SphericalSkyRegion):
     def discretize_boundary(self, *, n_vertices=100):
         raise ValueError('Not defined.')
 
-    def to_sky(self, wcs=None, *, include_boundary_distortions=False,
+    def to_sky(self, *, wcs=None, include_boundary_distortions=False,
                n_vertices=None):
         raise ValueError('Not defined.')
 


### PR DESCRIPTION
This PR fixes several instances where the `wcs` keyword was specified in method signatures as an optional keyword (e.g., `wcs=None`), but it was actually required.

It also updates the tests to use the `pytest` `match` keyword.