### PR TITLE
Rename include_boundary_distortions to boundary_distortions

### DIFF
--- a/docs/getting_started/examples.rst
+++ b/docs/getting_started/examples.rst
@@ -79,7 +79,7 @@ full sky image (seen in this `Astropy visualization demo
         25 * u.deg)
     circ.to_pixel(
         wcs=wcs,
-        include_boundary_distortions=True,
+        boundary_distortions=True,
         n_vertices=1000,
     ).plot(ax=ax, edgecolor='red',
            facecolor='none', lw=2)
@@ -91,7 +91,7 @@ full sky image (seen in this `Astropy visualization demo
     )
     lon_lat_range.to_pixel(
         wcs=wcs,
-        include_boundary_distortions=True,
+        boundary_distortions=True,
         n_vertices=250,
     ).plot(ax=ax, edgecolor='blue',
            facecolor='none', lw=2)

--- a/docs/getting_started/overview.rst
+++ b/docs/getting_started/overview.rst
@@ -327,11 +327,11 @@ spherical circle falling outside of the planar circle and vice versa.
         center=SkyCoord(50, 45, unit='deg', frame='galactic'),
         radius=Angle('30 deg'))
     # Note: circle is equivalent to transforming from sph_circle
-    # with sph_circle.to_sky(wcs=wcs, include_boundary_distortions=False)
+    # with sph_circle.to_sky(wcs=wcs, boundary_distortions=False)
 
     # Define transformed-to pixel regions
     pix_circ_distort = sph_circle.to_pixel(wcs=wcs,
-                                           include_boundary_distortions=True,
+                                           boundary_distortions=True,
                                            n_vertices=1000)
     pix_circ_nodistort = circle.to_pixel(wcs=wcs)
 

--- a/docs/user_guide/compound.rst
+++ b/docs/user_guide/compound.rst
@@ -245,7 +245,7 @@ and spherical sky regions, with the same circle centers and radii.
                color='magenta', label='and',
                transform=ax.get_transform('galactic'))
 
-    boundary_kwargs = {'include_boundary_distortions': True,
+    boundary_kwargs = {'boundary_distortions': True,
                        'n_vertices': 1000}
     sph_circle1.to_pixel(wcs=wcs, **boundary_kwargs).plot(
         ax=ax, edgecolor='green', facecolor='none', alpha=0.8, lw=3)

--- a/docs/user_guide/plotting.rst
+++ b/docs/user_guide/plotting.rst
@@ -88,12 +88,11 @@ Plotting Spherical Sky Regions
 
 Similarly, `~regions.SphericalSkyRegion` objects do not
 have an ``as_artist()`` or ``plot()`` method. To plot a
-`~regions.SphericalSkyRegion` object, you will need to convert
-it to a pixel region (using a WCS object). Boundary distortions
-can also be included in this conversion (by setting the
-``include_boundary_distortions`` keyword), to capture the effects of
-the WCS projection from spherical to a planar geometry. See the second
-example in :ref:`examples`.
+`~regions.SphericalSkyRegion` object, you will need to convert it to
+a pixel region (using a WCS object). Boundary distortions can also be
+included in this conversion (by setting the ``boundary_distortions``
+keyword), to capture the effects of the WCS projection from spherical to
+a planar geometry. See the second example in :ref:`examples`.
 
 It is also possible to use the coordinates of a discretized
 `~regions.SphericalSkyRegion` to show the region's boundary in a figure.
@@ -124,7 +123,7 @@ It is also possible to use the coordinates of a discretized
 
     sph_sky_region.to_pixel(
         wcs=wcs,
-        include_boundary_distortions=True,
+        boundary_distortions=True,
         n_vertices=1000,
     ).plot(ax=ax, color='tab:red', lw=3)
 

--- a/docs/user_guide/shapes.rst
+++ b/docs/user_guide/shapes.rst
@@ -376,7 +376,7 @@ then a WCS object is not necessary:
 
 .. code-block:: python
 
-    >>> sky_reg = sph_sky_reg.to_sky(include_boundary_distortions=False)
+    >>> sky_reg = sph_sky_reg.to_sky(boundary_distortions=False)
     >>> print(sky_reg)  # doctest: +FLOAT_CMP
     Region: CircleSkyRegion
     center: <SkyCoord (ICRS): (ra, dec) in deg
@@ -397,7 +397,7 @@ to the `~regions.SphericalSkyRegion.discretize_boundary()` method.
 .. code-block:: python
 
     >>> sky_reg = sph_sky_reg.to_sky(wcs=wcs,
-    ...                              include_boundary_distortions=True,
+    ...                              boundary_distortions=True,
     ...                              n_vertices=10)
     >>> print(sky_reg)  # doctest: +FLOAT_CMP
     Region: PolygonSkyRegion
@@ -415,14 +415,14 @@ respectively).
 .. code-block:: python
 
     >>> pix_reg = sph_sky_reg.to_pixel(wcs=wcs,
-    ...                                include_boundary_distortions=False)
+    ...                                boundary_distortions=False)
     >>> print(pix_reg)  # doctest: +FLOAT_CMP
     Region: CirclePixelRegion
     center: PixCoord(x=49.0, y=49.0)
     radius: 300.0
 
     >>> pix_reg2 = sph_sky_reg.to_pixel(wcs=wcs,
-    ...                                 include_boundary_distortions=True,
+    ...                                 boundary_distortions=True,
     ...                                 n_vertices=10)
     >>> print(pix_reg2)  # doctest: +FLOAT_CMP
     Region: PolygonPixelRegion
@@ -439,7 +439,7 @@ methods.
     >>> center = SkyCoord(50, 10, unit='deg')
     >>> radius = Angle(30, 'arcsec')
     >>> sky_reg = CircleSkyRegion(center, radius)
-    >>> sph_sky_reg = sky_reg.to_spherical_sky(include_boundary_distortions=False)
+    >>> sph_sky_reg = sky_reg.to_spherical_sky(boundary_distortions=False)
     >>> print(sph_sky_reg)  # doctest: +FLOAT_CMP
     Region: CircleSphericalSkyRegion
     center: <SkyCoord (ICRS): (ra, dec) in deg

--- a/docs/user_guide/spherical_bounding_regions.rst
+++ b/docs/user_guide/spherical_bounding_regions.rst
@@ -130,13 +130,13 @@ both the original and transformed coordinate frames.
 
     patch = sph_circ.to_pixel(
         wcs=wcs,
-        include_boundary_distortions=True,
+        boundary_distortions=True,
         n_vertices=1000,
     ).plot(ax=ax, color='tab:blue', lw=3)
 
     sph_range.to_pixel(
         wcs=wcs,
-        include_boundary_distortions=True,
+        boundary_distortions=True,
         n_vertices=250,
     ).plot(ax=ax, color='tab:red', lw=3)
 
