### PR TITLE
Correction to frame standardization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Bug Fixes
 
 - Fixed a doubled comma in the serialized CRTF output when ``range`` or
   ``corr`` is the only metadata of a region. [#700]
+- Fixed an issue with frame standardization impacting creating
+  compound regions with RangeSphericalSkyRegion instances. [#704]
 
 API Changes
 -----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Bug Fixes
 - Fixed a doubled comma in the serialized CRTF output when ``range`` or
   ``corr`` is the only metadata of a region. [#700]
 - Fixed an issue with frame standardization impacting creating
-  compound regions with RangeSphericalSkyRegion instances. [#704]
+  compound regions with ``RangeSphericalSkyRegion`` instances. [#704]
 
 API Changes
 -----------

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -922,7 +922,8 @@ class SphericalSkyRegion(Region):
     def _standardize_frame(frame):
         # Standardize frame format:
         if isinstance(frame, BaseCoordinateFrame):
-            return frame
+            # Strip any attached data, keeping the frame attributes
+            return frame.replicate_without_data()
 
         # Otherwise, get an astropy coordinate frame class,
         # and create an instance without data:

--- a/regions/core/core.py
+++ b/regions/core/core.py
@@ -920,8 +920,14 @@ class SphericalSkyRegion(Region):
 
     @staticmethod
     def _standardize_frame(frame):
-        # Standardize frame format: get as an astropy coordinate frame class
-        frame = get_astropy_frame_class(frame)
+        # Standardize frame format:
+        if isinstance(frame, BaseCoordinateFrame):
+            return frame
+
+        # Otherwise, get an astropy coordinate frame class,
+        # and create an instance without data:
+        frame_cls = get_astropy_frame_class(frame)
+        frame = frame_cls()
         return frame
 
     def _validate_frame_transformation(self, frame):

--- a/regions/shapes/tests/test_range.py
+++ b/regions/shapes/tests/test_range.py
@@ -52,6 +52,20 @@ class TestRangeSphericalSkyRegion(BaseTestSphericalSkyRegion):
         with pytest.raises(ValueError, match=match):
             RangeSphericalSkyRegion(frame='icrs')
 
+    def test_frame_instance_with_data(self):
+        """
+        Test that a frame instance with attached data does not raise an
+        error when comparing to a frame name string.
+        """
+        frame = SkyCoord(1 * u.deg, 2 * u.deg, frame='icrs').frame
+        reg1 = RangeSphericalSkyRegion(longitude_range=[0, 10] * u.deg,
+                                       frame=frame)
+        reg2 = RangeSphericalSkyRegion(longitude_range=[0, 10] * u.deg,
+                                       frame='icrs')
+        assert not reg1._frame.has_data
+        assert reg1 == reg2
+        assert reg2 == reg1
+
     def test_invalid_lon_range(self):
         # Test input types:
         for lon_range in [u.Quantity([0, 10], u.m / u.s),


### PR DESCRIPTION
Fixes #703.

Changes the method `SphericalSkyRegion._standardize_frame()`, to return an instance, not a frame, and to first check if the frame is already an instance of BaseCoordinateFrame.

Test case for that issue now works as expected:
```
from astropy import units as u
from regions import RangeSphericalSkyRegion

reg1 = RangeSphericalSkyRegion(
    frame="icrs",
    latitude_range=[0 * u.deg, 1 * u.deg],
)
reg2 = RangeSphericalSkyRegion(
    frame="icrs",
    latitude_range=[0.5 * u.deg, 1.5 * u.deg],
)
reg1 & reg2
```
returns
```
<CompoundSphericalSkyRegion(region1=Region: RangeSphericalSkyRegion
frame: icrs
longitude_range: None
latitude_range: [<Quantity 0. deg>, <Quantity 1. deg>], region2=Region: RangeSphericalSkyRegion
frame: icrs
longitude_range: None
latitude_range: [<Quantity 0.5 deg>, <Quantity 1.5 deg>], operator=<built-in function and_>)>
```
 