@@ -165,7 +165,7 @@ both the original and transformed coordinate frames.
     bound_color = 'tab:red'
     sph_range.bounding_circle.to_pixel(
         wcs=wcs,
-        include_boundary_distortions=True,
+        boundary_distortions=True,
         n_vertices=1000,
     ).plot(ax=ax, color='tab:red', lw=bound_lw, ls='--', zorder=bound_zord)
 
@@ -182,13 +182,13 @@ both the original and transformed coordinate frames.
 
     patch = sph_circ_transf.to_pixel(
         wcs=wcs_icrs,
-        include_boundary_distortions=True,
+        boundary_distortions=True,
         n_vertices=1000,
     ).plot(ax=ax, color='tab:blue', lw=3)
 
     sph_range_transf.to_pixel(
         wcs=wcs_icrs,
-        include_boundary_distortions=True,
+        boundary_distortions=True,
         n_vertices=250,
     ).plot(ax=ax, color='tab:red', lw=3)
 
@@ -235,7 +235,7 @@ both the original and transformed coordinate frames.
         ax.add_artist(l2)
     sph_range_transf.bounding_circle.to_pixel(
         wcs=wcs_icrs,
-        include_boundary_distortions=True,
+        boundary_distortions=True,
         n_vertices=1000,
     ).plot(ax=ax, color='tab:red', lw=bound_lw, ls='--', zorder=bound_zord)
 

--- a/docs/user_guide/spherical_frame_transform.rst
+++ b/docs/user_guide/spherical_frame_transform.rst
@@ -131,13 +131,13 @@ projections for the Galactic and ICRS coordinate reference frames
 
     patch = sph_circ.to_pixel(
         wcs=wcs,
-        include_boundary_distortions=True,
+        boundary_distortions=True,
         n_vertices=1000,
     ).plot(ax=ax, color='tab:blue', lw=3)
 
     sph_range.to_pixel(
         wcs=wcs,
-        include_boundary_distortions=True,
+        boundary_distortions=True,
         n_vertices=250,
     ).plot(ax=ax, color='tab:red', lw=3)
 
@@ -157,13 +157,13 @@ projections for the Galactic and ICRS coordinate reference frames
 
     patch = sph_circ_transf.to_pixel(
         wcs=wcs_icrs,
-        include_boundary_distortions=True,
+        boundary_distortions=True,
         n_vertices=1000,
     ).plot(ax=ax, color='tab:blue', lw=3)
 
     sph_range_transf.to_pixel(
         wcs=wcs_icrs,
-        include_boundary_distortions=True,
+        boundary_distortions=True,
         n_vertices=250,
     ).plot(ax=ax, color='tab:red', lw=3)
 

--- a/regions/core/compound.py
+++ b/regions/core/compound.py
@@ -98,16 +98,16 @@ class CompoundPixelRegion(PixelRegion):
                                  region2=skyreg2, meta=self.meta.copy(),
                                  visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, boundary_distortions=False,
                          n_vertices=None):
         sphreg1 = self.region1.to_spherical_sky(
             wcs=wcs,
-            include_boundary_distortions=include_boundary_distortions,
+            boundary_distortions=boundary_distortions,
             n_vertices=n_vertices,
         )
         sphreg2 = self.region2.to_spherical_sky(
             wcs=wcs,
-            include_boundary_distortions=include_boundary_distortions,
+            boundary_distortions=boundary_distortions,
             n_vertices=n_vertices,
         )
         return CompoundSphericalSkyRegion(
@@ -276,16 +276,16 @@ class CompoundSkyRegion(SkyRegion):
                                    region2=pixreg2, meta=self.meta.copy(),
                                    visual=self.visual.copy())
 
-    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, boundary_distortions=False,
                          n_vertices=None):
         sphreg1 = self.region1.to_spherical_sky(
             wcs=wcs,
-            include_boundary_distortions=include_boundary_distortions,
+            boundary_distortions=boundary_distortions,
             n_vertices=n_vertices,
         )
         sphreg2 = self.region2.to_spherical_sky(
             wcs=wcs,
-            include_boundary_distortions=include_boundary_distortions,
+            boundary_distortions=boundary_distortions,
             n_vertices=n_vertices,
         )
         return CompoundSphericalSkyRegion(
@@ -478,16 +478,16 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
             visual=self.visual.copy(),
         )
 
-    def to_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_sky(self, *, wcs=None, boundary_distortions=False,
                n_vertices=None):
         planarreg1 = self.region1.to_sky(
             wcs=wcs,
-            include_boundary_distortions=include_boundary_distortions,
+            boundary_distortions=boundary_distortions,
             n_vertices=n_vertices,
         )
         planarreg2 = self.region2.to_sky(
             wcs=wcs,
-            include_boundary_distortions=include_boundary_distortions,
+            boundary_distortions=boundary_distortions,
             n_vertices=n_vertices,
         )
         return CompoundSkyRegion(
@@ -498,16 +498,16 @@ class CompoundSphericalSkyRegion(SphericalSkyRegion):
             visual=self.visual.copy(),
         )
 
-    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+    def to_pixel(self, wcs, *, boundary_distortions=False,
                  n_vertices=None):
         pixreg1 = self.region1.to_pixel(
             wcs,
-            include_boundary_distortions=include_boundary_distortions,
+            boundary_distortions=boundary_distortions,
             n_vertices=n_vertices,
         )
         pixreg2 = self.region2.to_pixel(
             wcs,
-            include_boundary_distortions=include_boundary_distortions,
+            boundary_distortions=boundary_distortions,
             n_vertices=n_vertices,
         )
         return CompoundPixelRegion(

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -378,12 +378,12 @@ class Region(abc.ABC):
 
     @staticmethod
     def _validate_planar_spherical_transform(
-            wcs, include_boundary_distortions):
+            wcs, boundary_distortions):
         # Validate whether inputs are valid for planar <-> spherical
         # transformations
-        if include_boundary_distortions and (wcs is None):
+        if boundary_distortions and (wcs is None):
             raise ValueError(
-                "'wcs' must be set if `include_boundary_distortions=True`",
+                "'wcs' must be set if `boundary_distortions=True`",
             )
 
 
@@ -532,7 +532,7 @@ class PixelRegion(Region):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, boundary_distortions=False,
                          n_vertices=None):
         """
         Convert to an equivalent spherical `~regions.SphericalSkyRegion`
@@ -544,25 +544,25 @@ class PixelRegion(Region):
             The world coordinate system transformation to use to convert
             between pixel and sky coordinates.
 
-        include_boundary_distortions : bool, optional
-            If True, accounts for boundary distortions in spherical to planar
-            conversions, by discretizing the boundary and
-            converting the boundary polygon.
-            Default is False, which converts to an equivalent idealized shape.
+        boundary_distortions : bool, optional
+            If `True`, the projection-induced distortions of the
+            region's boundary are preserved by discretizing the
+            boundary into a polygon and transforming that polygon. If
+            `False` (default), the region is converted to an equivalent
+            idealized shape that ignores these boundary distortions.
 
         n_vertices : int, optional
-            The number of polygon vertices for boundary discretization.
-            This keyword will have no effect unless
-            ``include_boundary_distortions=True``.
-            Default is 100.
+            The number of polygon vertices for boundary
+            discretization. This keyword will have no effect unless
+            ``boundary_distortions=True``. Default is 100.
 
         Returns
         -------
         spherical_sky_region : `~regions.SphericalSkyRegion`
             A spherical sky region, with an equivalent shape (if
-            ``include_boundary_distortions`` is False), or a
+            ``boundary_distortions`` is False), or a
             discretized polygon of the boundary (if
-            ``include_boundary_distortions`` is True).
+            ``boundary_distortions`` is True).
         """
         raise NotImplementedError
 
@@ -827,7 +827,7 @@ class SkyRegion(Region):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, boundary_distortions=False,
                          n_vertices=None):
         """
         Convert to an equivalent spherical `~regions.SphericalSkyRegion`
@@ -839,28 +839,27 @@ class SkyRegion(Region):
             The world coordinate system transformation to use to convert
             between sky and pixel coordinates. Required if transforming
             with boundary distortions (if
-            ``include_boundary_distortions`` is True).
+            ``boundary_distortions`` is True).
             Ignored if boundary distortions not included.
 
-        include_boundary_distortions : bool, optional
-            If True, accounts for boundary distortions in spherical to planar
-            conversions, by discretizing the boundary and
-            converting the boundary polygon.
-            Default is False, which converts to an equivalent idealized shape.
+        boundary_distortions : bool, optional
+            If `True`, the projection-induced distortions of the
+            region's boundary are preserved by discretizing the
+            boundary into a polygon and transforming that polygon. If
+            `False` (default), the region is converted to an equivalent
+            idealized shape that ignores these boundary distortions.
 
         n_vertices : int, optional
-            The number of polygon vertices for boundary discretization.
-            This keyword will have no effect unless
-            ``include_boundary_distortions=True``.
-            Default is 100.
+            The number of polygon vertices for boundary
+            discretization. This keyword will have no effect unless
+            ``boundary_distortions=True``. Default is 100.
 
         Returns
         -------
         spherical_sky_region : `~regions.SphericalSkyRegion`
             A spherical sky region, with an equivalent shape (if
-            ``include_boundary_distortions`` is False), or a
-            discretized polygon of the boundary (if
-            ``include_boundary_distortions`` is True).
+            ``boundary_distortions`` is False), or a discretized polygon
+            of the boundary (if ``boundary_distortions`` is True).
         """
         raise NotImplementedError
 
@@ -1099,7 +1098,7 @@ class SphericalSkyRegion(Region):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def to_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_sky(self, *, wcs=None, boundary_distortions=False,
                n_vertices=None):
         """
         Convert to a planar `~regions.SkyRegion`.
@@ -1110,33 +1109,32 @@ class SphericalSkyRegion(Region):
             The world coordinate system transformation to use to convert
             between sky and pixel coordinates. Required if transforming
             with boundary distortions (if
-            ``include_boundary_distortions`` is True).
+            ``boundary_distortions`` is True).
             Ignored if boundary distortions not included.
 
-        include_boundary_distortions : bool, optional
-            If True, accounts for boundary distortions in spherical to planar
-            conversions, by discretizing the boundary and
-            converting the boundary polygon.
-            Default is False, which converts to an equivalent idealized shape.
+        boundary_distortions : bool, optional
+            If `True`, the projection-induced distortions of the
+            region's boundary are preserved by discretizing the
+            boundary into a polygon and transforming that polygon. If
+            `False` (default), the region is converted to an equivalent
+            idealized shape that ignores these boundary distortions.
 
         n_vertices : int, optional
-            The number of polygon vertices for boundary discretization.
-            This keyword will have no effect unless
-            ``include_boundary_distortions=True``.
-            Default is 100.
+            The number of polygon vertices for boundary
+            discretization. This keyword will have no effect unless
+            ``boundary_distortions=True``. Default is 100.
 
         Returns
         -------
         sky_region : `~regions.SkyRegion`
             A planar sky region, with an equivalent shape (if
-            ``include_boundary_distortions`` is False), or a
-            discretized polygon of the boundary (if
-            ``include_boundary_distortions`` is True).
+            ``boundary_distortions`` is False), or a discretized polygon
+            of the boundary (if ``boundary_distortions`` is True).
         """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+    def to_pixel(self, wcs, *, boundary_distortions=False,
                  n_vertices=None):
         """
         Convert to a planar `~regions.PixelRegion`.
@@ -1147,25 +1145,24 @@ class SphericalSkyRegion(Region):
             The world coordinate system transformation to use to convert
             between sky and pixel coordinates.
 
-        include_boundary_distortions : bool, optional
-            If True, accounts for boundary distortions in spherical to planar
-            conversions, by discretizing the boundary and
-            converting the boundary polygon.
-            Default is False, which converts to an equivalent idealized shape.
+        boundary_distortions : bool, optional
+            If `True`, the projection-induced distortions of the
+            region's boundary are preserved by discretizing the
+            boundary into a polygon and transforming that polygon. If
+            `False` (default), the region is converted to an equivalent
+            idealized shape that ignores these boundary distortions.
 
         n_vertices : int, optional
-            The number of polygon vertices for boundary discretization.
-            This keyword will have no effect unless
-            ``include_boundary_distortions=True``.
-            Default is 100.
+            The number of polygon vertices for boundary
+            discretization. This keyword will have no effect unless
+            ``boundary_distortions=True``. Default is 100.
 
         Returns
         -------
         pixel_region : `~regions.PixelRegion`
             A pixel region, with an equivalent shape (if
-            ``include_boundary_distortions`` is False), or a
-            discretized polygon of the boundary (if
-            ``include_boundary_distortions`` is True).
+            ``boundary_distortions`` is False), or a discretized polygon
+            of the boundary (if ``boundary_distortions`` is True).
         """
         raise NotImplementedError
 

--- a/regions/shapes/annulus.py
+++ b/regions/shapes/annulus.py
@@ -278,12 +278,12 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
                                    operator.xor, self.meta.copy(),
                                    self.visual.copy())
 
-    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(
-            wcs, include_boundary_distortions)
+            wcs, boundary_distortions)
 
-        if include_boundary_distortions:
+        if boundary_distortions:
             # Requires planar to spherical projection (using WCS)
             # and discretization
             # Will require implementing discretization in pixel space
@@ -297,7 +297,7 @@ class CircleAnnulusPixelRegion(AnnulusPixelRegion):
             # # that polygon approximation
             # return self.discretize_boundary(
             #     n_vertices=n_vertices).to_spherical_sky(
-            #     wcs=wcs, include_boundary_distortions=False
+            #     wcs=wcs, boundary_distortions=False
             # )
 
         return self.to_sky(wcs).to_spherical_sky()
@@ -412,12 +412,12 @@ class CircleAnnulusSkyRegion(SkyRegion):
         """
         return self.to_pixel(wcs).to_polygon(n_vertices=n_vertices).to_sky(wcs)
 
-    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(
-            wcs, include_boundary_distortions)
+            wcs, boundary_distortions)
 
-        if include_boundary_distortions:
+        if boundary_distortions:
             # Requires planar to spherical projection (using WCS)
             # and discretization
             # Will require implementing discretization in pixel space
@@ -432,7 +432,7 @@ class CircleAnnulusSkyRegion(SkyRegion):
             # return self.to_pixel(wcs)
             #     .discretize_boundary(n_vertices=n_vertices)
             #     .to_spherical_sky(
-            #     wcs=wcs, include_boundary_distortions=False
+            #     wcs=wcs, boundary_distortions=False
             # )
 
         return CircleAnnulusSphericalSkyRegion(
@@ -536,18 +536,18 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
         """
         return self.discretize_boundary(n_vertices=n_vertices)
 
-    def to_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_sky(self, *, wcs=None, boundary_distortions=False,
                n_vertices=None):
         self._validate_planar_spherical_transform(
-            wcs, include_boundary_distortions)
+            wcs, boundary_distortions)
 
-        if include_boundary_distortions:
+        if boundary_distortions:
             # Requires spherical to planar projection (from WCS)
             # and discretization
             # Use to_pixel(), then apply "small angle approx" to get planar
             # sky.
             return self.to_pixel(
-                include_boundary_distortions=include_boundary_distortions,
+                boundary_distortions=boundary_distortions,
                 wcs=wcs, n_vertices=n_vertices,
             ).to_sky(wcs)
 
@@ -559,12 +559,12 @@ class CircleAnnulusSphericalSkyRegion(AnnulusSphericalSkyRegion):
             visual=self.visual.copy(),
         )
 
-    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+    def to_pixel(self, wcs, *, boundary_distortions=False,
                  n_vertices=None):
         self._validate_planar_spherical_transform(
-            wcs, include_boundary_distortions)
+            wcs, boundary_distortions)
 
-        if include_boundary_distortions:
+        if boundary_distortions:
             from .polygon import PolygonPixelRegion
 
             # Requires spherical to planar projection (from WCS) and
@@ -864,7 +864,7 @@ class EllipseAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
                                        meta=self.meta.copy(),
                                        visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -948,7 +948,7 @@ class EllipseAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
                                          meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
-    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -1067,7 +1067,7 @@ class RectangleAnnulusPixelRegion(AsymmetricAnnulusPixelRegion):
                                          meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -1166,6 +1166,6 @@ class RectangleAnnulusSkyRegion(AsymmetricAnnulusSkyRegion):
                                            meta=self.meta.copy(),
                                            visual=self.visual.copy())
 
-    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/circle.py
+++ b/regions/shapes/circle.py
@@ -145,12 +145,12 @@ class CirclePixelRegion(PixelRegion):
         return CircleSkyRegion(center, radius, meta=self.meta.copy(),
                                visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(wcs,
-                                                  include_boundary_distortions)
+                                                  boundary_distortions)
 
-        if include_boundary_distortions:
+        if boundary_distortions:
             # Requires planar to spherical projection (using WCS) and
             # discretization.
             # Will require implementing discretization in pixel space
@@ -163,7 +163,7 @@ class CirclePixelRegion(PixelRegion):
             # computed in creating that polygon approximation
             # return self.discretize_boundary(
             #     n_vertices=n_vertices).to_spherical_sky(
-            #     wcs=wcs, include_boundary_distortions=False
+            #     wcs=wcs, boundary_distortions=False
             # )
 
         return self.to_sky(wcs).to_spherical_sky()
@@ -369,12 +369,12 @@ class CircleSkyRegion(SkyRegion):
         """
         return self.to_pixel(wcs).to_polygon(n_vertices=n_vertices).to_sky(wcs)
 
-    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(wcs,
-                                                  include_boundary_distortions)
+                                                  boundary_distortions)
 
-        if include_boundary_distortions:
+        if boundary_distortions:
             # Requires planar to spherical projection (using WCS)
             # and discretization
             # Will require implementing discretization in pixel space
@@ -389,7 +389,7 @@ class CircleSkyRegion(SkyRegion):
             # return self.to_pixel(wcs)
             #     .discretize_boundary(n_vertices=n_vertices)
             #     .to_spherical_sky(
-            #     wcs=wcs, include_boundary_distortions=False
+            #     wcs=wcs, boundary_distortions=False
             # )
 
         return CircleSphericalSkyRegion(
@@ -495,18 +495,18 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
         """
         return self.discretize_boundary(n_vertices=n_vertices)
 
-    def to_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_sky(self, *, wcs=None, boundary_distortions=False,
                n_vertices=None):
         self._validate_planar_spherical_transform(wcs,
-                                                  include_boundary_distortions)
+                                                  boundary_distortions)
 
-        if include_boundary_distortions:
+        if boundary_distortions:
             # Requires spherical to planar projection (from WCS)
             # and discretization
             # Use to_pixel(), then apply "small angle approx" to get planar
             # sky.
             return self.to_pixel(
-                include_boundary_distortions=include_boundary_distortions,
+                boundary_distortions=boundary_distortions,
                 wcs=wcs,
                 n_vertices=n_vertices,
             ).to_sky(wcs)
@@ -515,12 +515,12 @@ class CircleSphericalSkyRegion(SphericalSkyRegion):
             self.center, self.radius, meta=self.meta, visual=self.visual,
         )
 
-    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+    def to_pixel(self, wcs, *, boundary_distortions=False,
                  n_vertices=None):
         self._validate_planar_spherical_transform(wcs,
-                                                  include_boundary_distortions)
+                                                  boundary_distortions)
 
-        if include_boundary_distortions:
+        if boundary_distortions:
             from .polygon import PolygonPixelRegion
 
             disc_kwargs = ({} if n_vertices is None

--- a/regions/shapes/ellipse.py
+++ b/regions/shapes/ellipse.py
@@ -130,7 +130,7 @@ class EllipsePixelRegion(PixelRegion):
                                 meta=self.meta.copy(),
                                 visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -438,6 +438,6 @@ class EllipseSkyRegion(SkyRegion):
         """
         return self.to_pixel(wcs).to_polygon(n_vertices=n_vertices).to_sky(wcs)
 
-    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/line.py
+++ b/regions/shapes/line.py
@@ -85,7 +85,7 @@ class LinePixelRegion(PixelRegion):
         return LineSkyRegion(start, end, meta=self.meta.copy(),
                              visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -201,6 +201,6 @@ class LineSkyRegion(SkyRegion):
         return LinePixelRegion(start, end, meta=self.meta.copy(),
                                visual=self.visual.copy())
 
-    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/lune.py
+++ b/regions/shapes/lune.py
@@ -202,39 +202,39 @@ class LuneSphericalSkyRegion(SphericalSkyRegion):
         """
         return self.discretize_boundary(n_vertices=n_vertices)
 
-    def to_sky(self, wcs, *, include_boundary_distortions=False,
+    def to_sky(self, wcs, *, boundary_distortions=False,
                n_vertices=None):
-        if not include_boundary_distortions:
+        if not boundary_distortions:
             raise ValueError(
-                'Invalid parameter: `include_boundary_distortions=False`!\n'
+                'Invalid parameter: `boundary_distortions=False`!\n'
                 'Transforming lune to planar sky region is only possible by '
                 'including boundary distortions, as there is no '
                 'analogous sky region.',
             )
 
         self._validate_planar_spherical_transform(
-            wcs, include_boundary_distortions)
+            wcs, boundary_distortions)
 
         # Requires spherical to planar projection (from WCS) and
         # discretization. Use to_pixel(), then apply "small angle
         # approx" to get planar sky.
         return self.to_pixel(
-            include_boundary_distortions=include_boundary_distortions,
+            boundary_distortions=boundary_distortions,
             wcs=wcs, n_vertices=n_vertices,
         ).to_sky(wcs)
 
-    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+    def to_pixel(self, wcs, *, boundary_distortions=False,
                  n_vertices=None):
-        if not include_boundary_distortions:
+        if not boundary_distortions:
             raise ValueError(
-                'Invalid parameter: `include_boundary_distortions=False`!\n'
+                'Invalid parameter: `boundary_distortions=False`!\n'
                 'Transforming lune to planar pixel region is only possible by '
                 'including boundary distortions, as there is no '
                 'analogous pixel region.',
             )
 
         self._validate_planar_spherical_transform(
-            wcs, include_boundary_distortions)
+            wcs, boundary_distortions)
 
         disc_kwargs = {} if n_vertices is None else {'n_vertices': n_vertices}
 

--- a/regions/shapes/point.py
+++ b/regions/shapes/point.py
@@ -89,7 +89,7 @@ class PointPixelRegion(PixelRegion):
         return PointSkyRegion(center, meta=self.meta.copy(),
                               visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -196,6 +196,6 @@ class PointSkyRegion(SkyRegion):
         return PointPixelRegion(center, meta=self.meta.copy(),
                                 visual=self.visual.copy())
 
-    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/polygon.py
+++ b/regions/shapes/polygon.py
@@ -128,12 +128,12 @@ class PolygonPixelRegion(PixelRegion):
         return PolygonSkyRegion(vertices=vertices_sky, meta=self.meta.copy(),
                                 visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(
-            wcs, include_boundary_distortions)
+            wcs, boundary_distortions)
 
-        if include_boundary_distortions:
+        if boundary_distortions:
             # Requires planar to spherical projection (using WCS)
             # and discretization
             # Will require implementing discretization in pixel space
@@ -148,7 +148,7 @@ class PolygonPixelRegion(PixelRegion):
             # return self.to_pixel(wcs)
             #     .discretize_boundary(n_vertices=n_vertices)
             #     .to_spherical_sky(
-            #     wcs=wcs, include_boundary_distortions=False
+            #     wcs=wcs, boundary_distortions=False
             # )
 
         # TODO: ensure vertices are in CW order,
@@ -429,12 +429,12 @@ class PolygonSkyRegion(SkyRegion):
         return PolygonPixelRegion(vertices_pix, meta=self.meta.copy(),
                                   visual=self.visual.copy())
 
-    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, boundary_distortions=False,
                          n_vertices=None):
         self._validate_planar_spherical_transform(
-            wcs, include_boundary_distortions)
+            wcs, boundary_distortions)
 
-        if include_boundary_distortions:
+        if boundary_distortions:
             # Requires planar to spherical projection (using WCS)
             # and discretization
             # Will require implementing discretization in pixel space
@@ -449,7 +449,7 @@ class PolygonSkyRegion(SkyRegion):
             # return self.to_pixel(wcs)
             #     .discretize_boundary(n_vertices=n_vertices)
             #     .to_spherical_sky(
-            #     wcs=wcs, include_boundary_distortions=False
+            #     wcs=wcs, boundary_distortions=False
             # )
 
         # TODO: ensure vertices are in CW order,
@@ -614,18 +614,18 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
         return PolygonSphericalSkyRegion(bound_verts, meta=self.meta.copy(),
                                          visual=self.visual.copy())
 
-    def to_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_sky(self, *, wcs=None, boundary_distortions=False,
                n_vertices=None):
         self._validate_planar_spherical_transform(
-            wcs, include_boundary_distortions)
+            wcs, boundary_distortions)
 
-        if include_boundary_distortions:
+        if boundary_distortions:
             # Requires spherical to planar projection (from WCS)
             # and discretization
             # Use to_pixel(), then apply "small angle approx" to get planar
             # sky.
             return self.to_pixel(
-                include_boundary_distortions=include_boundary_distortions,
+                boundary_distortions=boundary_distortions,
                 wcs=wcs, n_vertices=n_vertices,
             ).to_sky(wcs)
 
@@ -635,12 +635,12 @@ class PolygonSphericalSkyRegion(SphericalSkyRegion):
             visual=self.visual,
         )
 
-    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+    def to_pixel(self, wcs, *, boundary_distortions=False,
                  n_vertices=None):
         self._validate_planar_spherical_transform(
-            wcs, include_boundary_distortions)
+            wcs, boundary_distortions)
 
-        if include_boundary_distortions:
+        if boundary_distortions:
             # Requires spherical to planar projection (from WCS) and
             # discretization
             disc_kwargs = (

--- a/regions/shapes/range.py
+++ b/regions/shapes/range.py
@@ -881,37 +881,37 @@ class RangeSphericalSkyRegion(ComplexSphericalSkyRegion):
         """
         return self.discretize_boundary(n_vertices=n_vertices)
 
-    def to_sky(self, wcs, *, include_boundary_distortions=False,
+    def to_sky(self, wcs, *, boundary_distortions=False,
                n_vertices=None):
-        if not include_boundary_distortions:
+        if not boundary_distortions:
             raise ValueError(
-                'Invalid parameter: `include_boundary_distortions=False`!\n'
+                'Invalid parameter: `boundary_distortions=False`!\n'
                 'Transforming range to planar sky region is only possible by '
                 'including boundary distortions.',
             )
 
         self._validate_planar_spherical_transform(
-            wcs, include_boundary_distortions)
+            wcs, boundary_distortions)
 
         # Requires spherical to planar projection (from WCS) and discretization
         # Use to_pixel(), then apply "small angle approx" to get planar sky.
         return self.to_pixel(
-            include_boundary_distortions=include_boundary_distortions,
+            boundary_distortions=boundary_distortions,
             wcs=wcs, n_vertices=n_vertices,
         ).to_sky(wcs)
 
-    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+    def to_pixel(self, wcs, *, boundary_distortions=False,
                  n_vertices=None):
-        if not include_boundary_distortions:
+        if not boundary_distortions:
             raise ValueError(
-                'Invalid parameter: `include_boundary_distortions=False`!\n'
+                'Invalid parameter: `boundary_distortions=False`!\n'
                 'Transforming range to planar pixel region is'
                 ' only possible by '
                 'including boundary distortions.',
             )
 
         self._validate_planar_spherical_transform(
-            wcs, include_boundary_distortions)
+            wcs, boundary_distortions)
 
         disc_kwargs = {} if n_vertices is None else {'n_vertices': n_vertices}
 

--- a/regions/shapes/rectangle.py
+++ b/regions/shapes/rectangle.py
@@ -130,7 +130,7 @@ class RectanglePixelRegion(PixelRegion):
                                   meta=self.meta.copy(),
                                   visual=self.visual.copy())
 
-    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -452,6 +452,6 @@ class RectangleSkyRegion(SkyRegion):
         """
         return self.to_pixel(wcs).to_polygon().to_sky(wcs)
 
-    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/tests/test_annulus.py
+++ b/regions/shapes/tests/test_annulus.py
@@ -86,12 +86,12 @@ class TestCircleAnnulusPixelRegion(BaseTestPixelRegion):
 
     def test_to_spherical_sky(self, wcs):
         sphskyann = self.reg.to_spherical_sky(
-            wcs, include_boundary_distortions=False)
+            wcs, boundary_distortions=False)
         assert isinstance(sphskyann, CircleAnnulusSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
             _ = self.reg.to_spherical_sky(wcs,
-                                          include_boundary_distortions=True)
+                                          boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
         match = 'missing 1 required positional argument'
@@ -165,17 +165,17 @@ class TestCircleAnnulusSkyRegion(BaseTestSkyRegion):
 
     def test_to_spherical_sky(self, wcs):
         sphskyann = self.reg.to_spherical_sky(
-            wcs=wcs, include_boundary_distortions=False)
+            wcs=wcs, boundary_distortions=False)
         assert isinstance(sphskyann, CircleAnnulusSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
             _ = self.reg.to_spherical_sky(wcs=wcs,
-                                          include_boundary_distortions=True)
+                                          boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
-        match = "'wcs' must be set if `include_boundary_distortions=True`"
+        match = "'wcs' must be set if `boundary_distortions=True`"
         with pytest.raises(ValueError, match=match):
-            self.reg.to_spherical_sky(include_boundary_distortions=True)
+            self.reg.to_spherical_sky(boundary_distortions=True)
 
     def test_eq(self):
         reg = self.reg.copy()
@@ -236,17 +236,17 @@ class TestCircleAnnulusSphericalSkyRegion(BaseTestSphericalSkyRegion):
         assert isinstance(skyannulus, CircleAnnulusSkyRegion)
 
         polysky = self.reg.to_sky(
-            wcs=self.wcs, include_boundary_distortions=True)
+            wcs=self.wcs, boundary_distortions=True)
         assert isinstance(polysky, CompoundSkyRegion)
 
         polypix = self.reg.to_pixel(
-            self.wcs, include_boundary_distortions=True)
+            self.wcs, boundary_distortions=True)
         assert isinstance(polypix, CompoundPixelRegion)
 
     def test_transformation_no_wcs(self):
-        match = "'wcs' must be set if `include_boundary_distortions=True`"
+        match = "'wcs' must be set if `boundary_distortions=True`"
         with pytest.raises(ValueError, match=match):
-            self.reg.to_sky(include_boundary_distortions=True)
+            self.reg.to_sky(boundary_distortions=True)
 
     def test_frame_transformation(self):
         reg2 = self.reg.transform_to('galactic')

--- a/regions/shapes/tests/test_api.py
+++ b/regions/shapes/tests/test_api.py
@@ -71,7 +71,7 @@ SPHERICAL_SKY_REGIONS = [
         frame='icrs'),
     WholeSphericalSkyRegion()]
 
-INCLUDE_BOUNDARY_DISTORTIONS = [True, False]
+BOUNDARY_DISTORTIONS = [True, False]
 
 MASK_MODES = ['center', 'exact', 'subpixels']
 COMMON_WCS = WCS(naxis=2)
@@ -112,7 +112,7 @@ def test_pix_to_sky(region):
 
 @pytest.mark.parametrize('region', PIXEL_REGIONS, ids=ids_func)
 @pytest.mark.parametrize('include_dist',
-                         INCLUDE_BOUNDARY_DISTORTIONS, ids=ids_func)
+                         BOUNDARY_DISTORTIONS, ids=ids_func)
 def test_pix_to_spherical_sky(region, include_dist):
     # TODO: remove expected failures when implemented
     # Expected failure:
@@ -136,13 +136,13 @@ def test_pix_to_spherical_sky(region, include_dist):
         with pytest.raises(NotImplementedError):
             sph_sky_region = region.to_spherical_sky(
                 COMMON_WCS,
-                include_boundary_distortions=include_dist,
+                boundary_distortions=include_dist,
             )
             assert isinstance(sph_sky_region, SphericalSkyRegion)
     else:
         sph_sky_region = region.to_spherical_sky(
             COMMON_WCS,
-            include_boundary_distortions=include_dist,
+            boundary_distortions=include_dist,
         )
         assert isinstance(sph_sky_region, SphericalSkyRegion)
 
@@ -176,7 +176,7 @@ def test_sky_to_pix(region):
 
 @pytest.mark.parametrize('region', SKY_REGIONS, ids=ids_func)
 @pytest.mark.parametrize('include_dist',
-                         INCLUDE_BOUNDARY_DISTORTIONS, ids=ids_func)
+                         BOUNDARY_DISTORTIONS, ids=ids_func)
 def test_sky_to_spherical_sky(region, include_dist):
     # TODO: remove expected failures when implemented
     # Expected failure:
@@ -200,71 +200,71 @@ def test_sky_to_spherical_sky(region, include_dist):
         with pytest.raises(NotImplementedError):
             sph_sky_region = region.to_spherical_sky(
                 wcs=COMMON_WCS,
-                include_boundary_distortions=include_dist,
+                boundary_distortions=include_dist,
             )
             assert isinstance(sph_sky_region, SphericalSkyRegion)
     else:
         sph_sky_region = region.to_spherical_sky(
             wcs=COMMON_WCS,
-            include_boundary_distortions=include_dist,
+            boundary_distortions=include_dist,
         )
         assert isinstance(sph_sky_region, SphericalSkyRegion)
 
 
 @pytest.mark.parametrize('region', SPHERICAL_SKY_REGIONS, ids=ids_func)
 @pytest.mark.parametrize('include_dist',
-                         INCLUDE_BOUNDARY_DISTORTIONS, ids=ids_func)
+                         BOUNDARY_DISTORTIONS, ids=ids_func)
 def test_spherical_sky_to_sky(region, include_dist):
     if isinstance(region, WholeSphericalSkyRegion):
         with pytest.raises(ValueError):
             _ = region.to_sky(
                 wcs=COMMON_WCS,
-                include_boundary_distortions=include_dist,
+                boundary_distortions=include_dist,
             )
 
     elif (isinstance(region, (LuneSphericalSkyRegion, RangeSphericalSkyRegion))
           & (not include_dist)):
         # No distortions: not defined:
-        match = 'Invalid parameter: `include_boundary_distortions=False`!'
+        match = 'Invalid parameter: `boundary_distortions=False`!'
         with pytest.raises(ValueError, match=match):
             region.to_sky(
                 COMMON_WCS,
-                include_boundary_distortions=include_dist,
+                boundary_distortions=include_dist,
             )
 
     else:
         sky_region = region.to_sky(
             wcs=COMMON_WCS,
-            include_boundary_distortions=include_dist,
+            boundary_distortions=include_dist,
         )
         assert isinstance(sky_region, SkyRegion)
 
 
 @pytest.mark.parametrize('region', SPHERICAL_SKY_REGIONS, ids=ids_func)
 @pytest.mark.parametrize('include_dist',
-                         INCLUDE_BOUNDARY_DISTORTIONS, ids=ids_func)
+                         BOUNDARY_DISTORTIONS, ids=ids_func)
 def test_spherical_sky_to_pix(region, include_dist):
     if isinstance(region, WholeSphericalSkyRegion):
         with pytest.raises(ValueError):
             _ = region.to_pixel(
                 COMMON_WCS,
-                include_boundary_distortions=include_dist,
+                boundary_distortions=include_dist,
             )
 
     elif (isinstance(region, (LuneSphericalSkyRegion, RangeSphericalSkyRegion))
           & (not include_dist)):
         # No distortions: not defined:
-        match = 'Invalid parameter: `include_boundary_distortions=False`!'
+        match = 'Invalid parameter: `boundary_distortions=False`!'
         with pytest.raises(ValueError, match=match):
             region.to_pixel(
                 COMMON_WCS,
-                include_boundary_distortions=include_dist,
+                boundary_distortions=include_dist,
             )
 
     else:
         pixel_region = region.to_pixel(
             COMMON_WCS,
-            include_boundary_distortions=include_dist,
+            boundary_distortions=include_dist,
         )
         assert isinstance(pixel_region, PixelRegion)
 

--- a/regions/shapes/tests/test_circle.py
+++ b/regions/shapes/tests/test_circle.py
@@ -65,12 +65,12 @@ class TestCirclePixelRegion(BaseTestPixelRegion):
 
     def test_to_spherical_sky(self, wcs):
         sphskycircle = self.reg.to_spherical_sky(
-            wcs, include_boundary_distortions=False)
+            wcs, boundary_distortions=False)
         assert isinstance(sphskycircle, CircleSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
             _ = self.reg.to_spherical_sky(wcs,
-                                          include_boundary_distortions=True)
+                                          boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
         match = 'missing 1 required positional argument'
@@ -166,17 +166,17 @@ class TestCircleSkyRegion(BaseTestSkyRegion):
         assert_quantity_allclose(skycircle2.radius, skycircle.radius)
 
         sphskycircle = self.reg.to_spherical_sky(
-            wcs=wcs, include_boundary_distortions=False)
+            wcs=wcs, boundary_distortions=False)
         assert isinstance(sphskycircle, CircleSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
             _ = self.reg.to_spherical_sky(wcs=wcs,
-                                          include_boundary_distortions=True)
+                                          boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
-        match = "'wcs' must be set if `include_boundary_distortions=True`"
+        match = "'wcs' must be set if `boundary_distortions=True`"
         with pytest.raises(ValueError, match=match):
-            self.reg.to_spherical_sky(include_boundary_distortions=True)
+            self.reg.to_spherical_sky(boundary_distortions=True)
 
     def test_dimension_center(self):
         center = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
@@ -247,16 +247,16 @@ class TestCircleSphericalSkyRegion(BaseTestSphericalSkyRegion):
         assert_quantity_allclose(sphskycircle2.radius, sphskycircle.radius)
 
         polysky = sphskycircle.to_sky(
-            wcs=wcs, include_boundary_distortions=True)
+            wcs=wcs, boundary_distortions=True)
         assert isinstance(polysky, PolygonSkyRegion)
 
-        polypix = sphskycircle.to_pixel(wcs, include_boundary_distortions=True)
+        polypix = sphskycircle.to_pixel(wcs, boundary_distortions=True)
         assert isinstance(polypix, PolygonPixelRegion)
 
     def test_transformation_no_wcs(self):
-        match = "'wcs' must be set if `include_boundary_distortions=True`"
+        match = "'wcs' must be set if `boundary_distortions=True`"
         with pytest.raises(ValueError, match=match):
-            self.reg.to_sky(include_boundary_distortions=True)
+            self.reg.to_sky(boundary_distortions=True)
 
     def test_frame_transformation(self):
         skycoord = SkyCoord(3 * u.deg, 4 * u.deg, frame='galactic')

--- a/regions/shapes/tests/test_lune.py
+++ b/regions/shapes/tests/test_lune.py
@@ -57,17 +57,17 @@ class TestLuneSphericalSkyRegion(BaseTestSphericalSkyRegion):
 
     def test_transformation(self, wcs):
         # Test error for no boundary distortions:
-        match = 'Invalid parameter: `include_boundary_distortions=False`!'
+        match = 'Invalid parameter: `boundary_distortions=False`!'
         with pytest.raises(ValueError, match=match):
             self.reg.to_pixel(wcs)
 
-        match = 'Invalid parameter: `include_boundary_distortions=False`!'
+        match = 'Invalid parameter: `boundary_distortions=False`!'
         with pytest.raises(ValueError, match=match):
             self.reg.to_sky(wcs)
 
-        # Test for transformations with `include_boundary_distortions=True`
+        # Test for transformations with `boundary_distortions=True`
         polypix = self.reg.to_pixel(wcs,
-                                    include_boundary_distortions=True,
+                                    boundary_distortions=True,
                                     n_vertices=4)
         assert isinstance(polypix, PolygonPixelRegion)
         assert len(polypix.vertices) == 4
@@ -77,7 +77,7 @@ class TestLuneSphericalSkyRegion(BaseTestSphericalSkyRegion):
                         [-560.164308, -1256.912621, -338.786552, 1455.912621])
 
         polysky = self.reg.to_sky(wcs,
-                                  include_boundary_distortions=True,
+                                  boundary_distortions=True,
                                   n_vertices=4)
         assert isinstance(polysky, PolygonSkyRegion)
         assert len(polysky.vertices) == 4

--- a/regions/shapes/tests/test_polygon.py
+++ b/regions/shapes/tests/test_polygon.py
@@ -75,12 +75,12 @@ class TestPolygonPixelRegion(BaseTestPixelRegion):
 
     def test_to_spherical_sky(self, wcs):
         polysphsky = self.reg.to_spherical_sky(
-            wcs, include_boundary_distortions=False)
+            wcs, boundary_distortions=False)
         assert isinstance(polysphsky, PolygonSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
             _ = self.reg.to_spherical_sky(wcs,
-                                          include_boundary_distortions=True)
+                                          boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
         match = 'missing 1 required positional argument'
@@ -230,17 +230,17 @@ class TestPolygonSkyRegion(BaseTestSkyRegion):
                                  self.reg.vertices.data.lat, atol=1e-3 * u.deg)
 
         polysphsky = self.reg.to_spherical_sky(
-            wcs=wcs, include_boundary_distortions=False)
+            wcs=wcs, boundary_distortions=False)
         assert isinstance(polysphsky, PolygonSphericalSkyRegion)
 
         with pytest.raises(NotImplementedError):
             _ = self.reg.to_spherical_sky(wcs=wcs,
-                                          include_boundary_distortions=True)
+                                          boundary_distortions=True)
 
     def test_to_spherical_sky_no_wcs(self):
-        match = "'wcs' must be set if `include_boundary_distortions=True`"
+        match = "'wcs' must be set if `boundary_distortions=True`"
         with pytest.raises(ValueError, match=match):
-            self.reg.to_spherical_sky(include_boundary_distortions=True)
+            self.reg.to_spherical_sky(boundary_distortions=True)
 
     def test_contains(self, wcs):
         position = SkyCoord([1, 3.25] * u.deg, [2, 3.75] * u.deg)
@@ -396,21 +396,21 @@ class TestPolygonSphericalSkyRegion(BaseTestSphericalSkyRegion):
                                  polysky2.vertices.dec.deg)
 
         polysky3 = self.reg.to_sky(wcs=wcs,
-                                   include_boundary_distortions=True,
+                                   boundary_distortions=True,
                                    n_vertices=10)
         assert isinstance(polysky3, PolygonSkyRegion)
         assert len(polysky3.vertices) == 10
 
         polypix2 = self.reg.to_pixel(wcs,
-                                     include_boundary_distortions=True,
+                                     boundary_distortions=True,
                                      n_vertices=10)
         assert isinstance(polypix2, PolygonPixelRegion)
         assert len(polypix2.vertices) == 10
 
     def test_transformation_no_wcs(self):
-        match = "'wcs' must be set if `include_boundary_distortions=True`"
+        match = "'wcs' must be set if `boundary_distortions=True`"
         with pytest.raises(ValueError, match=match):
-            self.reg.to_sky(include_boundary_distortions=True)
+            self.reg.to_sky(boundary_distortions=True)
 
     def test_frame_transformation(self):
         reg = self.reg.transform_to('galactic')

--- a/regions/shapes/tests/test_range.py
+++ b/regions/shapes/tests/test_range.py
@@ -272,17 +272,17 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
     def test_transformation(self, wcs):
 
         # Test error for no boundary distortions:
-        match = 'Invalid parameter: `include_boundary_distortions=False`!'
+        match = 'Invalid parameter: `boundary_distortions=False`!'
         with pytest.raises(ValueError, match=match):
             self.reg.to_pixel(wcs)
 
-        match = 'Invalid parameter: `include_boundary_distortions=False`!'
+        match = 'Invalid parameter: `boundary_distortions=False`!'
         with pytest.raises(ValueError, match=match):
             self.reg.to_sky(wcs)
 
         # Test boundary distortion transformations:
         polypix2 = self.reg.to_pixel(wcs,
-                                     include_boundary_distortions=True,
+                                     boundary_distortions=True,
                                      n_vertices=8)
         assert isinstance(polypix2, PolygonPixelRegion)
         assert len(polypix2.vertices) == 8
@@ -299,7 +299,7 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
                          -2837.972245, -2798.470494])
 
         polysky2 = self.reg.to_sky(wcs,
-                                   include_boundary_distortions=True,
+                                   boundary_distortions=True,
                                    n_vertices=8)
         assert isinstance(polysky2, PolygonSkyRegion)
         assert len(polysky2.vertices) == 8
@@ -324,7 +324,7 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
 
         with pytest.raises(NotImplementedError):
             _ = reg.to_pixel(wcs,
-                             include_boundary_distortions=True,
+                             boundary_distortions=True,
                              n_vertices=10)
 
     def test_transformation_no_wcs(self):

--- a/regions/shapes/text.py
+++ b/regions/shapes/text.py
@@ -87,7 +87,7 @@ class TextPixelRegion(PointPixelRegion):
         return TextSkyRegion(center, self.text, meta=self.meta.copy(),
                              visual=visual.copy())
 
-    def to_spherical_sky(self, wcs, *, include_boundary_distortions=False,
+    def to_spherical_sky(self, wcs, *, boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError
 
@@ -168,6 +168,6 @@ class TextSkyRegion(PointSkyRegion):
                                meta=self.meta.copy(),
                                visual=visual.copy())
 
-    def to_spherical_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_spherical_sky(self, *, wcs=None, boundary_distortions=False,
                          n_vertices=None):
         raise NotImplementedError

--- a/regions/shapes/whole_sky.py
+++ b/regions/shapes/whole_sky.py
@@ -58,10 +58,10 @@ class WholeSphericalSkyRegion(SphericalSkyRegion):
     def discretize_boundary(self, *, n_vertices=100):
         raise ValueError('Not defined.')
 
-    def to_sky(self, *, wcs=None, include_boundary_distortions=False,
+    def to_sky(self, *, wcs=None, boundary_distortions=False,
                n_vertices=None):
         raise ValueError('Not defined.')
 
-    def to_pixel(self, wcs, *, include_boundary_distortions=False,
+    def to_pixel(self, wcs, *, boundary_distortions=False,
                  n_vertices=None):
         raise ValueError('Not defined.')


### PR DESCRIPTION
This PR renames the `include_boundary_distortions` keyword to `boundary_distortions`.  The shorter name still preserves this boolean keyword meaning.